### PR TITLE
[redhat-3.18] PROJQUAY-12739: fix(cve): CVE-2026-67320 - bump axios to 1.19.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,7 @@
         "@tanstack/react-query": "^4.13.5",
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
-        "axios": "^1.16.1",
+        "axios": "^1.19.0",
         "https-proxy-agent": "^5.0.1",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -4678,13 +4678,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^4.13.5",
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
-    "axios": "^1.16.1",
+    "axios": "^1.19.0",
     "https-proxy-agent": "^5.0.1",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",
@@ -124,7 +124,7 @@
     "webpack-merge": "^5.10.0"
   },
   "overrides": {
-    "axios": "^1.16.1",
+    "axios": "^1.19.0",
     "cross-spawn": "^7.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -141,7 +141,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "^1.16.1",
+      "axios": "^1.19.0",
       "cross-spawn": "^7.0.6",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.16.1
+  axios: ^1.19.0
   cross-spawn: ^7.0.6
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -55,8 +55,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.28
       axios:
-        specifier: ^1.16.1
-        version: 1.16.1
+        specifier: ^1.19.0
+        version: 1.19.0
       https-proxy-agent:
         specifier: ^5.0.1
         version: 5.0.1
@@ -159,7 +159,7 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       axios-mock-adapter:
         specifier: ^1.22.0
-        version: 1.22.0(axios@1.16.1)
+        version: 1.22.0(axios@1.19.0)
       copy-webpack-plugin:
         specifier: ^10.2.4
         version: 10.2.4(webpack@5.106.2)
@@ -2131,8 +2131,8 @@ packages:
     peerDependencies:
       axios: ^1.16.1
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7268,7 +7268,7 @@ snapshots:
       '@redhat-cloud-services/types': 2.0.3
       '@sentry/browser': 7.120.4
       awesome-debounce-promise: 2.1.0
-      axios: 1.16.1
+      axios: 1.19.0
       commander: 2.20.3
       mkdirp: 1.0.4
       p-map: 7.0.4
@@ -7308,7 +7308,7 @@ snapshots:
 
   '@redhat-cloud-services/javascript-clients-shared@1.2.7':
     dependencies:
-      axios: 1.16.1
+      axios: 1.19.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
@@ -7317,7 +7317,7 @@ snapshots:
   '@redhat-cloud-services/rbac-client@2.2.11':
     dependencies:
       '@redhat-cloud-services/javascript-clients-shared': 1.2.7
-      axios: 1.16.1
+      axios: 1.19.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
@@ -8176,13 +8176,13 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios-mock-adapter@1.22.0(axios@1.16.1):
+  axios-mock-adapter@1.22.0(axios@1.19.0):
     dependencies:
-      axios: 1.16.1
+      axios: 1.19.0
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
-  axios@1.16.1:
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6


### PR DESCRIPTION
## Summary

Bump axios from 1.16.1 to 1.19.0 (>=1.18.0) to address 4 security vulnerabilities.

## CVEs Fixed

- **CVE-2026-67320** (HIGH 8.3): Attacker-controlled proxy routing via prototype pollution in Node HTTP adapter
- **CVE-2026-67314** (MEDIUM 6.3): Prototype pollution read-side gadgets in Basic auth subfield handling
- **CVE-2026-67313** (MEDIUM 6.3): Uncontrolled recursion in formDataToJSON causing DoS
- **CVE-2026-67321** (MEDIUM 6.9): Incomplete depth-limit bypass in toFormData.js causing DoS

## Changes

- `web/package.json`: Updated axios specifier from `^1.16.1` to `^1.19.0`
- `web/package-lock.json`: Updated axios version, resolved URL, integrity hash, and form-data dependency specifier (^4.0.5 -> ^4.0.6)
- `web/pnpm-lock.yaml`: Updated overrides, importers, packages, and snapshots sections

## Approach

Hand-crafted minimal lockfile edits (no `npm install` or `pnpm install` to avoid unrelated transitive dependency drift). Only the axios entry and its direct dependency specifiers were updated.

## Reference

- Master PR: https://github.com/quay/quay/pull/6859
- Advisory: https://github.com/axios/axios/security/advisories/GHSA-gcfj-64vw-6mp9

## Jira Tracker

- [PROJQUAY-12739](https://redhat.atlassian.net/browse/PROJQUAY-12739)

Made with [Cursor](https://cursor.com)