### PR TITLE
PROJQUAY-12557: fix: Clean up orphaned multipart uploads as part of blob cleanup

### DIFF
--- a/config.py
+++ b/config.py
@@ -1061,3 +1061,7 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Whether to allow sparse manifest indexes where not all architectures are required.
     # When enabled, manifests for missing architectures will be skipped instead of raising errors.
     FEATURE_SPARSE_INDEX = False
+
+    # Feature flag: Enables cleanup of stale multipart uploads on the backend bucket. This feature flag
+    # is only applicable to S3 storage engines.
+    FEATURE_ENABLE_STALE_MPU_CLEANUP = True

--- a/storage/basestorage.py
+++ b/storage/basestorage.py
@@ -97,6 +97,13 @@ class BaseStorage(StoragePaths):
     def clean_partial_uploads(self, deletion_date_threshold):
         raise NotImplementedError
 
+    def clean_orphaned_multipart_uploads(self, deletion_date_threshold):
+        """
+        Attempts to clean orphaned multipart uploads older than the set delete threshold on a compatible
+        storage engine.
+        """
+        raise NotImplementedError
+
     def stream_write_to_fp(self, in_fp, out_fp, num_bytes=READ_UNTIL_END):
         """
         Copy the specified number of bytes from the input file stream to the output stream.

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -755,6 +755,55 @@ class _CloudStorage(BaseStorageV2):
                                 "Blob not found in uploads folder with key %s", obj_info["Key"]
                             )
 
+    def clean_orphaned_multipart_uploads(self, deletion_date_threshold):
+        """
+        Lists and deletes all orphaned multipart uploads that are older than the provided threshold.
+        The threashold must be large enough so we don't clean up multipart uploads that are potentially
+        in progress.
+        """
+        self._initialize_cloud_conn()
+        paginator = self.get_cloud_conn().get_paginator("list_multipart_uploads")
+        deleted = 0
+        page_iterator = paginator.paginate(Bucket=self._bucket_name)
+        for page in page_iterator:
+            # check if there are any multipart uploads
+            if "Uploads" in page:
+                for upload in page["Uploads"]:
+                    # if the upload is older than the designated deletion time
+                    if upload["Initiated"] <= datetime.now(timezone.utc) - deletion_date_threshold:
+                        try:
+                            logger.info(
+                                "Aborting stale multipart upload: uploadid=%s, key=%s, initiated=%s",
+                                upload["UploadId"],
+                                upload["Key"],
+                                upload["Initiated"],
+                            )
+                            self.get_cloud_conn().abort_multipart_upload(
+                                Bucket=self._bucket_name,
+                                Key=upload["Key"],
+                                UploadId=upload["UploadId"],
+                            )
+                            logger.info(
+                                "Deleted stale multipart upload with upload id %s and key %s",
+                                upload["UploadId"],
+                                upload["Key"],
+                            )
+                            deleted = deleted + 1
+                        except botocore.exceptions.ClientError as s3r:
+                            if not s3r.response["Error"]["Code"] in _MISSING_KEY_ERROR_CODES:
+                                logger.exception(
+                                    "Got error when attempting to clean up stale multipart upload: key=%s, uploadid=%s, exception=%s",
+                                    upload["Key"],
+                                    upload["UploadId"],
+                                    str(s3r),
+                                )
+                            else:
+                                logger.debug(
+                                    "Multipart upload with upload id %s not found",
+                                    upload["UploadId"],
+                                )
+        return deleted
+
 
 class S3Storage(_CloudStorage):
     REGIONS = {

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -764,7 +764,7 @@ class _CloudStorage(BaseStorageV2):
         self._initialize_cloud_conn()
         paginator = self.get_cloud_conn().get_paginator("list_multipart_uploads")
         deleted = 0
-        page_iterator = paginator.paginate(Bucket=self._bucket_name)
+        page_iterator = paginator.paginate(Bucket=self._bucket_name, Prefix=self._root_path)
         for page in page_iterator:
             # check if there are any multipart uploads
             if "Uploads" in page:

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -758,7 +758,7 @@ class _CloudStorage(BaseStorageV2):
     def clean_orphaned_multipart_uploads(self, deletion_date_threshold):
         """
         Lists and deletes all orphaned multipart uploads that are older than the provided threshold.
