### PR TITLE
QUAYIO-2060: fix(deploy): switch externalTrafficPolicy to Cluster for even load distribution

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -12,7 +12,7 @@ objects:
       app: quay-envoy
   spec:
     type: NodePort
-    externalTrafficPolicy: Local
+    externalTrafficPolicy: Cluster
     ports:
     - name: https
       protocol: TCP


### PR DESCRIPTION
## Summary
- Switch `quay-envoy-svc` from `externalTrafficPolicy: Local` to `Cluster`

## Why?

With `Local`, the ALB distributes traffic to **nodes**, and kube-proxy only routes to pods on the same node. This causes uneven load:

- Nodes with 1 Envoy pod: that pod handles 100% of the node's traffic (~2,750m CPU)
- Nodes with 2 Envoy pods: each handles 50% (~1,450m CPU)
- Empty nodes: health check fails, wasted ALB capacity

With `Cluster`, kube-proxy distributes traffic across **all pods** regardless of which node receives it. Every pod gets equal load.

## Source IP preservation

`Cluster` mode SNATs the TCP source IP to a node IP. However, Envoy already extracts the real client IP from the `X-Forwarded-For` header set by the ALB:

```yaml
use_remote_address: true
xff_num_trusted_hops: 1
```

This is unaffected by the traffic policy change. Rate limiting descriptors that use client IP (via XFF) will continue to work correctly.

## Trade-offs

- Extra network hop when traffic crosses nodes — minimal latency within the cluster
- TCP source IP becomes node IP — mitigated by XFF as described above

JIRA: https://redhat.atlassian.net/browse/QUAYIO-2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)