### PR TITLE
NO-ISSUE: fix(pre-commit): ensure pnpm 10 and robust node_modules install in hook scripts

### DIFF
--- a/.github/hooks/check-playwright-tags.sh
+++ b/.github/hooks/check-playwright-tags.sh
@@ -19,13 +19,13 @@ fi
 if [ ! -d "${WEB_DIR}/node_modules" ]; then
   if command -v pnpm &>/dev/null; then
     echo "web/node_modules not found; installing dependencies via pnpm..."
-    (cd "${WEB_DIR}" && pnpm install --frozen-lockfile --prefer-offline --silent)
+    (cd "${WEB_DIR}" && pnpm install --frozen-lockfile) || true
+  elif command -v npx &>/dev/null; then
+    echo "web/node_modules not found; installing dependencies via npx pnpm@10..."
+    (cd "${WEB_DIR}" && npx --yes pnpm@10 install --frozen-lockfile) || true
   elif command -v corepack &>/dev/null; then
     echo "web/node_modules not found; installing dependencies via corepack pnpm..."
-    (cd "${WEB_DIR}" && corepack pnpm install --frozen-lockfile --prefer-offline --silent)
-  elif command -v npx &>/dev/null; then
-    echo "web/node_modules not found; installing dependencies via npx pnpm..."
-    (cd "${WEB_DIR}" && npx --yes pnpm install --frozen-lockfile --prefer-offline --silent)
+    (cd "${WEB_DIR}" && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --frozen-lockfile) || true
   fi
 fi
 

--- a/.github/hooks/run-eslint.sh
+++ b/.github/hooks/run-eslint.sh
@@ -19,13 +19,13 @@ fi
 if [ ! -d "${WEB_DIR}/node_modules" ]; then
   if command -v pnpm &>/dev/null; then
     echo "web/node_modules not found; installing dependencies via pnpm..."
-    (cd "${WEB_DIR}" && pnpm install --frozen-lockfile --prefer-offline --silent)
+    (cd "${WEB_DIR}" && pnpm install --frozen-lockfile) || true
+  elif command -v npx &>/dev/null; then
+    echo "web/node_modules not found; installing dependencies via npx pnpm@10..."
+    (cd "${WEB_DIR}" && npx --yes pnpm@10 install --frozen-lockfile) || true
   elif command -v corepack &>/dev/null; then
     echo "web/node_modules not found; installing dependencies via corepack pnpm..."
-    (cd "${WEB_DIR}" && corepack pnpm install --frozen-lockfile --prefer-offline --silent)
-  elif command -v npx &>/dev/null; then
-    echo "web/node_modules not found; installing dependencies via npx pnpm..."
-    (cd "${WEB_DIR}" && npx --yes pnpm install --frozen-lockfile --prefer-offline --silent)
+    (cd "${WEB_DIR}" && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --frozen-lockfile) || true
   fi
 fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         stages: [pre-commit]
     -   id: npm-lockfile-sync
         name: Sync npm lockfile with pnpm changes
-        entry: bash -c 'if git diff --cached --name-only | grep -qE "^web/(pnpm-lock\.yaml|package\.json)$"; then cd web && npm install --package-lock-only --legacy-peer-deps --silent 2>/dev/null && git add package-lock.json; fi'
+        entry: bash -c 'if git diff --cached --name-only | grep -qE "^web/(pnpm-lock\.yaml|package\.json)$"; then npm --prefix web install --package-lock-only --legacy-peer-deps --no-workspaces --silent 2>/dev/null && git add web/package-lock.json; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "quay-ui",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.34.2",
   "insights": {
     "appname": "quay"
   },


### PR DESCRIPTION
## Summary

Enhances the pre-commit hook scripts (`run-eslint.sh` and `check-playwright-tags.sh`) and `.pre-commit-config.yaml` to ensure reliable dependency resolution and execution in fresh runner environments (such as Fullsend and CI agents):

1. **`web/package.json`**: Added `"packageManager": "pnpm@10.34.2"`. This informs Node 22 Corepack and modern engines to use pnpm 10 when parsing `web/pnpm-lock.yaml`, preventing Corepack from defaulting to older incompatible pnpm versions (e.g. pnpm 9).
2. **`.github/hooks/run-eslint.sh` & `.github/hooks/check-playwright-tags.sh`**:
   - Prioritizes `npx --yes pnpm@10` to guarantee pnpm 10 execution in environments without a globally pre-installed `pnpm` binary.
   - Sets `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to prevent Corepack from blocking in non-interactive CI environments.
   - Removed `--prefer-offline` (which failed on fresh empty caches in CI/agent runners) and `--silent` so installation issues are clearly diagnosable.
   - Wrapped the installation attempt so any network or install errors fall through to the explicit error handling at the bottom of the script.
3. **`.pre-commit-config.yaml`**: Updated `npm-lockfile-sync` hook to use `npm --prefix web install --package-lock-only --legacy-peer-deps --no-workspaces` and explicitly stage `web/package-lock.json`, preventing npm from traversing up and modifying the root `package-lock.json`.

## Testing

- Verified all pre-commit hooks pass locally on modified and staged files.
- Verified `npm --prefix web install --no-workspaces` keeps lockfile modifications cleanly scoped to `web/package-lock.json`.
- Tested `npx --yes pnpm@10` resolution in clean temporary environment.