-        The threashold must be large enough so we don't clean up multipart uploads that are potentially
+        The threshold must be large enough so we don't clean up multipart uploads that are potentially
         in progress.
         """
         self._initialize_cloud_conn()

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -764,7 +764,12 @@ class _CloudStorage(BaseStorageV2):
         self._initialize_cloud_conn()
         paginator = self.get_cloud_conn().get_paginator("list_multipart_uploads")
         deleted = 0
-        page_iterator = paginator.paginate(Bucket=self._bucket_name, Prefix=self._root_path)
+
+        root_prefix = self._init_path()
+        if root_prefix and not root_prefix.endswith("/"):
+            root_prefix = root_prefix + "/"
+
+        page_iterator = paginator.paginate(Bucket=self._bucket_name, Prefix=root_prefix)
         for page in page_iterator:
             # check if there are any multipart uploads
             if "Uploads" in page:
@@ -790,17 +795,20 @@ class _CloudStorage(BaseStorageV2):
                             )
                             deleted = deleted + 1
                         except botocore.exceptions.ClientError as s3r:
-                            if not s3r.response["Error"]["Code"] in _MISSING_KEY_ERROR_CODES:
+                            if (
+                                s3r.response["Error"]["Code"]
+                                in ("NoSuchUpload",) + _MISSING_KEY_ERROR_CODES
+                            ):
+                                logger.debug(
+                                    "Multipart upload with upload id %s not found",
+                                    upload["UploadId"],
+                                )
+                            else:
                                 logger.exception(
                                     "Got error when attempting to clean up stale multipart upload: key=%s, uploadid=%s, exception=%s",
                                     upload["Key"],
                                     upload["UploadId"],
                                     str(s3r),
-                                )
-                            else:
-                                logger.debug(
-                                    "Multipart upload with upload id %s not found",
-                                    upload["UploadId"],
                                 )
         return deleted
 

--- a/storage/distributedstorage.py
+++ b/storage/distributedstorage.py
@@ -110,6 +110,9 @@ class DistributedStorage(StoragePaths):
     get_checksum = _location_aware(BaseStorage.get_checksum)
     get_supports_resumable_downloads = _location_aware(BaseStorage.get_supports_resumable_downloads)
     clean_partial_uploads = _location_aware(BaseStorage.clean_partial_uploads, requires_write=True)
+    clean_orphaned_multipart_uploads = _location_aware(
+        BaseStorage.clean_orphaned_multipart_uploads, requires_write=True
+    )
 
     initiate_chunked_upload = _location_aware(
         BaseStorageV2.initiate_chunked_upload, requires_write=True

--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -1,11 +1,15 @@
+import datetime
 import os
 import time
 from datetime import timedelta
 from io import BytesIO
+from unittest.mock import patch
 
 import boto3
 import botocore.exceptions
 import pytest
+from botocore.client import BaseClient
+from freezegun import freeze_time
 from moto import mock_s3
 
 from storage import S3Storage, StorageContext
@@ -376,3 +380,138 @@ def test_clean_partial_uploads(storage_engine, path):
     storage_engine.remove("uploads")
     assert not storage_engine.exists("uploads")
     storage_engine.clean_partial_uploads(timedelta(seconds=0))
+
+
+@pytest.fixture
+def mock_mpu_dates():
+    """
+    Fixture to allow freezegun control moto's multipart upload dates. Needed since Moto
+    hardcodes MPU creation date in its source code which goes back to 2010.
+    Clears state automatically between tests.
+    """
+    _UPLOAD_DATES = {}
+    original_make_api_call = BaseClient._make_api_call
+
+    def _mock_make_api_call(self, operation_name, api_params):
+        response = original_make_api_call(self, operation_name, api_params)
+
+        if operation_name == "CreateMultipartUpload":
+            _UPLOAD_DATES[response["UploadId"]] = datetime.datetime.now(datetime.timezone.utc)
+
+        elif operation_name == "ListMultipartUploads" and "Uploads" in response:
+            for upload in response["Uploads"]:
+                upload_id = upload["UploadId"]
+                if upload_id in _UPLOAD_DATES:
+                    upload["Initiated"] = _UPLOAD_DATES[upload_id]
+
+        return response
+
+    with patch.object(BaseClient, "_make_api_call", new=_mock_make_api_call):
+        yield
+
+
+def test_clean_orphaned_multipart_uploads(storage_engine, mock_mpu_dates):
+    """
+    Tests clean up of stale multipart uploads based on specific threshold.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    # initialize an MPU
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key="test/multipart/upload.txt"
+        )
+
+    # verify that the upload exists
+    assert mpu_response
+    upload_id = mpu_response["UploadId"]
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+    assert len(uploads.get("Uploads", [])) == 1
+    assert uploads["Uploads"][0]["UploadId"] == upload_id
+
+    # Check that the multipart upload is not cleaned for a very large threshold
+    with freeze_time(now):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        assert len(uploads.get("Uploads", [])) == 1
+
+    # Check that the upload is deleted with a threshold of 0
+    with freeze_time(now + timedelta(seconds=5)):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        assert len(uploads.get("Uploads", [])) == 0
+
+
+def test_cleanup_multiple_orphaned_multipart_uploads(storage_engine, mock_mpu_dates):
+    """
+    Tests that all created multipart uploads are cleaned after a certain threshold.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    file_list = ["apple", "ibm", "redhat", "github", "jira", "email"]
+
+    # create multiple MPUs
+    with freeze_time(now):
+        for keyname in file_list:
+            mpu_response = client.create_multipart_upload(
+                Bucket=_TEST_BUCKET, Key="test/multipart/%s" % keyname + ".txt"
+            )
+            assert mpu_response
+
+    # check that we can list all MPUs
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    assert len(uploads) == len(file_list)
+
+    # check that multipart uploads are not delte with a high enough threshold
+    with freeze_time(now):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        assert len(uploads) == len(file_list)
+
+    # assert that all multipart uploads are deleted with a threshold of 0
+    with freeze_time(now + timedelta(seconds=5)):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        assert len(uploads.get("Uploads", [])) == 0
+
+
+def test_partial_cleanup_of_multipart_uploads(storage_engine, mock_mpu_dates):
+    """
+    Tests that partial MPU deletion occurs after a provided threshold. Stale MPUs should
+    be deleted, active MPUs should not be touched.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    file_list = ["apple", "ibm", "redhat", "github", "jira", "email"]
+
+    # create multiple MPUs with a timedelta of 1 hour between them
+    for i, keyname in enumerate(file_list):
+        with freeze_time(now + timedelta(hours=1 * i)):
+            mpu_response = client.create_multipart_upload(
+                Bucket=_TEST_BUCKET, Key="test/multipart/%s" % keyname + ".txt"
+            )
+            assert mpu_response
+
+    # check that we can list all MPUs
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    assert len(uploads) == len(file_list)
+
+    # check that multipart uploads are not delte with a high enough threshold
+    with freeze_time(now + timedelta(hours=5)):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        assert len(uploads) == len(file_list)
+
+    # assert that only some multipart uploads are deleted after a certain threshold
+    # fast forward time by 6 hours, set timedelta to 3.5 hours meaning that
+    # cutoff rate is at now + 2.5 hours. So 3 out of 6 MPUs should be deleted.
+    with freeze_time(now + timedelta(hours=6)):
+        storage_engine.clean_orphaned_multipart_uploads(timedelta(hours=3.5))
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        assert len(uploads) == 3
+        assert uploads[0]["Key"] == "test/multipart/github.txt"
+        assert uploads[1]["Key"] == "test/multipart/jira.txt"
+        assert uploads[2]["Key"] == "test/multipart/email.txt"

