### PR TITLE
PROJQUAY-12760: feat(config): support CREATE_PRIVATE_REPO_ON_PUSH for default repo visibility

### DIFF
--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -2,10 +2,11 @@ package config
 
 // Auth holds authentication and authorization settings.
 type Auth struct {
-	AuthenticationType string   `yaml:"AUTHENTICATION_TYPE"`
-	SuperUsers         []string `yaml:"SUPER_USERS"`
-	RobotsDisallow     bool     `yaml:"ROBOTS_DISALLOW"`
-	RobotsWhitelist    []string `yaml:"ROBOTS_WHITELIST"`
+	AuthenticationType  string   `yaml:"AUTHENTICATION_TYPE"`
+	SuperUsers          []string `yaml:"SUPER_USERS"`
+	RobotsDisallow      bool     `yaml:"ROBOTS_DISALLOW"`
+	RobotsWhitelist     []string `yaml:"ROBOTS_WHITELIST"`
+	CreatePrivateOnPush bool     `yaml:"CREATE_PRIVATE_REPO_ON_PUSH"`
 }
 
 // validateAuth checks authentication enum values.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,23 @@ func TestParseExplicitFalseNotOverridden(t *testing.T) {
 	assert.False(t, cfg.FeatureDirectLogin)
 }
 
