### PR TITLE
PROJQUAY-12537: docs(clair): document manual standalone scanner setup

### DIFF
--- a/docs/clair-standalone-configuration.md
+++ b/docs/clair-standalone-configuration.md
@@ -110,10 +110,10 @@ sudo podman run -d --name clairv4 \
   -e CLAIR_CONF=/clair/config.yaml \
   -e CLAIR_MODE=combo \
   -v /etc/opt/clairv4/config:/clair:Z \
-  quay.io/projectquay/clair:latest
+  quay.io/projectquay/clair:4.7.2
 ```
 
-Use a port that is not already in use on the Quay host for `http_listen_addr` (for example, `8081`). If you change `http_listen_addr`, also update the Podman `-p` port mapping, `SECURITY_SCANNER_V4_ENDPOINT` in Quay, and the notifier `webhook.target` and `webhook.callback` URLs so they reference the same port.
+Use a port that is not already in use on the Quay host for `http_listen_addr` (for example, `8081`). If you change `http_listen_addr`, also update the Podman `-p` port mapping, `SECURITY_SCANNER_V4_ENDPOINT` in Quay, and the notifier `webhook.callback` URL. Keep `webhook.target` on Quay's HTTP port, and change it only if Quay's HTTP listener changes.
 
 ## Configure Quay for security scanning
 
@@ -123,12 +123,13 @@ Edit your Quay `config.yaml` (for example, `$QUAY/config/config.yaml`) and add o
 FEATURE_SECURITY_SCANNER: true
 SECURITY_SCANNER_V4_ENDPOINT: http://quay-server.example.com:8081
 SECURITY_SCANNER_V4_PSK: "<base64-encoded-psk>"
+SECURITY_SCANNER_ISSUER_NAME: quay
 FEATURE_SECURITY_NOTIFICATIONS: true
 ```
 
 - `SECURITY_SCANNER_V4_ENDPOINT` must reach Clair's HTTP listener from the Quay container.
 - `SECURITY_SCANNER_V4_PSK` must match the `auth.psk.key` value in Clair's configuration.
-- Quay signs Clair JWTs with issuer `quay`; Clair's `auth.psk.iss` must include `quay`.
+- `SECURITY_SCANNER_ISSUER_NAME` must match an entry in Clair's `auth.psk.iss` list (both are `quay` in the examples above).
 - Set `FEATURE_SECURITY_NOTIFICATIONS` to `true` when using Clair's notifier webhook.
 
 Optionally validate `config.yaml` with the config-tool CLI (validation only; no web UI):