--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -567,3 +567,119 @@ def test_cleanup_does_not_impact_multipart_uploads_under_different_paths(
 
         # explicitly verify that the key matches
         assert uploads[0]["Key"] == "/completely/different/deletion/path.txt"
+
+
+def test_cleanup_triggers_on_non_normalized_root(storage_engine, mock_mpu_dates):
+    """
+    Asserts that deletion happens even if our root prefix contains a slash at the beginning.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    # root path has a slash
+    storage_engine._root_path = "/" + _TEST_PATH
+
+    # create an MPU
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/test/root_prefix/starts/with/slash.txt"
+        )
+        assert mpu_response
+
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    assert len(uploads) == 1
+
+    # clean up MPU
+    with freeze_time(now + timedelta(seconds=5)):
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        assert deleted == 1
+
+        # list MPUs on the bucket
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)
+        assert len(uploads.get("Uploads", [])) == 0
+
+
+def test_cleanup_does_not_trigger_on_sibling_suffix(storage_engine, mock_mpu_dates):
+    """
+    Asserts that deletion does not happen on sibling suffixes. Eg: cleanup should happen on
+    some/cool/path/testfile.txt but not on /some/cool/path-with-suffix/testfile.txt.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    storage_engine._root_path = _TEST_PATH
+
+    # create MPU
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/testfile.txt"
+        )
+        assert mpu_response
+
+    # create MPU under different suffix
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "-with-suffix/testfile.txt"
+        )
+        assert mpu_response
+
+    # verify we have both MPUs present
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    assert len(uploads) == 2
+
+    # clean up only under default path
+    with freeze_time(now + timedelta(seconds=5)):
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        assert deleted == 1
+
+        # specifically verify that the key that's left is the 2nd MPU
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH + "/")
+        assert len(uploads.get("Uploads", [])) == 0
+
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        assert len(uploads) == 1
+        assert uploads[0]["Key"] == _TEST_PATH + "-with-suffix/testfile.txt"
+
+
+def test_cleanup_handles_already_aborted_mpu(storage_engine, mock_mpu_dates):
+    """
+    Asserts that the NoSuchUpload exception is caught by the code and not raised.
+    """
+
+    err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "NoSuchUpload", "Message": "The specified upload does not exist."}},
+        "AbortMultipartUpload",
+    )
+
+    def abort_side_effects(Bucket, Key, UploadId):
+        """
+        Helper function to simulate NoSuchUpload exception raised
+        """
+        if Key.endswith("gone.txt"):
+            raise err
+        return {}
+
+    client = boto3.client("s3", region_name=_TEST_REGION)
+    storage_engine._root_path = _TEST_PATH
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    # create two multipart uploads
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/keep.txt"
+        )
+        assert mpu_response
+
+    with freeze_time(now + timedelta(seconds=30)):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/gone.txt"
+        )
+        assert mpu_response
+
+    # conduct deletion
+    with patch.object(
+        storage_engine.get_cloud_conn(), "abort_multipart_upload", side_effect=abort_side_effects
+    ):
+        with freeze_time(now + timedelta(hours=1)):
+            deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+            assert deleted == 1

