### PR TITLE
QUAYIO-2060: fix(deploy): increase preStop sleep to prevent ELB errors during rollouts

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -75,7 +75,7 @@ objects:
                   matchLabels:
                     app: quay-envoy
                 topologyKey: topology.kubernetes.io/zone
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: envoy
           image: ${ENVOY_IMAGE}:${ENVOY_IMAGE_TAG}
@@ -95,7 +95,7 @@ objects:
                 command:
                 - "/bin/sh"
                 - "-c"
-                - "curl -sf --max-time 10 -X POST http://localhost:9901/drain_listeners?graceful ; sleep 30"
+                - "curl -sf --max-time 10 -X POST http://localhost:9901/drain_listeners?graceful ; sleep 45"
           env:
           - name: ENVOY_LOG_LEVEL
             value: "${ENVOY_LOG_LEVEL}"


### PR DESCRIPTION
## Summary
- Increase preStop sleep from 30s to 45s
- Increase terminationGracePeriodSeconds from 60s to 90s

## Why these values?

During Envoy pod rollouts at 50% production traffic, we observed ELB 5xx errors caused by a race condition between pod termination and ALB target deregistration.

**The race condition:**
1. Kubernetes sends SIGTERM → preStop hook runs (drain + sleep)
2. Simultaneously, pod is removed from Endpoints → kube-proxy updates iptables
3. ALB health check detects the target is unhealthy → **takes up to 30s** (health check interval 15s × 2 unhealthy threshold)
4. During step 3, ALB still routes new connections to the terminating pod → 5xx errors

**Why 45s sleep (was 30s):**
The ALB health check can take up to 30s to mark a target unhealthy (15s interval × 2 consecutive failures). The previous 30s sleep overlapped exactly with this window, leaving no margin. 45s provides 15s of buffer after the ALB stops routing, ensuring all in-flight requests complete before the pod shuts down.

**Why 90s terminationGracePeriodSeconds (was 60s):**
Kubernetes kills the pod after `terminationGracePeriodSeconds` regardless of preStop status. The shutdown sequence is:
- preStop: drain_listeners (~instant) + sleep 45s = **45s**
- Envoy drain-time-s: **30s** (runs after SIGTERM, overlaps with sleep)
- Buffer: **15s**
- Total: **90s** ensures Kubernetes never force-kills a draining pod

JIRA: https://redhat.atlassian.net/browse/QUAYIO-2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)