### PR TITLE
[redhat-3.15] PROJQUAY-12736: fix(cve): CVE-2026-67320 - bump axios to 1.19.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^29.5.3",
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
-        "axios": "^1.16.1",
+        "axios": "^1.19.0",
         "buffer": "^4.9.2",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -6237,13 +6237,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "proxy-from-env": "^2.1.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
-    "axios": "^1.16.1",
+    "axios": "^1.19.0",
     "buffer": "^4.9.2",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",


### PR DESCRIPTION
## Summary

Bump axios from 1.16.1 to 1.19.0 (>=1.18.0) to address 4 security vulnerabilities.

## CVEs Fixed

- **CVE-2026-67320** (HIGH 8.3): Attacker-controlled proxy routing via prototype pollution in Node HTTP adapter
- **CVE-2026-67314** (MEDIUM 6.3): Prototype pollution read-side gadgets in Basic auth subfield handling
- **CVE-2026-67313** (MEDIUM 6.3): Uncontrolled recursion in formDataToJSON causing DoS
- **CVE-2026-67321** (MEDIUM 6.9): Incomplete depth-limit bypass in toFormData.js causing DoS

## Changes

- `web/package.json`: Updated axios specifier from `^1.16.1` to `^1.19.0`
- `web/package-lock.json`: Updated axios version, resolved URL, integrity hash, and form-data dependency specifier (^4.0.5 -> ^4.0.6)

## Approach

Hand-crafted minimal lockfile edits (no `npm install` or `pnpm install` to avoid unrelated transitive dependency drift). Only the axios entry and its direct dependency specifiers were updated. Note: `https-proxy-agent` was intentionally omitted from the axios lockfile dependencies on this branch as it does not exist in the 3.15 lockfile tree.

## Reference

- Master PR: https://github.com/quay/quay/pull/6859
- Advisory: https://github.com/axios/axios/security/advisories/GHSA-gcfj-64vw-6mp9

## Jira Tracker

- [PROJQUAY-12736](https://redhat.atlassian.net/browse/PROJQUAY-12736)

Made with [Cursor](https://cursor.com)