--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -415,32 +415,37 @@ def test_clean_orphaned_multipart_uploads(storage_engine, mock_mpu_dates):
     Tests clean up of stale multipart uploads based on specific threshold.
     """
     client = boto3.client("s3", region_name=_TEST_REGION)
-
     now = datetime.datetime.now(datetime.timezone.utc)
 
     # initialize an MPU
     with freeze_time(now):
         mpu_response = client.create_multipart_upload(
-            Bucket=_TEST_BUCKET, Key="test/multipart/upload.txt"
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/test/multipart/upload.txt"
         )
 
     # verify that the upload exists
     assert mpu_response
+    print(mpu_response)
     upload_id = mpu_response["UploadId"]
-    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+    storage_engine._root_path = _TEST_PATH
+
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)
+
     assert len(uploads.get("Uploads", [])) == 1
     assert uploads["Uploads"][0]["UploadId"] == upload_id
 
     # Check that the multipart upload is not cleaned for a very large threshold
     with freeze_time(now):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        assert deleted == 0
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)
         assert len(uploads.get("Uploads", [])) == 1
 
     # Check that the upload is deleted with a threshold of 0
     with freeze_time(now + timedelta(seconds=5)):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        assert deleted == 1
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)
         assert len(uploads.get("Uploads", [])) == 0
 
 
@@ -449,6 +454,7 @@ def test_cleanup_multiple_orphaned_multipart_uploads(storage_engine, mock_mpu_da
     Tests that all created multipart uploads are cleaned after a certain threshold.
     """
     client = boto3.client("s3", region_name=_TEST_REGION)
+    storage_engine._root_path = _TEST_PATH
 
     now = datetime.datetime.now(datetime.timezone.utc)
     file_list = ["apple", "ibm", "redhat", "github", "jira", "email"]
@@ -457,24 +463,26 @@ def test_cleanup_multiple_orphaned_multipart_uploads(storage_engine, mock_mpu_da
     with freeze_time(now):
         for keyname in file_list:
             mpu_response = client.create_multipart_upload(
-                Bucket=_TEST_BUCKET, Key="test/multipart/%s" % keyname + ".txt"
+                Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/test/multipart/%s" % keyname + ".txt"
             )
             assert mpu_response
 
     # check that we can list all MPUs
-    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)["Uploads"]
     assert len(uploads) == len(file_list)
 
     # check that multipart uploads are not delte with a high enough threshold
     with freeze_time(now):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        assert deleted == 0
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)["Uploads"]
         assert len(uploads) == len(file_list)
 
     # assert that all multipart uploads are deleted with a threshold of 0
     with freeze_time(now + timedelta(seconds=5)):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        assert deleted == 6
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)
         assert len(uploads.get("Uploads", [])) == 0
 
 
@@ -486,32 +494,76 @@ def test_partial_cleanup_of_multipart_uploads(storage_engine, mock_mpu_dates):
     client = boto3.client("s3", region_name=_TEST_REGION)
     now = datetime.datetime.now(datetime.timezone.utc)
     file_list = ["apple", "ibm", "redhat", "github", "jira", "email"]
+    storage_engine._root_path = _TEST_PATH
 
     # create multiple MPUs with a timedelta of 1 hour between them
     for i, keyname in enumerate(file_list):
         with freeze_time(now + timedelta(hours=1 * i)):
             mpu_response = client.create_multipart_upload(
-                Bucket=_TEST_BUCKET, Key="test/multipart/%s" % keyname + ".txt"
+                Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/test/multipart/%s" % keyname + ".txt"
             )
             assert mpu_response
 
     # check that we can list all MPUs
-    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)["Uploads"]
     assert len(uploads) == len(file_list)
 
-    # check that multipart uploads are not delte with a high enough threshold
+    # check that multipart uploads are not deleted with a high enough threshold
     with freeze_time(now + timedelta(hours=5)):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(days=1))
+        assert deleted == 0
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)["Uploads"]
         assert len(uploads) == len(file_list)
 
     # assert that only some multipart uploads are deleted after a certain threshold
     # fast forward time by 6 hours, set timedelta to 3.5 hours meaning that
     # cutoff rate is at now + 2.5 hours. So 3 out of 6 MPUs should be deleted.
     with freeze_time(now + timedelta(hours=6)):
-        storage_engine.clean_orphaned_multipart_uploads(timedelta(hours=3.5))
-        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(hours=3.5))
+        assert deleted == 3
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET, Prefix=_TEST_PATH)["Uploads"]
         assert len(uploads) == 3
