### PR TITLE
PROJQUAY-12772: feat(config): add digest algorithm allowlist

### DIFF
--- a/config.py
+++ b/config.py
@@ -445,6 +445,10 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: If set to true, Quay will run using FIPS compliant hash functions.
     FEATURE_FIPS = False
 
+    # Exact allowlist of digest algorithms accepted for new client-visible digest writes.
+    # Internal storage and deduplication continue to use canonical SHA-256.
+    ALLOWED_HASH_ALGORITHMS: List[str] = ["sha256"]
+
     # If a namespace is defined in the public namespace list, then it will appear on *all*
     # user's repository list pages, regardless of whether that user is a member of the namespace.
     # Typically, this is used by an enterprise customer in configuring a set of "well-known"

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -138,7 +138,7 @@ def create_user_noverify(
         # ID to ensure that the database consistency check remains intact.
         email = email or str(uuid.uuid4())
 
-    (username_valid, username_issue) = validate_username(username)
+    username_valid, username_issue = validate_username(username)
     if not username_valid:
         raise InvalidUsernameException("Invalid namespace %s: %s" % (username, username_issue))
 
@@ -278,7 +278,7 @@ def get_user_prompts(user):
 
 
 def change_username(user_id, new_username):
-    (username_valid, username_issue) = validate_username(new_username)
+    username_valid, username_issue = validate_username(new_username)
     if not username_valid:
         raise InvalidUsernameException("Invalid username %s: %s" % (new_username, username_issue))
 
@@ -353,7 +353,7 @@ def update_enabled(user, set_enabled):
 
 
 def create_robot(robot_shortname, parent, description="", unstructured_metadata=None, token=None):
-    (username_valid, username_issue) = validate_username(robot_shortname)
+    username_valid, username_issue = validate_username(robot_shortname)
     if config.app_config.get("ROBOTS_DISALLOW", False):
         msg = "Robot accounts have been disabled. Please contact your administrator."
         raise InvalidRobotException(msg)

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -654,7 +654,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                     continue
 
             try:
-                (report, state) = self._secscan_api.index(manifest, layers)
+                report, state = self._secscan_api.index(manifest, layers)
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.warning("Failed to perform indexing, invalid content sent")

--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -376,7 +376,7 @@ class UserAuthentication(object):
             else:
                 password = decrypted
 
-        (result, err_msg) = self.state.verify_and_link_user(username_or_email, password)
+        result, err_msg = self.state.verify_and_link_user(username_or_email, password)
         if not result:
             return (result, err_msg)
 

--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -215,7 +215,7 @@ def page_support(page_token_kwarg="page_token", parsed_args_kwarg="parsed_args")
             page_token = decrypt_page_token(kwargs[parsed_args_kwarg]["next_page"])
             kwargs[page_token_kwarg] = page_token
 
-            (result, next_page_token) = func(self, *args, **kwargs)
+            result, next_page_token = func(self, *args, **kwargs)
             if next_page_token is not None:
                 result["next_page"] = encrypt_page_token(next_page_token)
 
@@ -248,7 +248,7 @@ def parse_args(kwarg_name="parsed_args"):
 def parse_repository_name(func):
     @wraps(func)
     def wrapper(repository, *args, **kwargs):
-        (namespace, repository) = parse_namespace_repository(
+        namespace, repository = parse_namespace_repository(
             repository, app.config["LIBRARY_NAMESPACE"]
         )
         return func(namespace, repository, *args, **kwargs)
@@ -825,7 +825,7 @@ def deprecated():
     def wrapper(func):
         @wraps(func)
         def wrapped(self, *args, **kwargs):
-            (data, code, headers) = unpack(func(self, *args, **kwargs))
+            data, code, headers = unpack(func(self, *args, **kwargs))
             headers["Deprecation"] = "true"
 
             return (data, code, headers)

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -99,7 +99,7 @@ class SuperUserAggregateLogs(ApiResource):
         Returns the aggregated logs for the current system.
         """
         if allow_if_any_superuser():
-            (start_time, end_time) = _validate_logs_arguments(
+            start_time, end_time = _validate_logs_arguments(
                 parsed_args["starttime"], parsed_args["endtime"]
             )
             try:
@@ -142,7 +142,7 @@ class SuperUserLogs(ApiResource):
             start_time = parsed_args["starttime"]
             end_time = parsed_args["endtime"]
 
-            (start_time, end_time) = _validate_logs_arguments(start_time, end_time)
+            start_time, end_time = _validate_logs_arguments(start_time, end_time)
             try:
                 log_entry_page = logs_model.lookup_logs(start_time, end_time, page_token=page_token)
             except SearchNotConfiguredError as e:
@@ -1025,7 +1025,7 @@ class SuperUserServiceKeyManagement(ApiResource):
             )
 
             # Generate a key with a private key that we *never save*.
-            (private_key, key_id) = pre_oci_model.generate_service_key(
+            private_key, key_id = pre_oci_model.generate_service_key(
                 body["service"], expiration_date, metadata=metadata, name=key_name
             )
             # Auto-approve the service key.

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -21,7 +21,11 @@ from flask_login import current_user
 
 import features
 from _init import ROOT_DIR, __version__
-from app import app, authentication, avatar
+from app import (
+    app,
+    authentication,
+    avatar,
+)
 from app import billing as stripe
 from app import (
     build_logs,
@@ -301,7 +305,7 @@ def privacy():
 @no_cache
 def instance_health():
     checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_instance()
+    data, status_code = checker.check_instance()
     response = jsonify(dict(data=data, status_code=status_code))
     response.status_code = status_code
     return response
@@ -313,7 +317,7 @@ def instance_health():
 @no_cache
 def endtoend_health():
     checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_endtoend()
+    data, status_code = checker.check_endtoend()
     response = jsonify(dict(data=data, status_code=status_code))
     response.status_code = status_code
     return response
@@ -324,7 +328,7 @@ def endtoend_health():
 @no_cache
 def warning_health():
     checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_warning()
+    data, status_code = checker.check_warning()
     response = jsonify(dict(data=data, status_code=status_code))
     response.status_code = status_code
     return response

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Auth      `yaml:",inline"`
 	Features  `yaml:",inline"`
 	Security  `yaml:",inline"`
+	Digest    `yaml:",inline"`
 	Keys      `yaml:",inline"`
 	AccessLog `yaml:",inline"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,58 @@ func TestParseDefaults(t *testing.T) {
 	assert.True(t, cfg.FeatureDirectLogin)
 }
 
+func TestParseAllowedHashAlgorithmsDefaultsToSHA256(t *testing.T) {
+	cfg, err := Parse([]byte("SERVER_HOSTNAME: test\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, HashAlgorithms{"sha256"}, cfg.AllowedHashAlgorithms)
+}
+
+func TestParseAllowedHashAlgorithmsUsesExplicitListExactly(t *testing.T) {
+	tests := []struct {
+		name       string
+		algorithms string
+		expected   HashAlgorithms
+	}{
+		{name: "sha256 only", algorithms: "[sha256]", expected: HashAlgorithms{"sha256"}},
+		{name: "sha512 only", algorithms: "[sha512]", expected: HashAlgorithms{"sha512"}},
+		{name: "sha256 and sha512", algorithms: "[sha256, sha512]", expected: HashAlgorithms{"sha256", "sha512"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Parse([]byte("ALLOWED_HASH_ALGORITHMS: " + tt.algorithms + "\n"))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, cfg.AllowedHashAlgorithms)
+			assert.NotContains(t, cfg.Extra, "ALLOWED_HASH_ALGORITHMS")
+		})
+	}
+}
+
+func TestParseAllowedHashAlgorithmsRejectsInvalidTypes(t *testing.T) {
+	tests := map[string]string{
+		"string":          "ALLOWED_HASH_ALGORITHMS: sha256\n",
+		"mapping":         "ALLOWED_HASH_ALGORITHMS: {sha256: true}\n",
+		"integer":         "ALLOWED_HASH_ALGORITHMS: 256\n",
+		"non-string item": "ALLOWED_HASH_ALGORITHMS: [sha256, 512]\n",
+		"null item":       "ALLOWED_HASH_ALGORITHMS: [sha256, null]\n",
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse([]byte(input))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewDefaultAllowedHashAlgorithmsUsesSHA256(t *testing.T) {
+	cfg := NewDefault("localhost", "/data/storage")
+
+	assert.Equal(t, HashAlgorithms{"sha256"}, cfg.AllowedHashAlgorithms)
+}
+
 func TestParseRobotAuthConfig(t *testing.T) {
 	cfg, err := Parse([]byte(`
 SERVER_HOSTNAME: test

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -10,6 +10,7 @@ const (
 	DefaultLastAccessedUpdateThresholdS = 60
 	DefaultInstanceServiceKeyService    = "quay"
 	DefaultRegistryJWTAuthMaxFreshS     = 3660
+	DefaultHashAlgorithm                = "sha256"
 
 	// Feature defaults mirror the Python configuration defaults. A nil feature
 	// value is resolved against these defaults by internal/features.
@@ -52,6 +53,9 @@ func newDefaultConfig() Config {
 		},
 		AccessLog: AccessLog{
 			LastAccessedUpdateThresholdS: DefaultLastAccessedUpdateThresholdS,
+		},
+		Digest: Digest{
+			AllowedHashAlgorithms: HashAlgorithms{DefaultHashAlgorithm},
 		},
 		Keys: Keys{
 			InstanceServiceKeyService: DefaultInstanceServiceKeyService,

--- a/internal/config/digest.go
+++ b/internal/config/digest.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+var supportedHashAlgorithms = map[string]struct{}{
+	"sha256": {},
+	"sha512": {},
+}
+
+// HashAlgorithms is a strictly typed list of digest algorithm identifiers.
+type HashAlgorithms []string
+
+// UnmarshalYAML rejects YAML coercion of non-string values into strings.
+func (algorithms *HashAlgorithms) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.SequenceNode {
+		return fmt.Errorf("ALLOWED_HASH_ALGORITHMS: expected a sequence of strings")
+	}
+
+	decoded := make(HashAlgorithms, len(value.Content))
+	for index, item := range value.Content {
+		if item.Kind != yaml.ScalarNode || item.Tag != "!!str" {
+			return fmt.Errorf(
+				"ALLOWED_HASH_ALGORITHMS: item %d must be a string",
+				index,
+			)
+		}
+		decoded[index] = item.Value
+	}
+
+	*algorithms = decoded
+	return nil
+}
+
+// Digest holds client-visible digest algorithm settings. Canonical internal
+// storage and deduplication continue to use SHA-256 independently of this list.
+type Digest struct {
+	AllowedHashAlgorithms HashAlgorithms `yaml:"ALLOWED_HASH_ALGORITHMS"`
+}
+
+// validateDigest checks that the configured exact allowlist is non-empty,
+// unique, and contains only supported lowercase algorithm identifiers.
+func validateDigest(cfg *Config, _ ValidateOptions) []ValidationError {
+	if len(cfg.AllowedHashAlgorithms) == 0 {
+		return []ValidationError{{
+			Field:    fieldAllowedHashAlgorithms,
+			Severity: SeverityError,
+			Message:  "must contain at least one algorithm",
+		}}
+	}
+
+	seen := make(map[string]struct{}, len(cfg.AllowedHashAlgorithms))
+	var errs []ValidationError
+	for _, algorithm := range cfg.AllowedHashAlgorithms {
+		if _, duplicate := seen[algorithm]; duplicate {
+			errs = append(errs, ValidationError{
+				Field:    fieldAllowedHashAlgorithms,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("contains duplicate algorithm %q", algorithm),
+			})
+			continue
+		}
+		seen[algorithm] = struct{}{}
+
+		if _, supported := supportedHashAlgorithms[algorithm]; !supported {
+			errs = append(errs, ValidationError{
+				Field:    fieldAllowedHashAlgorithms,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("contains unsupported algorithm %q", algorithm),
+			})
+		}
+	}
+
+	return errs
+}

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -8,6 +8,7 @@ const (
 	fieldTagExpirationOptions         = "TAG_EXPIRATION_OPTIONS"
 	fieldSecretKey                    = "SECRET_KEY"
 	fieldDatabaseSecretKey            = "DATABASE_SECRET_KEY"
+	fieldAllowedHashAlgorithms        = "ALLOWED_HASH_ALGORITHMS"
 
 	msgRequired = "is required"
 )

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -135,6 +135,9 @@ func NewDefault(hostname, storagePath string) *Config {
 			InstanceServiceKeyService: DefaultInstanceServiceKeyService,
 			RegistryJWTAuthMaxFreshS:  DefaultRegistryJWTAuthMaxFreshS,
 		},
+		Digest: Digest{
+			AllowedHashAlgorithms: HashAlgorithms{DefaultHashAlgorithm},
+		},
 		Storage: Storage{
 			DistributedStorageConfig: StorageEntries{
 				"default": {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -64,6 +64,7 @@ func Validate(ctx context.Context, cfg *Config, opts ValidateOptions) []Validati
 	errs = append(errs, validateRedis(cfg, opts)...)
 	errs = append(errs, validateAuth(cfg, opts)...)
 	errs = append(errs, validateSecurity(cfg, opts)...)
+	errs = append(errs, validateDigest(cfg, opts)...)
 
 	// Phase 2: online probes (only if offline passed and mode is "online").
 	if opts.Mode == "online" && !HasErrors(errs) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -124,6 +124,35 @@ func TestValidateTagExpirationNotInOptions(t *testing.T) {
 	assert.True(t, hasFieldWarning(errs, "DEFAULT_TAG_EXPIRATION"), "expected warning for DEFAULT_TAG_EXPIRATION not in TAG_EXPIRATION_OPTIONS")
 }
 
+func TestValidateAllowedHashAlgorithms(t *testing.T) {
+	tests := []struct {
+		name       string
+		algorithms string
+		wantError  bool
+	}{
+		{name: "sha256 only", algorithms: "[sha256]"},
+		{name: "sha512 only", algorithms: "[sha512]"},
+		{name: "sha256 and sha512", algorithms: "[sha256, sha512]"},
+		{name: "empty", algorithms: "[]", wantError: true},
+		{name: "duplicate", algorithms: "[sha256, sha256]", wantError: true},
+		{name: "unknown", algorithms: "[sha384]", wantError: true},
+		{name: "uppercase", algorithms: "[SHA256]", wantError: true},
+		{name: "malformed hyphen", algorithms: "[sha-256]", wantError: true},
+		{name: "malformed punctuation", algorithms: "[sha512!]", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := minimalValidYAML + "\nALLOWED_HASH_ALGORITHMS: " + tt.algorithms + "\n"
+			cfg, err := Parse([]byte(yaml))
+			require.NoError(t, err)
+
+			errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+			assert.Equal(t, tt.wantError, hasFieldError(errs, "ALLOWED_HASH_ALGORITHMS"), "validation errors: %v", errs)
+		})
+	}
+}
+
 func TestValidateInvalidSecurityEndpoint(t *testing.T) {
 	yaml := minimalValidYAML + `
 SECURITY_SCANNER_V4_ENDPOINT: not-a-url

--- a/oauth/login_utils.py
+++ b/oauth/login_utils.py
@@ -207,7 +207,7 @@ def _conduct_oauth_login(
                 service_name=service_name, error_message="Configuration error in this provider"
             )
 
-        (user_obj, err) = auth_system.link_user(lookup_value)
+        user_obj, err = auth_system.link_user(lookup_value)
         if err is not None:
             logger.debug("%s %s not found: %s", bound_field_name, lookup_value, err)
             msg = "%s %s not found in backing auth system" % (bound_field_name, lookup_value)

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1023,6 +1023,14 @@ CONFIG_SCHEMA = {
             "description": "If set to true, Quay will run using FIPS compliant hash functions. Defaults to False",
             "x-example": True,
         },
+        "ALLOWED_HASH_ALGORITHMS": {
+            "type": "array",
+            "description": "Exact allowlist of digest algorithms accepted for new client-visible blob and manifest digest writes. Defaults to sha256 when omitted. Internal storage and deduplication always use canonical SHA-256.",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {"type": "string", "enum": ["sha256", "sha512"]},
+            "x-example": ["sha256", "sha512"],
+        },
         # Feature Flag: Anonymous Users.
         "FEATURE_ANONYMOUS_ACCESS": {
             "type": "boolean",

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -3,6 +3,7 @@ from jsonschema import ValidationError, validate
 
 from auth.scopes import validate_scope_string
 from config import DefaultConfig
+from util.config.provider.baseprovider import import_yaml
 from util.config.schema import CONFIG_SCHEMA, INTERNAL_ONLY_PROPERTIES
 
 
@@ -10,6 +11,98 @@ def test_ensure_schema_defines_all_fields():
     for key in (key for key in vars(DefaultConfig) if key.isupper()):
         has_key = key in CONFIG_SCHEMA["properties"] or key in INTERNAL_ONLY_PROPERTIES
         assert has_key, "Property `%s` is missing from config schema" % key
+
+
+def test_allowed_hash_algorithms_defaults_to_sha256():
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    assert DefaultConfig.ALLOWED_HASH_ALGORITHMS == ["sha256"]
+    validate(DefaultConfig.ALLOWED_HASH_ALGORITHMS, schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["sha256"],
+        ["sha512"],
+        ["sha256", "sha512"],
+    ],
+)
+def test_allowed_hash_algorithms_accepts_exact_supported_allowlists(value, tmp_path):
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "ALLOWED_HASH_ALGORITHMS:\n" + "".join(f"  - {algorithm}\n" for algorithm in value)
+    )
+    config = {"ALLOWED_HASH_ALGORITHMS": DefaultConfig.ALLOWED_HASH_ALGORITHMS.copy()}
+
+    import_yaml(config, config_path)
+
+    validate(config["ALLOWED_HASH_ALGORITHMS"], schema)
+    assert config["ALLOWED_HASH_ALGORITHMS"] == value
+
+
+def test_allowed_hash_algorithms_rejects_empty_list():
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    with pytest.raises(ValidationError):
+        validate([], schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["sha256", "sha256"],
+        ["sha512", "sha512"],
+    ],
+)
+def test_allowed_hash_algorithms_rejects_duplicates(value):
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    with pytest.raises(ValidationError):
+        validate(value, schema)
+
+
+def test_allowed_hash_algorithms_rejects_unknown_algorithm():
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    with pytest.raises(ValidationError):
+        validate(["sha384"], schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["SHA256"],
+        ["sha-256"],
+        ["sha_512"],
+        ["sha512!"],
+    ],
+)
+def test_allowed_hash_algorithms_rejects_non_lowercase_or_malformed_identifiers(value):
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    with pytest.raises(ValidationError):
+        validate(value, schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "sha256",
+        {"sha256": True},
+        256,
+        True,
+        [256],
+        [None],
+    ],
+)
+def test_allowed_hash_algorithms_rejects_invalid_types(value):
+    schema = CONFIG_SCHEMA["properties"]["ALLOWED_HASH_ALGORITHMS"]
+
+    with pytest.raises(ValidationError):
+        validate(value, schema)
 
 
 def test_bootstrap_token_expiration_must_be_positive():


### PR DESCRIPTION
## Summary

- add `ALLOWED_HASH_ALGORITHMS` with a default of `sha256`
- preserve explicit algorithm lists exactly without adding SHA-256
- accept only non-empty, unique combinations of `sha256` and `sha512`
- add equivalent typed parsing, defaults, and offline validation to the Go configuration path
- document that canonical internal storage and deduplication remain SHA-256

## Validation

- `TEST=true PYTHONPATH=. ../.venv/bin/pytest -q util/config/test/test_schema.py --tb=short` — 68 passed
- `go test ./internal/config -count=1` — passed
- `go vet ./internal/config` — passed
- `../.venv/bin/black --check config.py util/config/schema.py util/config/test/test_schema.py` — passed
- pre-commit hooks for all changed files — passed
- `git diff --check` — passed

## Scope

This change only establishes configuration defaults, schema validation, documentation, and typed Go configuration support. It does not implement blob or manifest endpoint enforcement, upload hashing, digest registration, or database changes.

Jira: https://redhat.atlassian.net/browse/PROJQUAY-12772