@@ -136,7 +137,7 @@ Optionally validate `config.yaml` with the config-tool CLI (validation only; no 
 ```shell
 podman run --rm -v $QUAY/config:/conf/stack:Z \
   quay.io/projectquay/quay:latest \
-  /quay-registry/config-tool validate -c /conf/stack
+  config-tool validate -c /conf/stack -m offline
 ```
 
 Restart the Quay registry container to load the updated configuration.

--- a/docs/clair-standalone-configuration.md
+++ b/docs/clair-standalone-configuration.md
@@ -1,0 +1,143 @@
+# Setting up Clair on standalone deployments
+
+This guide describes how to configure Clair on a standalone Project Quay deployment without the configuration tool web UI. As of Quay 3.17, the configuration tool UI was removed from the Quay image ([quay/quay#4769](https://github.com/quay/quay/pull/4769)). Enable security scanning by editing `config.yaml` directly.
+
+For local development, use `make local-dev-up-with-clair` instead of following this guide. See [Getting Started](./getting-started.md#running-quay-for-development).
+
+## Overview
+
+To configure Clair on a standalone deployment:
+
+1. Deploy a PostgreSQL database for Clair.
+2. Create a Clair `config.yaml` and start the Clair container.
+3. Update the Quay `config.yaml` with security scanner settings.
+4. Restart Quay.
+
+## Deploy a Clair PostgreSQL database
+
+In your Quay installation directory, create a directory for Clair database data:
+
+```shell-session
+$ mkdir /home/<user-name>/quay-poc/postgres-clairv4
+```
+
+Set permissions for the database data directory:
+
+```shell-session
+$ setfacl -m u:26:-wx /home/<user-name>/quay-poc/postgres-clairv4
+```
+
+Deploy PostgreSQL 15 for Clair:
+
+```shell-session
+$ sudo podman run -d --name postgresql-clairv4 \
+  -e POSTGRESQL_USER=clairuser \
+  -e POSTGRESQL_PASSWORD=clairpass \
+  -e POSTGRESQL_DATABASE=clair \
+  -e POSTGRESQL_ADMIN_PASSWORD=adminpass \
+  -p 5433:5432 \
+  -v /home/<user-name>/quay-poc/postgres-clairv4:/var/lib/pgsql/data:Z \
+  registry.redhat.io/rhel8/postgresql-15
+```
+
+Install the `uuid-ossp` extension:
+
+```shell-session
+$ sudo podman exec -it postgresql-clairv4 /bin/bash -c \
+  'echo "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"" | psql -d clair -U postgres'
+```
+
+Clair requires the `uuid-ossp` extension. If your database user lacks privileges to create extensions, add the extension before starting Clair. Without it, Clair fails with: `ERROR: Please load the "uuid-ossp" extension. (SQLSTATE 42501)`.
+
+## Generate a pre-shared key (PSK)
+
+Generate a base64-encoded PSK for Clair authentication:
+
+```shell-session
+$ openssl rand -base64 16
+```
+
+Use the same value in both Clair and Quay configuration.
+
+## Configure and start Clair
+
+Create a directory for Clair configuration:
+
+```shell-session
+$ mkdir /etc/opt/clairv4/config/
+$ cd /etc/opt/clairv4/config/
+```
+
+Create `config.yaml` (replace hostnames, credentials, and the PSK with your values):
+
+```yaml
+http_listen_addr: :8081
+introspection_addr: :8088
+log_level: debug
+indexer:
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  scanlock_retry: 10
+  layer_scan_concurrency: 5
+  migrations: true
+matcher:
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  max_conn_pool: 100
+  migrations: true
+  indexer_addr: clair-indexer
+notifier:
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  delivery_interval: 1m
+  poll_interval: 5m
+  migrations: true
+  webhook:
+    target: "http://quay-server.example.com:8080/secscan/notification"
+    callback: "http://quay-server.example.com:8081/notifier/api/v1/notification"
+auth:
+  psk:
+    key: "<base64-encoded-psk>"
+    iss: ["quay"]
+metrics:
+  name: "prometheus"
+```
+
+Start Clair in combo mode:
+
+```shell-session
+$ sudo podman run -d --name clairv4 \
+  -p 8081:8081 -p 8088:8088 \
+  -e CLAIR_CONF=/clair/config.yaml \
+  -e CLAIR_MODE=combo \
+  -v /etc/opt/clairv4/config:/clair:Z \
+  quay.io/projectquay/clair:latest
+```
+
+Use a port that is not already in use on the Quay host for `http_listen_addr` (for example, `8081`).
+
+## Configure Quay for security scanning
+
+Edit your Quay `config.yaml` (for example, `$QUAY/config/config.yaml`) and add or update:
+
+```yaml
+FEATURE_SECURITY_SCANNER: true
+SECURITY_SCANNER_V4_ENDPOINT: http://quay-server.example.com:8081
+SECURITY_SCANNER_V4_PSK: "<base64-encoded-psk>"
+FEATURE_SECURITY_NOTIFICATIONS: true
+```
+
+- `SECURITY_SCANNER_V4_ENDPOINT` must reach Clair's HTTP listener from the Quay container.
+- `SECURITY_SCANNER_V4_PSK` must match the `auth.psk.key` value in Clair's configuration.
+- Set `FEATURE_SECURITY_NOTIFICATIONS` to `true` when using Clair's notifier webhook.
+
+Optionally validate `config.yaml` with the config-tool CLI (validation only; no web UI):
+
+```shell-session
+$ podman run --rm -v $QUAY/config:/conf/stack:Z \
+  quay.io/projectquay/quay:latest \
+  /quay-registry/config-tool validate -c /conf/stack
+```
+
+Restart the Quay registry container to load the updated configuration.
+
+## Verify
+
+Push an image to Quay and confirm vulnerability data appears on the repository tag page after indexing completes.

--- a/docs/clair-standalone-configuration.md
+++ b/docs/clair-standalone-configuration.md
@@ -4,6 +4,8 @@ This guide describes how to configure Clair on a standalone Project Quay deploym
 
 For local development, use `make local-dev-up-with-clair` instead of following this guide. See [Getting Started](./getting-started.md#running-quay-for-development).
 
+> **Evaluation only:** The examples below use unencrypted HTTP between Quay and Clair and PostgreSQL with `sslmode=disable` on a single host. Do not use this transport configuration in production. For production deployments, terminate TLS at a load balancer or reverse proxy, use HTTPS for Quay–Clair traffic, and configure PostgreSQL with `sslmode=verify-full` (or `verify-ca`) plus the required CA certificates.
+
 ## Overview
 
 To configure Clair on a standalone deployment:
@@ -17,24 +19,24 @@ To configure Clair on a standalone deployment:
 
 In your Quay installation directory, create a directory for Clair database data:
 
-```shell-session
-$ mkdir /home/<user-name>/quay-poc/postgres-clairv4
+```shell
+mkdir /home/<user-name>/quay-poc/postgres-clairv4
 ```
 
 Set permissions for the database data directory:
 
-```shell-session
-$ setfacl -m u:26:-wx /home/<user-name>/quay-poc/postgres-clairv4
+```shell
+setfacl -m u:26:-wx /home/<user-name>/quay-poc/postgres-clairv4
 ```
 
-Deploy PostgreSQL 15 for Clair:
+Deploy PostgreSQL 15 for Clair (replace the password placeholders with strong values):
 
-```shell-session
-$ sudo podman run -d --name postgresql-clairv4 \
+```shell
+sudo podman run -d --name postgresql-clairv4 \
   -e POSTGRESQL_USER=clairuser \
-  -e POSTGRESQL_PASSWORD=clairpass \
+  -e POSTGRESQL_PASSWORD=<clair-db-password> \
   -e POSTGRESQL_DATABASE=clair \
-  -e POSTGRESQL_ADMIN_PASSWORD=adminpass \
+  -e POSTGRESQL_ADMIN_PASSWORD=<postgres-admin-password> \
   -p 5433:5432 \
   -v /home/<user-name>/quay-poc/postgres-clairv4:/var/lib/pgsql/data:Z \
   registry.redhat.io/rhel8/postgresql-15
@@ -42,8 +44,8 @@ $ sudo podman run -d --name postgresql-clairv4 \
 
 Install the `uuid-ossp` extension:
 
-```shell-session
-$ sudo podman exec -it postgresql-clairv4 /bin/bash -c \
+```shell
+sudo podman exec -it postgresql-clairv4 /bin/bash -c \
   'echo "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"" | psql -d clair -U postgres'
 ```
 
@@ -53,39 +55,39 @@ Clair requires the `uuid-ossp` extension. If your database user lacks privileges
 
 Generate a base64-encoded PSK for Clair authentication:
 
-```shell-session
-$ openssl rand -base64 16
+```shell
+openssl rand -base64 16
 ```
 
 Use the same value in both Clair and Quay configuration.
 
 ## Configure and start Clair
 
-Create a directory for Clair configuration:
+Create a directory for Clair configuration (requires root for `/etc/opt`):
 
-```shell-session
-$ mkdir /etc/opt/clairv4/config/
-$ cd /etc/opt/clairv4/config/
+```shell
+sudo mkdir -p /etc/opt/clairv4/config
+cd /etc/opt/clairv4/config
 ```
 
-Create `config.yaml` (replace hostnames, credentials, and the PSK with your values):
+Create `config.yaml` with a text editor or `sudo tee` (replace hostnames, credentials, and the PSK with your values):
 
 ```yaml
 http_listen_addr: :8081
 introspection_addr: :8088
 log_level: debug
 indexer:
-  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=<clair-db-password> sslmode=disable
   scanlock_retry: 10
   layer_scan_concurrency: 5
   migrations: true
 matcher:
-  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=<clair-db-password> sslmode=disable
   max_conn_pool: 100
   migrations: true
   indexer_addr: clair-indexer
 notifier:
-  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=clairpass sslmode=disable
+  connstring: host=quay-server.example.com port=5433 dbname=clair user=clairuser password=<clair-db-password> sslmode=disable
   delivery_interval: 1m
   poll_interval: 5m
   migrations: true
@@ -102,8 +104,8 @@ metrics:
 
 Start Clair in combo mode:
 
-```shell-session
-$ sudo podman run -d --name clairv4 \
+```shell
+sudo podman run -d --name clairv4 \
   -p 8081:8081 -p 8088:8088 \
   -e CLAIR_CONF=/clair/config.yaml \
   -e CLAIR_MODE=combo \
@@ -111,7 +113,7 @@ $ sudo podman run -d --name clairv4 \
   quay.io/projectquay/clair:latest
 ```
 
-Use a port that is not already in use on the Quay host for `http_listen_addr` (for example, `8081`).
+Use a port that is not already in use on the Quay host for `http_listen_addr` (for example, `8081`). If you change `http_listen_addr`, also update the Podman `-p` port mapping, `SECURITY_SCANNER_V4_ENDPOINT` in Quay, and the notifier `webhook.target` and `webhook.callback` URLs so they reference the same port.
 
 ## Configure Quay for security scanning
 
@@ -126,12 +128,13 @@ FEATURE_SECURITY_NOTIFICATIONS: true
 
 - `SECURITY_SCANNER_V4_ENDPOINT` must reach Clair's HTTP listener from the Quay container.
 - `SECURITY_SCANNER_V4_PSK` must match the `auth.psk.key` value in Clair's configuration.
+- Quay signs Clair JWTs with issuer `quay`; Clair's `auth.psk.iss` must include `quay`.
 - Set `FEATURE_SECURITY_NOTIFICATIONS` to `true` when using Clair's notifier webhook.
 
 Optionally validate `config.yaml` with the config-tool CLI (validation only; no web UI):
 
-```shell-session
-$ podman run --rm -v $QUAY/config:/conf/stack:Z \
+```shell
+podman run --rm -v $QUAY/config:/conf/stack:Z \
   quay.io/projectquay/quay:latest \
   /quay-registry/config-tool validate -c /conf/stack
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,7 @@
 If your goal is not to develop Quay, see the below guides.
 
  * [Deploy a Quick Local Environment With Podman](quick-local-deployment.md)
+ * [Configure Clair on standalone deployments](clair-standalone-configuration.md)
  * [Deploy a Proof-of-Concept](https://docs.projectquay.io/deploy_quay.html)
  * [Deploy to OpenShift with the Quay Operator](https://docs.projectquay.io/deploy_quay_on_openshift_op_tng.html)
  * [Deploy with High Availability](https://docs.projectquay.io/deploy_quay_ha.html)

--- a/docs/quick-local-deployment.md
+++ b/docs/quick-local-deployment.md
@@ -220,7 +220,7 @@ mysql> create database quay character set latin1;
 Query OK, 1 row affected (0.02 sec)
 ```
 
-Lastly, when configuring Quay manually, set the database type to `MySQL` and use the credentials `root/password` and database name `quay`. The legacy ConfigTool UI workflow is obsolete on Quay 3.17+; see [Legacy configuration tool workflow (obsolete)](./quick-local-deployment.md#legacy-configuration-tool-workflow-obsolete-in-quay-317).
+Lastly, when configuring Quay manually, set the database type to `MySQL` and use the credentials `root/password` and database name `quay`. The legacy ConfigTool UI workflow is obsolete on Quay 3.17+; see [Legacy configuration tool workflow (obsolete)](#legacy-configuration-tool-workflow-obsolete-in-quay-317).
 
 ## Legacy configuration tool workflow (obsolete in Quay 3.17+)
 

--- a/docs/quick-local-deployment.md
+++ b/docs/quick-local-deployment.md
@@ -231,7 +231,7 @@ This workflow no longer works on Quay 3.17+ images. It is preserved here only fo
 The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool:
 
 ```shell
-sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay config secret
+sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay:3.16.2 config secret
 ```
 
 1. Open https://localhost:8080 in browser

--- a/docs/quick-local-deployment.md
+++ b/docs/quick-local-deployment.md
@@ -63,11 +63,13 @@ $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" redis
 
 
 
-## Build the Quay Configuration via ConfigTool.
+## Build the Quay configuration
 
-The ConfigTool resides on the Quay image and lets you generate Quay configuration files and set up your Postgres database.  It is a web application that guides you through the Quay configuration process.  The Quay configuration is a tar/zipped YAML file that you can save locally for Quay to read at startup time.
+NOTE: The configuration tool web UI was removed from the Quay image in version 3.17. The steps below describe the legacy UI workflow and no longer work on current images. Configure Quay by editing `config.yaml` manually, or use the [local development environment](./getting-started.md#running-quay-for-development).
 
-We run the Quay image with runtime flags set to launch ConfigTool accepting the password 'secret':
+The ConfigTool web UI historically resided on the Quay image and let you generate Quay configuration files and set up your Postgres database.  The Quay configuration is a tar/zipped YAML file that you can save locally for Quay to read at startup time.
+
+The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool accepting the password 'secret':
 
 ```
 $ sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay config secret
@@ -182,7 +184,9 @@ Congratulations you have a local Quay instance running!  Of course this deployme
 
 ## Getting Clair Running
 
-coming soon
+For standalone Podman deployments with security scanning, see [Setting up Clair on standalone deployments](clair-standalone-configuration.md).
+
+For development, use `make local-dev-up-with-clair` as described in [Getting Started](./getting-started.md#running-quay-for-development).
 
 ## Next Steps
 
@@ -191,12 +195,15 @@ Quay and Clair can also be run as services on a Kubernetes cluster.  This is bec
 ## Troubleshooting
 
 ### I need to change my Quay configuration!
-This can be done by uploading your config tarball back into the ConfigTool:
+Edit `config.yaml` directly in `$QUAY/config`, then restart the Quay container. To enable Clair security scanning on a standalone deployment, see [clair-standalone-configuration.md](clair-standalone-configuration.md).
+
+Optionally validate changes with the config-tool CLI:
+
 ```
-$ cd $QUAY/config
-$ tar cvzf myconfig.tar.gz config.yaml
+$ podman run --rm -v $QUAY/config:/conf/stack:Z \
+  quay.io/projectquay/quay:latest \
+  /quay-registry/config-tool validate -c /conf/stack
 ```
-Run the ConfigTool and choose 'Modify Existing Config'.  You can upload the tarball, make changes and then re-download it.
 
 
 

--- a/docs/quick-local-deployment.md
+++ b/docs/quick-local-deployment.md
@@ -22,14 +22,16 @@ $ cat /etc/hosts
 
 ## Set Up Postgres
 
-Quay will need a database to hold its image metadata (we will store images themselves on local disk in this tutorial).  Postgres is the recommended database, especially for highly available configurations.  Below we are pulling Red Hat's Postgres image but you should be able to use an image from other sources
+Quay will need a database to hold its image metadata (we will store images themselves on local disk in this tutorial).  Postgres is the recommended database, especially for highly available configurations.  Below we are pulling Red Hat's Postgres image but you should be able to use an image from other sources.
+
+Choose a `<postgres-user>` and `<postgres-password>` for this deployment and use the same values in `config.yaml` later.
 
 ```
 $ mkdir -p $QUAY/postgres
 $ setfacl -m u:26:-wx $QUAY/postgres
 $ sudo podman run -d --rm --name postgresql \
-	-e POSTGRES_USER=user \
-	-e POSTGRES_PASSWORD=pass \
+	-e POSTGRES_USER=<postgres-user> \
+	-e POSTGRES_PASSWORD=<postgres-password> \
 	-e POSTGRES_DB=quay \
 	-p 5432:5432 \
 	-v $QUAY/postgres:/var/lib/postgresql/data:Z \
@@ -38,7 +40,7 @@ $ sudo podman run -d --rm --name postgresql \
 Quay needs the `pg_trgm` module installed, so we can do so as follows:
 
 ```
-$ sudo podman exec -it postgresql /bin/bash -c 'echo "CREATE EXTENSION IF NOT EXISTS pg_trgm" | psql -d quay -U user'
+$ sudo podman exec -it postgresql /bin/bash -c 'echo "CREATE EXTENSION IF NOT EXISTS pg_trgm" | psql -d quay -U <postgres-user>'
 CREATE EXTENSION
 ```
 Let's also grab the IP address of our Postgres container so we can refer to it later:
@@ -49,13 +51,13 @@ $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" postgresql
 
 ## Set Up Redis
 
-Quay also requires a Redis runtime to hold user events and if configured, build coordination and build logs.  This instance can be ephemeral as it doesn't hold any data we can't live without.  We should also get the redis IP address at this time:
+Quay also requires a Redis runtime to hold user events and if configured, build coordination and build logs.  This instance can be ephemeral as it doesn't hold any data we can't live without.  Choose a `<redis-password>` and use the same value in `config.yaml`.  We should also get the redis IP address at this time:
 
 ```
 $ sudo podman run -d --rm --name redis \
         -p 6379:6379 \
         redis:5.0.7 \
-        --requirepass strongpassword
+        --requirepass <redis-password>
 
 $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" redis
 10.88.0.14
@@ -67,19 +69,47 @@ $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" redis
 
 NOTE: The configuration tool web UI was removed from the Quay image in version 3.17 ([quay/quay#4769](https://github.com/quay/quay/pull/4769)). On current images, create `config.yaml` manually or use the [local development environment](./getting-started.md#running-quay-for-development) for a working reference configuration.
 
-Create a Quay configuration directory and a minimal `config.yaml` that matches the Postgres and Redis containers started above. At minimum, set database connection settings (`DB_URI` or equivalent fields), Redis settings, `SERVER_HOSTNAME` (for example `quay:8080`), and `SETUP_COMPLETE: true`. See the [Manage Quay](https://docs.projectquay.io/manage_quay.html) documentation for the full set of configuration fields.
+Create a Quay configuration directory and a minimal `config.yaml` that matches the Postgres and Redis containers started above. Replace the placeholders with the values you used when starting the database and Redis containers, and generate your own `SECRET_KEY` and `DATABASE_SECRET_KEY` values (for example with `openssl rand -hex 32`).
 
 ```shell
 mkdir -p $QUAY/config
-# Create and edit $QUAY/config/config.yaml with your database, Redis, and server settings.
 ```
 
-Optionally validate the configuration with the config-tool CLI (validation only; no web UI):
+Create `$QUAY/config/config.yaml` with content similar to the following (substitute `<postgres-ip>` and `<redis-ip>` with the container IP addresses obtained above):
+
+```yaml
+AUTHENTICATION_TYPE: Database
+DB_URI: postgresql://<postgres-user>:<postgres-password>@<postgres-ip>/quay
+DATABASE_SECRET_KEY: "<generate-a-random-secret>"
+SECRET_KEY: "<generate-a-random-secret>"
+BUILDLOGS_REDIS:
+  host: <redis-ip>
+  port: 6379
+  password: <redis-password>
+USER_EVENTS_REDIS:
+  host: <redis-ip>
+  port: 6379
+  password: <redis-password>
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - LocalStorage
+    - storage_path: /datastorage/registry
+DISTRIBUTED_STORAGE_PREFERENCE:
+  - default
+SERVER_HOSTNAME: quay:8080
+SETUP_COMPLETE: true
+SUPER_USERS:
+  - admin
+```
+
+See the [Manage Quay](https://docs.projectquay.io/manage_quay.html) documentation for the full set of configuration fields.
+
+Validate the configuration with the config-tool CLI before starting Quay (validation only; no web UI):
 
 ```shell
 podman run --rm -v $QUAY/config:/conf/stack:Z \
   quay.io/projectquay/quay:latest \
-  /quay-registry/config-tool validate -c /conf/stack
+  config-tool validate -c /conf/stack -m offline
 ```
 
 Set up a directory to hold image blobs:
@@ -157,33 +187,33 @@ Quay and Clair can also be run as services on a Kubernetes cluster.  This is bec
 ## Troubleshooting
 
 ### I need to change my Quay configuration!
-Edit `config.yaml` directly in `$QUAY/config`, then restart the Quay container. To enable Clair security scanning on a standalone deployment, see [clair-standalone-configuration.md](clair-standalone-configuration.md).
-
-Optionally validate changes with the config-tool CLI:
+Edit `config.yaml` directly in `$QUAY/config`. Validate changes with the config-tool CLI before restarting the Quay container:
 
 ```shell
 podman run --rm -v $QUAY/config:/conf/stack:Z \
   quay.io/projectquay/quay:latest \
-  /quay-registry/config-tool validate -c /conf/stack
+  config-tool validate -c /conf/stack -m offline
 ```
+
+Restart the Quay container to load the updated configuration. To enable Clair security scanning on a standalone deployment, see [clair-standalone-configuration.md](clair-standalone-configuration.md).
 
 
 
 ### I'd like to see inside the Quay database!
 ```
 $  podman exec -it postgresql /bin/bash
-bash-4.4$ psql -d quay -U user
+bash-4.4$ psql -d quay -U <postgres-user>
 psql (10.6)
 Type "help" for help.
 ```
 
 ### I'd like to use MySQL instead of Postgres!
 
-Not a problem.  Just replace the Postgres setup steps above with
+Not a problem. Choose a `<mysql-root-password>` for the MySQL container and use the same value in `DB_URI` when configuring Quay. Just replace the Postgres setup steps above with
 ```
 $ mkdir -p $QUAY/mysql
 $ setfacl -m u:26:-wx $QUAY/mysql
-$ sudo podman run --name mysql -v $QUAY/mysql:/var/lib/mysql:Z -e MYSQL_ROOT_PASSWORD=password -d mysql:5.7.31
+$ sudo podman run --name mysql -v $QUAY/mysql:/var/lib/mysql:Z -e MYSQL_ROOT_PASSWORD=<mysql-root-password> -d mysql:5.7.31
 ```
 
 Once MySQL is running, you'll want to get the IP address for the database:
@@ -195,8 +225,8 @@ $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" mysql
 
 Then you'll need to create a database for Quay by connecting to the IP address you just found (this step isn't needed for Postgres)
 ```
-$ sudo podman run -it --rm mysql:5.7.31 mysql -h10.88.0.108 -uroot -p
-Enter password:
+$ sudo podman run -it --rm mysql:5.7.31 mysql -h<mysql-ip> -uroot -p
+Enter password:  # enter <mysql-root-password>
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2
 Server version: 5.7.31 MySQL Community Server (GPL)
@@ -220,7 +250,7 @@ mysql> create database quay character set latin1;
 Query OK, 1 row affected (0.02 sec)
 ```
 
-Lastly, when configuring Quay manually, set the database type to `MySQL` and use the credentials `root/password` and database name `quay`. The legacy ConfigTool UI workflow is obsolete on Quay 3.17+; see [Legacy configuration tool workflow (obsolete)](#legacy-configuration-tool-workflow-obsolete-in-quay-317).
+Lastly, when configuring Quay manually, set `DB_URI` to `mysql+pymysql://root:<mysql-root-password>@<mysql-ip>/quay` (add `?charset=latin1` for MySQL 8.0 or higher). The legacy ConfigTool UI workflow is obsolete on Quay 3.17+; see [Legacy configuration tool workflow (obsolete)](#legacy-configuration-tool-workflow-obsolete-in-quay-317).
 
 ## Legacy configuration tool workflow (obsolete in Quay 3.17+)
 
@@ -228,22 +258,22 @@ The ConfigTool web UI historically resided on the Quay image and let you generat
 
 This workflow no longer works on Quay 3.17+ images. It is preserved here only for reference when working with older images.
 
-The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool:
+The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool (replace `<config-tool-password>` with a password of your choice):
 
 ```shell
-sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay:3.16.2 config secret
+sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay:3.16.2 config <config-tool-password>
 ```
 
 1. Open https://localhost:8080 in browser
-1. Log in with quayconfig/secret
+1. Log in with quayconfig/`<config-tool-password>`
 1. Start New Registry Setup
 
 ### Database Setup
 
 1. Choose Postgres database type...
 1. host: (enter the postgres IP address you obtained previously)
-1. user: `user`
-1. password: `pass`
+1. user: `<postgres-user>`
+1. password: `<postgres-password>`
 1. database: `quay`
 
 Hit `Validate Database Settings`.  This will begin setting up your database automatically.
@@ -260,7 +290,7 @@ On main config screen, you will have a few fields to fill out:
 #### redis
 
 1. For `Redis Hostname` enter the IP address for your Redis container obtained earlier.
-2. For `Redis password` enter `strongpassword` or whatever you used when you launched the redis container.
+2. For `Redis password` enter the `<redis-password>` value you used when you launched the Redis container.
 
 Click on `Save Configuration Changes` at bottom of page.  Popup window should show settings confirmed.
 

--- a/docs/quick-local-deployment.md
+++ b/docs/quick-local-deployment.md
@@ -65,67 +65,29 @@ $ sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" redis
 
 ## Build the Quay configuration
 
-NOTE: The configuration tool web UI was removed from the Quay image in version 3.17. The steps below describe the legacy UI workflow and no longer work on current images. Configure Quay by editing `config.yaml` manually, or use the [local development environment](./getting-started.md#running-quay-for-development).
+NOTE: The configuration tool web UI was removed from the Quay image in version 3.17 ([quay/quay#4769](https://github.com/quay/quay/pull/4769)). On current images, create `config.yaml` manually or use the [local development environment](./getting-started.md#running-quay-for-development) for a working reference configuration.
 
-The ConfigTool web UI historically resided on the Quay image and let you generate Quay configuration files and set up your Postgres database.  The Quay configuration is a tar/zipped YAML file that you can save locally for Quay to read at startup time.
+Create a Quay configuration directory and a minimal `config.yaml` that matches the Postgres and Redis containers started above. At minimum, set database connection settings (`DB_URI` or equivalent fields), Redis settings, `SERVER_HOSTNAME` (for example `quay:8080`), and `SETUP_COMPLETE: true`. See the [Manage Quay](https://docs.projectquay.io/manage_quay.html) documentation for the full set of configuration fields.
 
-The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool accepting the password 'secret':
-
-```
-$ sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay config secret
-```
-
-1. Open https://localhost:8080 in browser
-1. Log in with quayconfig/secret
-1. Start New Registry Setup
-
-### Database Setup
-
-1. Choose Postgres database type...
-1. host: (enter the postgres IP address you obtained previously)
-1. user: `user`
-1. password: `pass`
-1. database: `quay`
-
-Hit `Validate Database Settings`.  This will begin setting up your database automatically.
-
-On the next screen, set up a Quay super user account.  Click `Create Super User`.
-
-On main config screen, you will have a few fields to fill out:
-
-#### Server Configuration
-
-1. For `Server Hostname` use `quay:8080` (or `localhost` however the UI will complain).
-1. For `TLS` choose `None (Not for Production)` - verify that you've included the port number in step above.
-
-#### redis
-
-1. For `Redis Hostname` enter the IP address for your Redis container obtained earlier.
-2. For `Redis password` enter `strongpassword` or whatever you used when you launched the redis container.
-
-
-Click on `Save Configuration Changes` at bottom of page.  Popup window should show settings confirmed.
-
-On next screen, you will have the ability to download the Quay config.yaml as a gzipped tarball.  Click `Download Configuration`- we'll assume it goes into $DOWNLOADS.
-
-Unpack the config so Quay can use it:
-
-```
-$ mkdir $QUAY/config
-$ cp quay-config.tar.gz $QUAY/config
-$ cd $QUAY/config
-$ tar xvf quay-config.tar.gz
-
+```shell
+mkdir -p $QUAY/config
+# Create and edit $QUAY/config/config.yaml with your database, Redis, and server settings.
 ```
 
-While we're here, let's set up a directory to hold image blobs:
+Optionally validate the configuration with the config-tool CLI (validation only; no web UI):
+
+```shell
+podman run --rm -v $QUAY/config:/conf/stack:Z \
+  quay.io/projectquay/quay:latest \
+  /quay-registry/config-tool validate -c /conf/stack
+```
+
+Set up a directory to hold image blobs:
 
 ```
 $ mkdir $QUAY/storage
 $ setfacl -m u:1001:-wx $QUAY/storage
 ```
-
-Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it)- we won't need it anymore.
 
 ## Run Quay
 
@@ -199,8 +161,8 @@ Edit `config.yaml` directly in `$QUAY/config`, then restart the Quay container. 
 
 Optionally validate changes with the config-tool CLI:
 
-```
-$ podman run --rm -v $QUAY/config:/conf/stack:Z \
+```shell
+podman run --rm -v $QUAY/config:/conf/stack:Z \
   quay.io/projectquay/quay:latest \
   /quay-registry/config-tool validate -c /conf/stack
 ```
@@ -258,4 +220,59 @@ mysql> create database quay character set latin1;
 Query OK, 1 row affected (0.02 sec)
 ```
 
-Lastly, when you run the Quay Config Tool, remember to pick `MySQL` as your database type and use the credentials `root/password` and database name `quay`.
+Lastly, when configuring Quay manually, set the database type to `MySQL` and use the credentials `root/password` and database name `quay`. The legacy ConfigTool UI workflow is obsolete on Quay 3.17+; see [Legacy configuration tool workflow (obsolete)](./quick-local-deployment.md#legacy-configuration-tool-workflow-obsolete-in-quay-317).
+
+## Legacy configuration tool workflow (obsolete in Quay 3.17+)
+
+The ConfigTool web UI historically resided on the Quay image and let you generate Quay configuration files and set up your Postgres database. The Quay configuration was a tar/zipped YAML file that you could save locally for Quay to read at startup time.
+
+This workflow no longer works on Quay 3.17+ images. It is preserved here only for reference when working with older images.
+
+The legacy workflow ran the Quay image with runtime flags set to launch ConfigTool:
+
+```shell
+sudo podman run --rm -it --name quay_config -p 8080:8080 quay.io/projectquay/quay config secret
+```
+
+1. Open https://localhost:8080 in browser
+1. Log in with quayconfig/secret
+1. Start New Registry Setup
+
+### Database Setup
+
+1. Choose Postgres database type...
+1. host: (enter the postgres IP address you obtained previously)
+1. user: `user`
+1. password: `pass`
+1. database: `quay`
+
+Hit `Validate Database Settings`.  This will begin setting up your database automatically.
+
+On the next screen, set up a Quay super user account.  Click `Create Super User`.
+
+On main config screen, you will have a few fields to fill out:
+
+#### Server Configuration
+
+1. For `Server Hostname` use `quay:8080` (or `localhost` however the UI will complain).
+1. For `TLS` choose `None (Not for Production)` - verify that you've included the port number in step above.
+
+#### redis
+
+1. For `Redis Hostname` enter the IP address for your Redis container obtained earlier.
+2. For `Redis password` enter `strongpassword` or whatever you used when you launched the redis container.
+
+Click on `Save Configuration Changes` at bottom of page.  Popup window should show settings confirmed.
+
+On next screen, you will have the ability to download the Quay config.yaml as a gzipped tarball.  Click `Download Configuration`- we'll assume it goes into $DOWNLOADS.
+
+Unpack the config so Quay can use it:
+
+```shell
+mkdir $QUAY/config
+cp quay-config.tar.gz $QUAY/config
+cd $QUAY/config
+tar xvf quay-config.tar.gz
+```
+
+Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it).


### PR DESCRIPTION
## Summary
- Add `docs/clair-standalone-configuration.md` with the supported manual workflow for Clair on standalone deployments (no configuration tool UI).
- Document `FEATURE_SECURITY_SCANNER`, `SECURITY_SCANNER_V4_ENDPOINT`, and matching PSK settings in `config.yaml`.
- Update `docs/quick-local-deployment.md` to note the configuration tool UI removal and point readers to the new guide.

## Context
Red Hat Quay 3.17+ images no longer ship the configuration tool web UI ([quay/quay#4769](https://github.com/quay/quay/pull/4769)). Published downstream docs still reference `quay ... config secret` for standalone Clair setup; this upstream guide provides the corrected procedure for docs.redhat.com alignment.

## Test plan
- [ ] Review `docs/clair-standalone-configuration.md` for accuracy against Quay config schema
- [ ] Confirm links from `getting-started.md` and `quick-local-deployment.md` resolve correctly
- [ ] Downstream docs team can port this content to the `clair-standalone-configure` chapter for 3.17/3.18


Made with [Cursor](https://cursor.com)