-        assert uploads[0]["Key"] == "test/multipart/github.txt"
-        assert uploads[1]["Key"] == "test/multipart/jira.txt"
-        assert uploads[2]["Key"] == "test/multipart/email.txt"
+        assert uploads[0]["Key"] == _TEST_PATH + "/test/multipart/github.txt"
+        assert uploads[1]["Key"] == _TEST_PATH + "/test/multipart/jira.txt"
+        assert uploads[2]["Key"] == _TEST_PATH + "/test/multipart/email.txt"
+
+
+def test_cleanup_does_not_impact_multipart_uploads_under_different_paths(
+    storage_engine, mock_mpu_dates
+):
+    """
+    Verifies that we only clean up multipart uploads under the root path and not under all paths in
+    the bucket.
+    """
+    client = boto3.client("s3", region_name=_TEST_REGION)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    storage_engine._root_path = _TEST_PATH
+
+    # create an MPU under the default path
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key=_TEST_PATH + "/test/correct/deletion/path.txt"
+        )
+        assert mpu_response
+
+    # create an MPU under a completely different path
+    with freeze_time(now):
+        mpu_response = client.create_multipart_upload(
+            Bucket=_TEST_BUCKET, Key="/completely/different/deletion/path.txt"
+        )
+
+    # check that on the bucket we have two MPUs
+    uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+    assert len(uploads) == 2
+
+    # clean up only MPUs under the proper path
+    with freeze_time(now + timedelta(seconds=5)):
+        deleted = storage_engine.clean_orphaned_multipart_uploads(timedelta(seconds=0))
+        assert deleted == 1
+
+        # list MPUs on the bucket
+        uploads = client.list_multipart_uploads(Bucket=_TEST_BUCKET)["Uploads"]
+        assert len(uploads) == 1
+
+        # explicitly verify that the key matches
+        assert uploads[0]["Key"] == "/completely/different/deletion/path.txt"

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1991,6 +1991,11 @@ CONFIG_SCHEMA = {
             "description": "Comma separated list of urls to exclude from tracing",
             "x-example": "api/v1/.*,v2/([^/]+(/[^/]+)+)/(tags|blobs),v2/_catalog,v2/auth",
         },
