### PR TITLE
[redhat-3.15] PROJQUAY-12571: deps: Bump nanoid to 3.3.12

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17195,15 +17195,16 @@
       "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -130,6 +130,7 @@
     "decode-uri-component": "^0.5.0",
     "svgo": "4.0.1",
     "brace-expansion": "^1.1.18",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "nanoid": "^3.3.12"
   }
 }


### PR DESCRIPTION
## Summary

Bump nanoid from 3.3.8 to 3.3.12 to address CVE-2026-73086.

## CVE Fixed

- **CVE-2026-73086** (HIGH 7.4): Integer overflow in nanoid(size) corrupts
  process-wide CSPRNG state, causing all subsequent IDs to become the
  deterministic string "uuuuuuuuuuuuuuuuuuuuu" until process restart.
  Affects session tokens, CSRF tokens, API keys, and unique identifiers.

## Changes

- `web/package.json`: Added `"nanoid": "^3.3.12"` override to force
  resolution of the transitive dependency (pulled in by postcss)
- `web/package-lock.json`: Updated nanoid version, resolved URL, and
  integrity hash

## Approach

Hand-crafted minimal lockfile edits (no `npm install` to avoid unrelated
transitive dependency drift). Only the nanoid entry was updated. The override
ensures that regardless of postcss's declared semver range, nanoid resolves
to >= 3.3.12.

## Reference

- Advisory: https://github.com/ai/nanoid/security/advisories/GHSA-xwg4-73v4-xw9w
- Fix commit: https://github.com/ai/nanoid/commit/821dfed7b5db7f88e92f56c60eef32c8135077c3

## Jira Tracker

- [PROJQUAY-12571](https://redhat.atlassian.net/browse/PROJQUAY-12571)

Made with [Cursor](https://cursor.com)