+func TestParseCreatePrivateRepoOnPush(t *testing.T) {
+	cfg, err := Parse([]byte("CREATE_PRIVATE_REPO_ON_PUSH: true\n"))
+	require.NoError(t, err)
+	assert.True(t, cfg.CreatePrivateOnPush)
+}
+
+func TestParseCreatePrivateRepoOnPushDefaultPublic(t *testing.T) {
+	cfg, err := Parse([]byte("SERVER_HOSTNAME: test\n"))
+	require.NoError(t, err)
+	assert.False(t, cfg.CreatePrivateOnPush)
+}
+
+func TestNewDefaultCreatePrivateRepoOnPushPublic(t *testing.T) {
+	cfg := NewDefault("localhost", "/data/storage")
+	assert.False(t, cfg.CreatePrivateOnPush)
+}
+
 func TestParseUnknownFields(t *testing.T) {
 	yaml := `
 SERVER_HOSTNAME: test

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -232,7 +232,6 @@ var knownUnmapped = map[string]bool{
 	"AUTO_PRUNE_DEFAULT_POLICY":                      true,
 	"CLEAN_BLOB_UPLOAD_FOLDER":                       true,
 	"CREATE_NAMESPACE_ON_PUSH":                       true,
-	"CREATE_PRIVATE_REPO_ON_PUSH":                    true,
 	"DEFAULT_NAMESPACE_AUTOPRUNE_POLICY":             true,
 	"DEFAULT_NAMESPACE_MAXIMUM_BUILD_COUNT":          true,
 	"DISABLE_PUSHES":                                 true,

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -24,7 +24,7 @@ import (
 type SQLiteStore struct {
 	db *sql.DB
 
-	visibilityPrivate int64
+	defaultVisibility int64
 	repoKindImage     int64
 	tagKindTag        int64
 
@@ -38,22 +38,35 @@ var _ oci.MetadataStore = (*SQLiteStore)(nil)
 // DB returns the underlying database handle, primarily for use in tests.
 func (s *SQLiteStore) DB() *sql.DB { return s.db }
 
+// StoreConfig configures metastore behavior.
+type StoreConfig struct {
+	CreatePrivateOnPush bool
+}
+
 // NewSQLiteStore creates a Store backed by the given SQLite database. It
 // caches frequently-used enum IDs at construction time.
-func NewSQLiteStore(ctx context.Context, db *sql.DB) (*SQLiteStore, error) {
+func NewSQLiteStore(ctx context.Context, db *sql.DB, opts ...StoreConfig) (*SQLiteStore, error) {
+	var cfg StoreConfig
+	if len(opts) > 0 {
+		cfg = opts[0]
+	}
 	s := &SQLiteStore{db: db, mediaTypes: make(map[string]int64)}
-	if err := s.cacheEnums(ctx); err != nil {
+	if err := s.cacheEnums(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("metastore: cache enums: %w", err)
 	}
 	return s, nil
 }
 
-func (s *SQLiteStore) cacheEnums(ctx context.Context) error {
+func (s *SQLiteStore) cacheEnums(ctx context.Context, cfg StoreConfig) error {
 	q := daldb.New(s.db)
 
 	var err error
-	if s.visibilityPrivate, err = q.GetVisibilityByName(ctx, "private"); err != nil {
-		return fmt.Errorf("visibility 'private': %w", err)
+	visibilityName := "public"
+	if cfg.CreatePrivateOnPush {
+		visibilityName = "private"
+	}
+	if s.defaultVisibility, err = q.GetVisibilityByName(ctx, visibilityName); err != nil {
+		return fmt.Errorf("visibility %q: %w", visibilityName, err)
 	}
 	if s.repoKindImage, err = q.GetRepositoryKindByName(ctx, "image"); err != nil {
 		return fmt.Errorf("repositorykind 'image': %w", err)
@@ -102,7 +115,7 @@ func (s *SQLiteStore) EnsureRepository(ctx context.Context, name oci.RepositoryN
 	repoID, err := q.GetOrCreateRepository(ctx, daldb.GetOrCreateRepositoryParams{
 		NamespaceUserID: sql.NullInt64{Int64: userID, Valid: true},
 		Name:            name.Name,
-		VisibilityID:    s.visibilityPrivate,
+		VisibilityID:    s.defaultVisibility,
 		KindID:          s.repoKindImage,
 		BadgeToken:      "",
 	})

--- a/internal/dal/metastore/metastore_sqlite_test.go
+++ b/internal/dal/metastore/metastore_sqlite_test.go
@@ -28,6 +28,21 @@ func setupStore(t *testing.T) oci.MetadataStore {
 	return store
 }
 
+func setupStoreWithConfig(t *testing.T, cfg metastore.StoreConfig) *metastore.SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "quay.db")
+	db, err := dbcore.Setup(t.Context(), dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := metastore.NewSQLiteStore(t.Context(), db, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
 func TestEnsureRepository(t *testing.T) {
 	store := setupStore(t)
 	ctx := t.Context()
@@ -666,6 +681,89 @@ func TestListReferrers_FallbackTagSchema(t *testing.T) {
 	}
 	if refs[0].Annotations["org.test"] != "value" {
 		t.Errorf("annotations = %v, want org.test=value", refs[0].Annotations)
+	}
+}
+
+func TestEnsureRepository_DefaultVisibilityPublic(t *testing.T) {
+	store := setupStoreWithConfig(t, metastore.StoreConfig{CreatePrivateOnPush: false})
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "mirror", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db := store.DB()
+	var visibilityName string
+	err = db.QueryRowContext(ctx,
+		`SELECT v.name FROM repository r JOIN visibility v ON r.visibility_id = v.id WHERE r.id = ?`,
+		repoID).Scan(&visibilityName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if visibilityName != "public" {
+		t.Errorf("expected public visibility, got %q", visibilityName)
+	}
+}
+
+func TestEnsureRepository_CreatePrivateOnPush(t *testing.T) {
+	store := setupStoreWithConfig(t, metastore.StoreConfig{CreatePrivateOnPush: true})
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "mirror", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db := store.DB()
+	var visibilityName string
+	err = db.QueryRowContext(ctx,
+		`SELECT v.name FROM repository r JOIN visibility v ON r.visibility_id = v.id WHERE r.id = ?`,
+		repoID).Scan(&visibilityName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if visibilityName != "private" {
+		t.Errorf("expected private visibility, got %q", visibilityName)
+	}
+}
+
+func TestEnsureRepository_ExistingRepoVisibilityUnchanged(t *testing.T) {
+	store := setupStoreWithConfig(t, metastore.StoreConfig{CreatePrivateOnPush: false})
+	ctx := t.Context()
+	db := store.DB()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "mirror", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually change to private to simulate a user changing visibility.
+	_, err = db.ExecContext(ctx,
+		`UPDATE repository SET visibility_id = (SELECT id FROM visibility WHERE name = 'private') WHERE id = ?`,
+		repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-push (EnsureRepository again) should NOT change it back to public.
+	repoID2, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "mirror", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoID2 != repoID {
+		t.Fatalf("expected same repo ID %d, got %d", repoID, repoID2)
+	}
+
+	var visibilityName string
+	err = db.QueryRowContext(ctx,
+		`SELECT v.name FROM repository r JOIN visibility v ON r.visibility_id = v.id WHERE r.id = ?`,
+		repoID).Scan(&visibilityName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if visibilityName != "private" {
+		t.Errorf("expected visibility to remain private after re-push, got %q", visibilityName)
 	}
 }
 

--- a/internal/mirrorregistry/composition.go
+++ b/internal/mirrorregistry/composition.go
@@ -60,7 +60,9 @@ func compose(ctx context.Context, cfg *Config, resolved *config.Resolved, metric
 		return result, fmt.Errorf("database setup: %w", err)
 	}
 
-	store, err := metastore.NewSQLiteStore(ctx, result.db)
+	store, err := metastore.NewSQLiteStore(ctx, result.db, metastore.StoreConfig{
+		CreatePrivateOnPush: resolved.Config.CreatePrivateOnPush,
+	})
 	if err != nil {
 		return result, fmt.Errorf("metastore setup: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Wire `CREATE_PRIVATE_REPO_ON_PUSH` config key into the Go registry server (OMR 3.0)
- Default is `false` (public repos on push), matching the mirror-registry use case where `oc-mirror`'d content should be pullable anonymously without authentication
- Setting `CREATE_PRIVATE_REPO_ON_PUSH: true` in config.yaml restores private-by-default behavior (matching Python Quay)

**JIRA**: [PROJQUAY-12760](https://redhat.atlassian.net/browse/PROJQUAY-12760)

## Context

Repositories created by push (e.g., via `oc-mirror`) in OMR 3.0 were hardcoded to **private** visibility in `internal/dal/metastore/metastore_sqlite.go`. The Python Quay codebase supports `CREATE_PRIVATE_REPO_ON_PUSH` (default: true) that controls this. OMR 3.0 recognized the key in config validation but did not wire it into the code.

For the mirror-registry use case, images mirrored by `oc-mirror` should be publicly pullable without requiring authentication — the typical flow is:

1. `quay install` → starts registry
2. `oc-mirror` pushes images → repos created as **public**
3. Clients pull anonymously → works via `FEATURE_ANONYMOUS_ACCESS` (default true) + public visibility

## Changes

| File | What |
|------|------|
| `internal/config/auth.go` | Add `CreatePrivateOnPush` field |
| `internal/config/defaults.go` | Default to `false` (public on push) |
| `internal/config/resolve.go` | Same default for standalone `NewDefault()` |
| `internal/dal/metastore/metastore_sqlite.go` | Accept `StoreConfig`, resolve visibility from config at startup |
| `internal/mirrorregistry/composition.go` | Pass config through to metastore |
| `internal/config/config_test.go` | Config parsing tests |
| `internal/config/schema_test.go` | Remove from `knownUnmapped` (now has struct field) |
| `internal/dal/metastore/metastore_sqlite_test.go` | Visibility behavior tests |

## Test plan

- [x] `go test ./internal/config/` — 3 new tests: parse true, parse default false, NewDefault
- [x] `go test ./internal/dal/metastore/` — 3 new tests: default public visibility, explicit private, existing repo unchanged on re-push
- [x] `go test ./internal/mirrorregistry/` — no regressions
- [x] `golangci-lint run` — no new issues
- [x] `gofmt` — clean
- [x] Pre-commit hooks — all pass
- [ ] E2E: `e2e-mirror` CI job verifies oc-mirror push + pull works