+        "FEATURE_ENABLE_STALE_MPU_CLEANUP": {
+            "type": "boolean",
+            "description": "Enables cleanup of stale multipart uploads on the backend bucket. This feature flag is only applicable to S3 storage engines.",
+            "x-example": True,
+        },
     },
     "DEBUG": {
         "type": "boolean",

--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -53,16 +53,17 @@ class BlobUploadCleanupWorker(Worker):
         leftover in the uploads storage folder.
         This function cleans those blobs older than DELETION_DATE_THRESHOLD
         """
+        if not storage.preferred_locations:
+            logger.debug("No preferred storage locations defined, aborting cleanup of stale blobs")
+            return
+
         try:
             storage.clean_partial_uploads(storage.preferred_locations, DELETION_DATE_THRESHOLD)
         except NotImplementedError:
-            if len(storage.preferred_locations) > 0:
-                logger.debug(
-                    'Cleaning partial uploads not applicable to storage location "%s"',
-                    storage.preferred_locations[0],
-                )
-            else:
-                logger.debug("No preferred locations found")
+            logger.debug(
+                'Cleaning partial uploads not applicable to storage location "%s"',
+                storage.preferred_locations[0],
+            )
 
     def _try_clean_stale_multipart_uploads(self):
         """
@@ -71,6 +72,12 @@ class BlobUploadCleanupWorker(Worker):
         consuming storage needlessly. This function cleans all MPUs older than MPU_DELETION_DATE_THRESHOLD.
         """
         deleted = 0
+        if not storage.preferred_locations:
+            logger.debug(
+                "No preferred storage locations defined, aborting cleanup of stale multipart uploads"
+            )
+            return
+
         logger.debug("Performing cleanup of stale multipart uploads")
         try:
             deleted = storage.clean_orphaned_multipart_uploads(
@@ -79,13 +86,10 @@ class BlobUploadCleanupWorker(Worker):
             if deleted == 0:
                 logger.debug("No stale multipart uploads found")
         except NotImplementedError:
-            if len(storage.preferred_locations) > 0:
-                logger.debug(
-                    "Deletion of stale multipart uploads is not applicable to storage location %s",
-                    storage.preferred_locations[0],
-                )
-            else:
-                logger.debug("No preferred locations found")
+            logger.debug(
+                "Deletion of stale multipart uploads is not applicable to storage location %s",
+                storage.preferred_locations[0],
+            )
 
     def _cleanup_uploads(self):
         """

--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -23,15 +23,18 @@ LOCK_TTL = 60 * 20  # 20 minutes
 # then MPUs still in progress might be deleted causing push failures.
 MPU_CLEANUP_TTL = 60 * 60 * 24  # 1 day
 MPU_DELETION_DATE_THRESHOLD = timedelta(seconds=MPU_CLEANUP_TTL)
-# check if there are any stale MPUs every 60 seconds
-MPU_CLEANUP_FREQUENCY = 60
+# check if there are any stale MPUs every 6 hours
+MPU_CLEANUP_FREQUENCY = 6 * 60 * 60
 
 
 class BlobUploadCleanupWorker(Worker):
     def __init__(self):
         super(BlobUploadCleanupWorker, self).__init__()
         self.add_operation(self._try_cleanup_uploads, BLOBUPLOAD_CLEANUP_FREQUENCY)
-        self.add_operation(self._try_clean_stale_multipart_uploads, MPU_CLEANUP_FREQUENCY)
+        if app.config.get("FEATURE_ENABLE_STALE_MPU_CLEANUP", False):
+            self.add_operation(self._try_clean_stale_multipart_uploads, MPU_CLEANUP_FREQUENCY)
+        else:
+            logger.debug("Cleanup of stale multipart uploads not enabled, skipping...")
 
     def _try_cleanup_uploads(self):
         """
@@ -80,15 +83,21 @@ class BlobUploadCleanupWorker(Worker):
 
         logger.debug("Performing cleanup of stale multipart uploads")
         try:
-            deleted = storage.clean_orphaned_multipart_uploads(
-                storage.preferred_locations, MPU_DELETION_DATE_THRESHOLD
-            )
-            if deleted == 0:
-                logger.debug("No stale multipart uploads found")
-        except NotImplementedError:
+            with GlobalLock("STALE_MPU_CLEANUP", lock_ttl=LOCK_TTL):
+                try:
+                    deleted = storage.clean_orphaned_multipart_uploads(
+                        storage.preferred_locations, MPU_DELETION_DATE_THRESHOLD
+                    )
+                    if deleted == 0:
+                        logger.debug("No stale multipart uploads found")
+                except NotImplementedError:
+                    logger.debug(
+                        "Deletion of stale multipart uploads is not applicable to storage location %s",
+                        storage.preferred_locations[0],
+                    )
+        except LockNotAcquiredException:
             logger.debug(
-                "Deletion of stale multipart uploads is not applicable to storage location %s",
-                storage.preferred_locations[0],
+                "Could not acquire global lock for stale multipart upload cleanup, skipping..."
             )
 
     def _cleanup_uploads(self):

--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -18,11 +18,20 @@ DELETION_DATE_THRESHOLD = timedelta(minutes=threshold)
 BLOBUPLOAD_CLEANUP_FREQUENCY = app.config.get("BLOBUPLOAD_CLEANUP_FREQUENCY", 60 * 60)
 LOCK_TTL = 60 * 20  # 20 minutes
 
+# Sets MPU deletion date threshold to 1 day
+# The TTL is explicitly chosen not to be configurable by the client: if the threshold is set too low,
+# then MPUs still in progress might be deleted causing push failures.
+MPU_CLEANUP_TTL = 60 * 60 * 24  # 1 day
+MPU_DELETION_DATE_THRESHOLD = timedelta(seconds=MPU_CLEANUP_TTL)
+# check if there are any stale MPUs every 60 seconds
+MPU_CLEANUP_FREQUENCY = 60
+
 
 class BlobUploadCleanupWorker(Worker):
     def __init__(self):
         super(BlobUploadCleanupWorker, self).__init__()
         self.add_operation(self._try_cleanup_uploads, BLOBUPLOAD_CLEANUP_FREQUENCY)
+        self.add_operation(self._try_clean_stale_multipart_uploads, MPU_CLEANUP_FREQUENCY)
 
     def _try_cleanup_uploads(self):
         """
@@ -50,6 +59,29 @@ class BlobUploadCleanupWorker(Worker):
             if len(storage.preferred_locations) > 0:
                 logger.debug(
                     'Cleaning partial uploads not applicable to storage location "%s"',
+                    storage.preferred_locations[0],
+                )
+            else:
+                logger.debug("No preferred locations found")
+
+    def _try_clean_stale_multipart_uploads(self):
+        """
+        Attempts to clean up stale multipart uploads on the storage side. Stale uploads can happen if
+        the upload thread was terminated prematurely and MPU was not cancelled or committed properly,
+        consuming storage needlessly. This function cleans all MPUs older than MPU_DELETION_DATE_THRESHOLD.
+        """
+        deleted = 0
+        logger.debug("Performing cleanup of stale multipart uploads")
+        try:
+            deleted = storage.clean_orphaned_multipart_uploads(
+                storage.preferred_locations, MPU_DELETION_DATE_THRESHOLD
+            )
+            if deleted == 0:
+                logger.debug("No stale multipart uploads found")
+        except NotImplementedError:
+            if len(storage.preferred_locations) > 0:
+                logger.debug(
+                    "Deletion of stale multipart uploads is not applicable to storage location %s",
                     storage.preferred_locations[0],
                 )
             else:

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -7,6 +7,7 @@ from mock import Mock, patch
 from app import app as realapp
 from test.fixtures import *
 from workers.blobuploadcleanupworker.blobuploadcleanupworker import (
+    LOCK_TTL,
     MPU_DELETION_DATE_THRESHOLD,
     BlobUploadCleanupWorker,
 )
@@ -118,17 +119,21 @@ def test_verify_operation_is_registered_if_feature_flag_is_enabled(initialized_d
         assert "_try_clean_stale_multipart_uploads" in registered
 
 
-def test_verify_that_worker_acquires_a_global_lock(initialized_db):
+def test_verify_that_worker_acquires_a_global_lock_with_proper_values(initialized_db):
     """
-    Verifies that a GlobalLock is acquired if the worker is called.
+    Verifies that a GlobalLock is acquired if the worker is called and that proper values
+    were sent.
     """
     from util.locking import GlobalLock
 
-    class _FakeLock:
-        lock_factory = object()
+    captured = {}
 
+    class _FakeLock:
         def __init__(self, name, expire=None, auto_renewal=False):
             self._name = name
+            self._expire = expire
+            self._auto_renewal = auto_renewal
+            captured.update(name=name, expire=expire, auto_renewal=auto_renewal)
 
         def acquire(self):
             return True
@@ -137,6 +142,7 @@ def test_verify_that_worker_acquires_a_global_lock(initialized_db):
             pass
 
     storage_mock = Mock()
+
     storage_mock.preferred_locations = ["default"]
     storage_mock.clean_orphaned_multipart_uploads.return_value = 0
 
@@ -145,6 +151,38 @@ def test_verify_that_worker_acquires_a_global_lock(initialized_db):
             worker = BlobUploadCleanupWorker()
             worker._try_clean_stale_multipart_uploads()
 
+        # verify that the lock is initialized with proper values
+        assert captured["name"] == "STALE_MPU_CLEANUP"
+        assert captured["expire"] == LOCK_TTL
+        assert captured["auto_renewal"] is False
+
         storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
             ["default"], MPU_DELETION_DATE_THRESHOLD
         )
+
+
+def test_verify_that_multipart_cleanup_does_not_run_if_lock_cannot_be_acquired(initialized_db):
+    """
+    Verifies that cleanup of orphaned MPUs is not called if GlobalLock cannot be acquired.
+    """
+    from util.locking import GlobalLock, LockNotAcquiredException
+
+    class _FakeLock:
+        def __init__(self, name, expire=None, auto_renewal=False):
+            self._name = name
+
+        def acquire(self):
+            return False
+
+        def release(self):
+            pass
+
+    storage_mock = Mock()
+    storage_mock.preferred_locations = ["default"]
+
+    with patch.object(GlobalLock, "lock_factory", staticmethod(_FakeLock)):
+        with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+            worker = BlobUploadCleanupWorker()
+            worker._try_clean_stale_multipart_uploads()
+
+        storage_mock.clean_orphaned_multipart_uploads.assert_not_called()

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
+from datetime import timedelta
 
 import boto3
 from mock import Mock, patch
-from moto import mock_s3
 
 from test.fixtures import *
 from workers.blobuploadcleanupworker.blobuploadcleanupworker import (
@@ -45,6 +45,9 @@ def test_blobuploadcleanupworker_calls_mpu_cleanup(initialized_db):
     storage_mock = Mock()
     storage_mock.preferred_locations = ["default"]
 
+    # verify that the deletion threshold is always 1 day
+    assert MPU_DELETION_DATE_THRESHOLD == timedelta(days=1)
+
     # we'll mock the deleted count
     storage_mock.clean_orphaned_multipart_uploads.return_value = 5
 
@@ -56,3 +59,31 @@ def test_blobuploadcleanupworker_calls_mpu_cleanup(initialized_db):
     storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
         ["default"], MPU_DELETION_DATE_THRESHOLD
     )
+
+
+def test_mpu_cleanup_exits_if_no_preferred_storage_location_is_found(initialized_db):
+    """
+    Checks that the MPU cleanup is not called if preferred storage engine is not set.
+    """
+    storage_mock = Mock()
+    storage_mock.preferred_locations = []
+
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+        worker = BlobUploadCleanupWorker()
+        worker._try_clean_stale_multipart_uploads()
+
+    storage_mock.clean_orphaned_multipart_uploads.assert_not_called()
+
+
+def test_partial_blob_cleanup_exits_if_no_preferred_storage_location_is_found(initialized_db):
+    """
+    Checks that the partial blob cleanup is not called if preferred storage engine is not set.
+    """
+    storage_mock = Mock()
+    storage_mock.preferred_locations = []
+
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+        worker = BlobUploadCleanupWorker()
+        worker._try_clean_partial_uploads()
+
+    storage_mock.clean_partial_uploads.assert_not_called()

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -1,9 +1,12 @@
 from contextlib import contextmanager
-from test.fixtures import *
 
+import boto3
 from mock import Mock, patch
+from moto import mock_s3
 
+from test.fixtures import *
 from workers.blobuploadcleanupworker.blobuploadcleanupworker import (
+    MPU_DELETION_DATE_THRESHOLD,
     BlobUploadCleanupWorker,
 )
 from workers.blobuploadcleanupworker.models_pre_oci import pre_oci_model as model
@@ -33,3 +36,23 @@ def test_blobuploadcleanupworker(initialized_db):
 
     # Ensure the blob no longer exists.
     model.blob_upload_exists(blob_upload.uuid)
+
+
+def test_blobuploadcleanupworker_calls_mpu_cleanup(initialized_db):
+    """
+    Asserts that the MPU cleanup function is called from the worker.
+    """
+    storage_mock = Mock()
+    storage_mock.preferred_locations = ["default"]
+
+    # we'll mock the deleted count
+    storage_mock.clean_orphaned_multipart_uploads.return_value = 5
+
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+        # call cleanup and ensure it's cancelled
+        worker = BlobUploadCleanupWorker()
+        worker._try_clean_stale_multipart_uploads()
+
+    storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
+        ["default"], MPU_DELETION_DATE_THRESHOLD
+    )

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import boto3
 from mock import Mock, patch
 
