### PR TITLE
[redhat-3.14] PROJQUAY-12567: deps: Bump nanoid to 3.3.12

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -133,6 +133,7 @@
     "svgo": "4.0.1",
     "fast-uri": "3.1.3",
     "brace-expansion": "^1.1.18",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "nanoid": "^3.3.12"
   }
 }


### PR DESCRIPTION
## Summary

Bump nanoid from 3.3.11 to 3.3.12 to address CVE-2026-73086.

## CVE Fixed

- **CVE-2026-73086** (HIGH 7.4): Integer overflow in nanoid(size) corrupts
  process-wide CSPRNG state, causing all subsequent IDs to become the
  deterministic string "uuuuuuuuuuuuuuuuuuuuu" until process restart.
  Affects session tokens, CSRF tokens, API keys, and unique identifiers.

## Changes

- `web/package.json`: Added `"nanoid": "^3.3.12"` override to force
  resolution of the transitive dependency (pulled in by postcss)
- `web/package-lock.json`: Updated nanoid version, resolved URL, and
  integrity hash

## Approach

Hand-crafted minimal lockfile edits (no `npm install` to avoid unrelated
transitive dependency drift). Only the nanoid entry was updated. The override
ensures that regardless of postcss's declared semver range, nanoid resolves
to >= 3.3.12.

## Reference

- Advisory: https://github.com/ai/nanoid/security/advisories/GHSA-xwg4-73v4-xw9w
- Fix commit: https://github.com/ai/nanoid/commit/821dfed7b5db7f88e92f56c60eef32c8135077c3

## Jira Tracker

- [PROJQUAY-12567](https://redhat.atlassian.net/browse/PROJQUAY-12567)

Made with [Cursor](https://cursor.com)