+from app import app as realapp
 from test.fixtures import *
 from workers.blobuploadcleanupworker.blobuploadcleanupworker import (
     MPU_DELETION_DATE_THRESHOLD,
@@ -51,14 +52,16 @@ def test_blobuploadcleanupworker_calls_mpu_cleanup(initialized_db):
     # we'll mock the deleted count
     storage_mock.clean_orphaned_multipart_uploads.return_value = 5
 
-    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
-        # call cleanup and ensure it's cancelled
-        worker = BlobUploadCleanupWorker()
-        worker._try_clean_stale_multipart_uploads()
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.GlobalLock"):
+        with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
 
-    storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
-        ["default"], MPU_DELETION_DATE_THRESHOLD
-    )
+            # call cleanup and ensure it's cancelled
+            worker = BlobUploadCleanupWorker()
+            worker._try_clean_stale_multipart_uploads()
+
+        storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
+            ["default"], MPU_DELETION_DATE_THRESHOLD
+        )
 
 
 def test_mpu_cleanup_exits_if_no_preferred_storage_location_is_found(initialized_db):
@@ -68,9 +71,10 @@ def test_mpu_cleanup_exits_if_no_preferred_storage_location_is_found(initialized
     storage_mock = Mock()
     storage_mock.preferred_locations = []
 
-    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
-        worker = BlobUploadCleanupWorker()
-        worker._try_clean_stale_multipart_uploads()
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.GlobalLock"):
+        with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+            worker = BlobUploadCleanupWorker()
+            worker._try_clean_stale_multipart_uploads()
 
     storage_mock.clean_orphaned_multipart_uploads.assert_not_called()
 
@@ -82,8 +86,21 @@ def test_partial_blob_cleanup_exits_if_no_preferred_storage_location_is_found(in
     storage_mock = Mock()
     storage_mock.preferred_locations = []
 
-    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
-        worker = BlobUploadCleanupWorker()
-        worker._try_clean_partial_uploads()
+    with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.GlobalLock"):
+        with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+            worker = BlobUploadCleanupWorker()
+            worker._try_clean_partial_uploads()
 
     storage_mock.clean_partial_uploads.assert_not_called()
+
+
+def test_verify_operation_is_not_registered_if_feature_flag_is_disabled(initialized_db):
+    """
+    Verifies that the job is not scheduled unless the feature flag is set.
+    """
+    with patch.dict(realapp.config, {"FEATURE_ENABLE_STALE_MPU_CLEANUP": False}):
+        with patch.object(BlobUploadCleanupWorker, "add_operation") as mock_add:
+            BlobUploadCleanupWorker()
+
+        registered = [c.args[0].__name__ for c in mock_add.call_args_list]
+        assert "_try_clean_stale_multipart_uploads" not in registered

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -104,3 +104,47 @@ def test_verify_operation_is_not_registered_if_feature_flag_is_disabled(initiali
 
         registered = [c.args[0].__name__ for c in mock_add.call_args_list]
         assert "_try_clean_stale_multipart_uploads" not in registered
+
+
+def test_verify_operation_is_registered_if_feature_flag_is_enabled(initialized_db):
+    """
+    Asserts that the job operation is scheduled if the feature flag is set.
+    """
+    with patch.dict(realapp.config, {"FEATURE_ENABLE_STALE_MPU_CLEANUP": True}):
+        with patch.object(BlobUploadCleanupWorker, "add_operation") as mock_add:
+            BlobUploadCleanupWorker()
+
+        registered = [c.args[0].__name__ for c in mock_add.call_args_list]
+        assert "_try_clean_stale_multipart_uploads" in registered
+
+
+def test_verify_that_worker_acquires_a_global_lock(initialized_db):
+    """
+    Verifies that a GlobalLock is acquired if the worker is called.
+    """
+    from util.locking import GlobalLock
+
+    class _FakeLock:
+        lock_factory = object()
+
+        def __init__(self, name, expire=None, auto_renewal=False):
+            self._name = name
+
+        def acquire(self):
+            return True
+
+        def release(self):
+            pass
+
+    storage_mock = Mock()
+    storage_mock.preferred_locations = ["default"]
+    storage_mock.clean_orphaned_multipart_uploads.return_value = 0
+
+    with patch.object(GlobalLock, "lock_factory", staticmethod(_FakeLock)):
+        with patch("workers.blobuploadcleanupworker.blobuploadcleanupworker.storage", storage_mock):
+            worker = BlobUploadCleanupWorker()
+            worker._try_clean_stale_multipart_uploads()
+
+        storage_mock.clean_orphaned_multipart_uploads.assert_called_once_with(
+            ["default"], MPU_DELETION_DATE_THRESHOLD
+        )


### PR DESCRIPTION
Previously, the orphaned multipart uploads were not cleaned by the worker. Orphaned MPUs can occur when the upload thread is terminated before blob upload is either cancelled or committed. It can also occur on server side assemblies during copying of the file from the `uploads/` directory to its rightful place in the directory tree. 

This change allows us to cancel any orphaned (or stale) multipart uploads that are older than 1 day. The 1 day threshold is wide enough to not cancel any legitimate uploads that are still in progress. The change is only applicable to S3, other storage engines have different mechanisms to handle orphaned uploads.