### PR TITLE
PROJQUAY-12711: fix(mirrorregistry): avoid tag expiration timestamp collisions

### DIFF
--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -258,6 +258,9 @@ var knownUnmapped = map[string]bool{
 	"SPAM_DETECTION_FAIL_OPEN":                       true,
 	"SESSION_TIMEOUT":                                true,
 	"WEBHOOK_NOTIFICATION_CONFIG":                    true,
+
+	"GUNICORN_REGISTRY_TIMEOUT": true,
+	"GUNICORN_WEB_TIMEOUT":      true,
 }
 
 // goOnlyFields lists Go struct fields that intentionally have no corresponding

--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -76,13 +76,8 @@ func (q *Queries) GetActiveTagLifetimeStart(ctx context.Context, arg GetActiveTa
 const getTagsByRepository = `-- name: GetTagsByRepository :many
 SELECT id, name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id
 FROM tag
-WHERE repository_id = ? AND (lifetime_end_ms IS NULL OR lifetime_end_ms > ?) AND hidden = 0
+WHERE repository_id = ? AND lifetime_end_ms IS NULL AND hidden = 0
 `
-
-type GetTagsByRepositoryParams struct {
-	RepositoryID  int64         `json:"repository_id"`
-	LifetimeEndMs sql.NullInt64 `json:"lifetime_end_ms"`
-}
 
 type GetTagsByRepositoryRow struct {
 	ID              int64         `json:"id"`
@@ -94,8 +89,8 @@ type GetTagsByRepositoryRow struct {
 	TagKindID       int64         `json:"tag_kind_id"`
 }
 
-func (q *Queries) GetTagsByRepository(ctx context.Context, arg GetTagsByRepositoryParams) ([]GetTagsByRepositoryRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTagsByRepository, arg.RepositoryID, arg.LifetimeEndMs)
+func (q *Queries) GetTagsByRepository(ctx context.Context, repositoryID int64) ([]GetTagsByRepositoryRow, error) {
+	rows, err := q.db.QueryContext(ctx, getTagsByRepository, repositoryID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -53,6 +53,26 @@ func (q *Queries) GetActiveTagDigest(ctx context.Context, arg GetActiveTagDigest
 	return digest, err
 }
 
+const getActiveTagLifetimeStart = `-- name: GetActiveTagLifetimeStart :one
+SELECT lifetime_start_ms
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY lifetime_start_ms DESC
+LIMIT 1
+`
+
+type GetActiveTagLifetimeStartParams struct {
+	RepositoryID int64  `json:"repository_id"`
+	Name         string `json:"name"`
+}
+
+func (q *Queries) GetActiveTagLifetimeStart(ctx context.Context, arg GetActiveTagLifetimeStartParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getActiveTagLifetimeStart, arg.RepositoryID, arg.Name)
+	var lifetime_start_ms int64
+	err := row.Scan(&lifetime_start_ms)
+	return lifetime_start_ms, err
+}
+
 const getTagsByRepository = `-- name: GetTagsByRepository :many
 SELECT id, name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id
 FROM tag
@@ -146,6 +166,27 @@ func (q *Queries) InsertHiddenTag(ctx context.Context, arg InsertHiddenTagParams
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const tagLifetimeEndExists = `-- name: TagLifetimeEndExists :one
+SELECT EXISTS(
+    SELECT 1
+    FROM tag
+    WHERE repository_id = ? AND name = ? AND lifetime_end_ms = ?
+)
+`
+
+type TagLifetimeEndExistsParams struct {
+	RepositoryID  int64         `json:"repository_id"`
+	Name          string        `json:"name"`
+	LifetimeEndMs sql.NullInt64 `json:"lifetime_end_ms"`
+}
+
+func (q *Queries) TagLifetimeEndExists(ctx context.Context, arg TagLifetimeEndExistsParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, tagLifetimeEndExists, arg.RepositoryID, arg.Name, arg.LifetimeEndMs)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const upsertTag = `-- name: UpsertTag :one

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -430,9 +431,9 @@ func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, mani
 }
 
 // expireActiveTag chooses an unused transition millisecond no earlier than the
-// active tag's lifetime start. It begins with requestedEnd, then re-samples the
-// wall clock after a collision so forward progress and clock rollback are both
-// handled without one rollback-sized wait.
+// active tag's lifetime start. After a collision it follows the wall clock when
+// possible, or advances logically when rollback leaves the clock behind the
+// active generation.
 // q must be transaction-bound so the reads and update cannot interleave with
 // another tag mutation.
 func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag string, requestedEnd int64) (int64, error) {
@@ -469,9 +470,16 @@ func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag st
 		}
 
 		for {
-			next := max(time.Now().UnixMilli(), activeStart)
-			if next != candidate {
-				candidate = next
+			now := time.Now().UnixMilli()
+			if now < activeStart {
+				if candidate == math.MaxInt64 {
+					return 0, fmt.Errorf("no lifetime end available after %d", candidate)
+				}
+				candidate++
+				break
+			}
+			if now != candidate {
+				candidate = now
 				break
 			}
 

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -431,9 +431,8 @@ func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, mani
 }
 
 // expireActiveTag chooses an unused transition millisecond no earlier than the
-// active tag's lifetime start. After a collision it follows the wall clock when
-// possible, or advances logically when rollback leaves the clock behind the
-// active generation.
+// active tag's lifetime start. After the first collision it re-samples wall
+// time once, then advances logically while probing each candidate.
 // q must be transaction-bound so the reads and update cannot interleave with
 // another tag mutation.
 func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag string, requestedEnd int64) (int64, error) {
@@ -449,13 +448,7 @@ func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag st
 	}
 
 	candidate := max(requestedEnd, activeStart)
-	var poller *time.Ticker
-	defer func() {
-		if poller != nil {
-			poller.Stop()
-		}
-	}()
-
+	resampledWallClock := false
 	for {
 		exists, err := q.TagLifetimeEndExists(ctx, daldb.TagLifetimeEndExistsParams{
 			RepositoryID:  repoID,
@@ -469,29 +462,18 @@ func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag st
 			break
 		}
 
-		for {
-			now := time.Now().UnixMilli()
-			if now < activeStart {
-				if candidate == math.MaxInt64 {
-					return 0, fmt.Errorf("no lifetime end available after %d", candidate)
-				}
-				candidate++
-				break
-			}
-			if now != candidate {
-				candidate = now
-				break
-			}
-
-			if poller == nil {
-				poller = time.NewTicker(5 * time.Millisecond)
-			}
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-poller.C:
+		if !resampledWallClock {
+			resampledWallClock = true
+			next := max(time.Now().UnixMilli(), activeStart)
+			if next != candidate {
+				candidate = next
+				continue
 			}
 		}
+		if candidate == math.MaxInt64 {
+			return 0, fmt.Errorf("no lifetime end available after %d", candidate)
+		}
+		candidate++
 	}
 
 	_, err = q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
@@ -619,11 +601,7 @@ func (s *SQLiteStore) BlobExists(ctx context.Context, dgst digest.Digest) (bool,
 // ListTags returns all active tags for a repository.
 func (s *SQLiteStore) ListTags(ctx context.Context, repoID int64) ([]string, error) {
 	q := daldb.New(s.db)
-	now := time.Now().UnixMilli()
-	rows, err := q.GetTagsByRepository(ctx, daldb.GetTagsByRepositoryParams{
-		RepositoryID:  repoID,
-		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},
-	})
+	rows, err := q.GetTagsByRepository(ctx, repoID)
 	if err != nil {
 		return nil, fmt.Errorf("list tags: %w", err)
 	}

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -411,13 +411,8 @@ func (s *SQLiteStore) PutTag(ctx context.Context, repoID int64, t oci.TagRecord)
 // This avoids the NULL != NULL issue on the
 // (repository_id, name, lifetime_end_ms) unique index.
 func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, manifestID int64, tag string) (int64, error) {
-	now := time.Now().UnixMilli()
-
-	if _, err := q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
-		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},
-		RepositoryID:  repoID,
-		Name:          tag,
-	}); err != nil {
+	transitionMs, err := expireActiveTag(ctx, q, repoID, tag, time.Now().UnixMilli())
+	if err != nil {
 		return 0, fmt.Errorf("expire tag %q: %w", tag, err)
 	}
 
@@ -425,7 +420,7 @@ func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, mani
 		Name:            tag,
 		RepositoryID:    repoID,
 		ManifestID:      sql.NullInt64{Int64: manifestID, Valid: true},
-		LifetimeStartMs: now,
+		LifetimeStartMs: transitionMs,
 		TagKindID:       s.tagKindTag,
 	})
 	if err != nil {
@@ -434,18 +429,87 @@ func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, mani
 	return id, nil
 }
 
-// DeleteTag expires the active tag by setting lifetime_end_ms.
-func (s *SQLiteStore) DeleteTag(ctx context.Context, repoID int64, tag string) error {
-	q := daldb.New(s.db)
-	now := time.Now().UnixMilli()
+// expireActiveTag chooses an unused transition millisecond no earlier than the
+// active tag's lifetime start. It begins with requestedEnd, then re-samples the
+// wall clock after a collision so forward progress and clock rollback are both
+// handled without one rollback-sized wait.
+// q must be transaction-bound so the reads and update cannot interleave with
+// another tag mutation.
+func expireActiveTag(ctx context.Context, q *daldb.Queries, repoID int64, tag string, requestedEnd int64) (int64, error) {
+	activeStart, err := q.GetActiveTagLifetimeStart(ctx, daldb.GetActiveTagLifetimeStartParams{
+		RepositoryID: repoID,
+		Name:         tag,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return requestedEnd, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get active tag lifetime start: %w", err)
+	}
 
-	_, err := q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
-		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},
+	candidate := max(requestedEnd, activeStart)
+	var poller *time.Ticker
+	defer func() {
+		if poller != nil {
+			poller.Stop()
+		}
+	}()
+
+	for {
+		exists, err := q.TagLifetimeEndExists(ctx, daldb.TagLifetimeEndExistsParams{
+			RepositoryID:  repoID,
+			Name:          tag,
+			LifetimeEndMs: sql.NullInt64{Int64: candidate, Valid: true},
+		})
+		if err != nil {
+			return 0, fmt.Errorf("check lifetime end %d: %w", candidate, err)
+		}
+		if exists == 0 {
+			break
+		}
+
+		for {
+			next := max(time.Now().UnixMilli(), activeStart)
+			if next != candidate {
+				candidate = next
+				break
+			}
+
+			if poller == nil {
+				poller = time.NewTicker(5 * time.Millisecond)
+			}
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-poller.C:
+			}
+		}
+	}
+
+	_, err = q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
+		LifetimeEndMs: sql.NullInt64{Int64: candidate, Valid: true},
 		RepositoryID:  repoID,
 		Name:          tag,
 	})
 	if err != nil {
+		return 0, err
+	}
+	return candidate, nil
+}
+
+// DeleteTag expires the active tag by setting lifetime_end_ms.
+func (s *SQLiteStore) DeleteTag(ctx context.Context, repoID int64, tag string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	if _, err := expireActiveTag(ctx, daldb.New(tx), repoID, tag, time.Now().UnixMilli()); err != nil {
 		return fmt.Errorf("expire tag %q: %w", tag, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
 }

--- a/internal/dal/metastore/metastore_sqlite_internal_test.go
+++ b/internal/dal/metastore/metastore_sqlite_internal_test.go
@@ -2,6 +2,7 @@ package metastore
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -36,6 +37,73 @@ func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	seedOccupiedActiveStart := func(t *testing.T, tag string) (int64, int64) {
+		t.Helper()
+		futureStart := time.Now().Add(time.Hour).UnixMilli()
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			tag, repoID, manifestID, futureStart-1, futureStart, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, NULL, ?)`,
+			tag, repoID, manifestID, futureStart, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		activeTagID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return futureStart, activeTagID
+	}
+
+	assertCurrentTag := func(t *testing.T, tag string, expectedDigest digest.Digest, expiredTagID, previousStart int64) {
+		t.Helper()
+		gotDigest, err := store.GetTagDigest(ctx, repoID, tag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotDigest != expectedDigest {
+			t.Fatalf("tag digest = %s, want %s", gotDigest, expectedDigest)
+		}
+
+		tags, err := store.ListTags(ctx, repoID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var matches int
+		for _, listedTag := range tags {
+			if listedTag == tag {
+				matches++
+			}
+		}
+		if matches != 1 {
+			t.Fatalf("ListTags returned %d entries for %q, want 1: %v", matches, tag, tags)
+		}
+
+		var expiredEnd, activeStart int64
+		if err := db.QueryRowContext(ctx, `SELECT lifetime_end_ms FROM tag WHERE id = ?`, expiredTagID).Scan(&expiredEnd); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRowContext(ctx, `
+			SELECT lifetime_start_ms
+			FROM tag
+			WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL`,
+			repoID, tag).Scan(&activeStart); err != nil {
+			t.Fatal(err)
+		}
+		if expiredEnd != activeStart {
+			t.Fatalf("expired lifetime_end_ms = %d, replacement lifetime_start_ms = %d", expiredEnd, activeStart)
+		}
+		if expiredEnd <= previousStart {
+			t.Fatalf("transition = %d, want value after occupied active start %d", expiredEnd, previousStart)
+		}
 	}
 
 	const tag = "v1"
@@ -81,9 +149,6 @@ func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
 	}
 	if gotEnd <= requestedEnd {
 		t.Fatalf("lifetime_end_ms = %d, want value after occupied millisecond %d", gotEnd, requestedEnd)
-	}
-	if now := time.Now().UnixMilli(); gotEnd > now {
-		t.Fatalf("lifetime_end_ms = %d, ahead of wall clock %d", gotEnd, now)
 	}
 
 	var total, distinct int
@@ -193,27 +258,43 @@ func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("PutTag replaces a rollback generation consistently", func(t *testing.T) {
+		const rollbackTag = "put-tag-after-rollback"
+		newDigest := digest.FromString("manifest-put-tag")
+		if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+			Digest:    newDigest,
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Content:   []byte(`{"schemaVersion":2}`),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		futureStart, activeTagID := seedOccupiedActiveStart(t, rollbackTag)
+
+		if _, err := store.PutTag(ctx, repoID, oci.TagRecord{Name: rollbackTag, Digest: newDigest}); err != nil {
+			t.Fatal(err)
+		}
+		assertCurrentTag(t, rollbackTag, newDigest, activeTagID, futureStart)
+	})
+
+	t.Run("PutManifest replaces a rollback generation consistently", func(t *testing.T) {
+		const rollbackTag = "put-manifest-after-rollback"
+		newDigest := digest.FromString("manifest-put-manifest")
+		futureStart, activeTagID := seedOccupiedActiveStart(t, rollbackTag)
+
+		if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+			Digest:    newDigest,
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Content:   []byte(`{"schemaVersion":2}`),
+			Tag:       rollbackTag,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		assertCurrentTag(t, rollbackTag, newDigest, activeTagID, futureStart)
+	})
+
 	t.Run("deletes when clock rollback leaves active start occupied", func(t *testing.T) {
 		const rollbackTag = "occupied-active-start"
-		futureStart := time.Now().Add(time.Hour).UnixMilli()
-		_, err := db.ExecContext(ctx, `
-			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
-			VALUES (?, ?, ?, ?, ?, ?)`,
-			rollbackTag, repoID, manifestID, futureStart-1, futureStart, store.tagKindTag)
-		if err != nil {
-			t.Fatal(err)
-		}
-		result, err := db.ExecContext(ctx, `
-			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
-			VALUES (?, ?, ?, ?, NULL, ?)`,
-			rollbackTag, repoID, manifestID, futureStart, store.tagKindTag)
-		if err != nil {
-			t.Fatal(err)
-		}
-		activeTagID, err := result.LastInsertId()
-		if err != nil {
-			t.Fatal(err)
-		}
+		futureStart, activeTagID := seedOccupiedActiveStart(t, rollbackTag)
 
 		deleteCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -241,6 +322,19 @@ func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
 		}
 		if gotEnd <= futureStart {
 			t.Fatalf("lifetime_end_ms = %d, want value after occupied active start %d", gotEnd, futureStart)
+		}
+
+		if _, err := store.GetTagDigest(ctx, repoID, rollbackTag); !errors.Is(err, oci.ErrNotExist) {
+			t.Fatalf("GetTagDigest error = %v, want %v", err, oci.ErrNotExist)
+		}
+		tags, err := store.ListTags(ctx, repoID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, listedTag := range tags {
+			if listedTag == rollbackTag {
+				t.Fatalf("ListTags returned deleted tag %q: %v", rollbackTag, tags)
+			}
 		}
 
 		var total, distinct int

--- a/internal/dal/metastore/metastore_sqlite_internal_test.go
+++ b/internal/dal/metastore/metastore_sqlite_internal_test.go
@@ -1,0 +1,222 @@
+package metastore
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/quay/quay/internal/dal/daldb"
+	"github.com/quay/quay/internal/dal/dbcore"
+	"github.com/quay/quay/internal/oci"
+)
+
+func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
+	ctx := t.Context()
+	db, err := dbcore.Setup(ctx, filepath.Join(t.TempDir(), "quay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := NewSQLiteStore(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestID, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    digest.FromString("manifest-v1"),
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"schemaVersion":2}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const tag = "v1"
+	requestedEnd := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		tag, repoID, manifestID, requestedEnd-1, requestedEnd, store.tagKindTag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+		VALUES (?, ?, ?, ?, NULL, ?)`,
+		tag, repoID, manifestID, requestedEnd, store.tagKindTag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeTagID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+	transitionMs, err := expireActiveTag(ctx, daldb.New(tx), repoID, tag, requestedEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotEnd int64
+	if err := db.QueryRowContext(ctx, `SELECT lifetime_end_ms FROM tag WHERE id = ?`, activeTagID).Scan(&gotEnd); err != nil {
+		t.Fatal(err)
+	}
+	if gotEnd != transitionMs {
+		t.Fatalf("lifetime_end_ms = %d, returned transition = %d", gotEnd, transitionMs)
+	}
+	if gotEnd <= requestedEnd {
+		t.Fatalf("lifetime_end_ms = %d, want value after occupied millisecond %d", gotEnd, requestedEnd)
+	}
+	if now := time.Now().UnixMilli(); gotEnd > now {
+		t.Fatalf("lifetime_end_ms = %d, ahead of wall clock %d", gotEnd, now)
+	}
+
+	var total, distinct int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COUNT(DISTINCT lifetime_end_ms)
+		FROM tag
+		WHERE repository_id = ? AND name = ?`, repoID, tag).Scan(&total, &distinct); err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || distinct != total {
+		t.Fatalf("tag history rows = %d, distinct lifetime ends = %d", total, distinct)
+	}
+
+	t.Run("never expires before active lifetime start after clock rollback", func(t *testing.T) {
+		const rollbackTag = "active-start-after-clock"
+		futureStart := time.Now().Add(time.Hour).UnixMilli()
+		result, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, NULL, ?)`,
+			rollbackTag, repoID, manifestID, futureStart, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tagID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rollbackTx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rollbackTx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+		transitionMs, err := expireActiveTag(
+			ctx,
+			daldb.New(rollbackTx),
+			repoID,
+			rollbackTag,
+			time.Now().UnixMilli(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := rollbackTx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		var gotEnd int64
+		if err := db.QueryRowContext(ctx, `SELECT lifetime_end_ms FROM tag WHERE id = ?`, tagID).Scan(&gotEnd); err != nil {
+			t.Fatal(err)
+		}
+		if transitionMs != futureStart || gotEnd != futureStart {
+			t.Fatalf("transition = %d, lifetime_end_ms = %d, want active lifetime_start_ms %d", transitionMs, gotEnd, futureStart)
+		}
+	})
+
+	t.Run("reselects a stale candidate after clock rollback", func(t *testing.T) {
+		const rollbackTag = "stale-candidate-after-clock"
+		activeStart := time.Now().UnixMilli() - 1
+		staleCandidate := time.Now().Add(time.Hour).UnixMilli()
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			rollbackTag, repoID, manifestID, activeStart-1, staleCandidate, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, NULL, ?)`,
+			rollbackTag, repoID, manifestID, activeStart, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tagID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rollbackTx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rollbackTx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+		waitCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		transitionMs, err := expireActiveTag(waitCtx, daldb.New(rollbackTx), repoID, rollbackTag, staleCandidate)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := rollbackTx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		var gotEnd int64
+		if err := db.QueryRowContext(ctx, `SELECT lifetime_end_ms FROM tag WHERE id = ?`, tagID).Scan(&gotEnd); err != nil {
+			t.Fatal(err)
+		}
+		if transitionMs != gotEnd {
+			t.Fatalf("transition = %d, lifetime_end_ms = %d", transitionMs, gotEnd)
+		}
+		if transitionMs < activeStart {
+			t.Fatalf("transition = %d, before active lifetime_start_ms %d", transitionMs, activeStart)
+		}
+		if transitionMs >= staleCandidate {
+			t.Fatalf("transition = %d, want reselected value before stale candidate %d", transitionMs, staleCandidate)
+		}
+	})
+
+	t.Run("stops on cancellation after clock rollback", func(t *testing.T) {
+		const rollbackTag = "clock-rollback"
+		futureEnd := time.Now().Add(time.Hour).UnixMilli()
+		for _, lifetimeEnd := range []any{futureEnd, nil} {
+			_, err := db.ExecContext(ctx, `
+				INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+				rollbackTag, repoID, manifestID, futureEnd, lifetimeEnd, store.tagKindTag)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		waitTx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		_, err = expireActiveTag(waitCtx, daldb.New(waitTx), repoID, rollbackTag, futureEnd)
+		_ = waitTx.Rollback()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expireActiveTag error = %v, want context deadline exceeded", err)
+		}
+	})
+}

--- a/internal/dal/metastore/metastore_sqlite_internal_test.go
+++ b/internal/dal/metastore/metastore_sqlite_internal_test.go
@@ -2,7 +2,6 @@ package metastore
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -194,29 +193,65 @@ func TestExpireActiveTagWaitsForUnusedLifetimeEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("stops on cancellation after clock rollback", func(t *testing.T) {
-		const rollbackTag = "clock-rollback"
-		futureEnd := time.Now().Add(time.Hour).UnixMilli()
-		for _, lifetimeEnd := range []any{futureEnd, nil} {
-			_, err := db.ExecContext(ctx, `
-				INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
-				VALUES (?, ?, ?, ?, ?, ?)`,
-				rollbackTag, repoID, manifestID, futureEnd, lifetimeEnd, store.tagKindTag)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		waitTx, err := db.BeginTx(ctx, nil)
+	t.Run("deletes when clock rollback leaves active start occupied", func(t *testing.T) {
+		const rollbackTag = "occupied-active-start"
+		futureStart := time.Now().Add(time.Hour).UnixMilli()
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			rollbackTag, repoID, manifestID, futureStart-1, futureStart, store.tagKindTag)
 		if err != nil {
 			t.Fatal(err)
 		}
-		waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		result, err := db.ExecContext(ctx, `
+			INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id)
+			VALUES (?, ?, ?, ?, NULL, ?)`,
+			rollbackTag, repoID, manifestID, futureStart, store.tagKindTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		activeTagID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		deleteCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		_, err = expireActiveTag(waitCtx, daldb.New(waitTx), repoID, rollbackTag, futureEnd)
-		_ = waitTx.Rollback()
-		if !errors.Is(err, context.DeadlineExceeded) {
-			t.Fatalf("expireActiveTag error = %v, want context deadline exceeded", err)
+		if _, hasDeadline := deleteCtx.Deadline(); hasDeadline {
+			t.Fatal("DeleteTag context unexpectedly has a deadline")
+		}
+		done := make(chan error, 1)
+		go func() {
+			done <- store.DeleteTag(deleteCtx, repoID, rollbackTag)
+		}()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(time.Second):
+			cancel()
+			err := <-done
+			t.Fatalf("DeleteTag waited for the rolled-back clock; after cancellation it returned %v", err)
+		}
+
+		var gotEnd int64
+		if err := db.QueryRowContext(ctx, `SELECT lifetime_end_ms FROM tag WHERE id = ?`, activeTagID).Scan(&gotEnd); err != nil {
+			t.Fatal(err)
+		}
+		if gotEnd <= futureStart {
+			t.Fatalf("lifetime_end_ms = %d, want value after occupied active start %d", gotEnd, futureStart)
+		}
+
+		var total, distinct int
+		if err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*), COUNT(DISTINCT lifetime_end_ms)
+			FROM tag
+			WHERE repository_id = ? AND name = ?`, repoID, rollbackTag).Scan(&total, &distinct); err != nil {
+			t.Fatal(err)
+		}
+		if total != 2 || distinct != total {
+			t.Fatalf("tag history rows = %d, distinct lifetime ends = %d", total, distinct)
 		}
 	})
 }

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -13,6 +13,20 @@ RETURNING id;
 UPDATE tag SET lifetime_end_ms = ?
 WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL;
 
+-- name: GetActiveTagLifetimeStart :one
+SELECT lifetime_start_ms
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY lifetime_start_ms DESC
+LIMIT 1;
+
+-- name: TagLifetimeEndExists :one
+SELECT EXISTS(
+    SELECT 1
+    FROM tag
+    WHERE repository_id = ? AND name = ? AND lifetime_end_ms = ?
+);
+
 -- name: DeleteTagsByManifest :exec
 DELETE FROM tag WHERE manifest_id = ?;
 

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -33,7 +33,7 @@ DELETE FROM tag WHERE manifest_id = ?;
 -- name: GetTagsByRepository :many
 SELECT id, name, repository_id, manifest_id, lifetime_start_ms, lifetime_end_ms, tag_kind_id
 FROM tag
-WHERE repository_id = ? AND (lifetime_end_ms IS NULL OR lifetime_end_ms > ?) AND hidden = 0;
+WHERE repository_id = ? AND lifetime_end_ms IS NULL AND hidden = 0;
 
 -- name: InsertHiddenTag :one
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id, hidden)

--- a/internal/e2e/mirrorregistry/registry_protocol_test.go
+++ b/internal/e2e/mirrorregistry/registry_protocol_test.go
@@ -1,8 +1,10 @@
 package mirrorregistry_test
 
 import (
+	"errors"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -88,6 +90,49 @@ func TestRegistryTagPagination(t *testing.T) {
 	assert.Equal(t, repository, second.Name)
 	assert.Equal(t, []string{"gamma"}, second.Tags)
 	assert.Empty(t, second.Link)
+}
+
+func TestRegistryConcurrentSameTagPushes(t *testing.T) {
+	h := e2etest.New(t)
+	ctx := t.Context()
+	const (
+		repository       = "admin/e2e-concurrent-tag"
+		concurrentPushes = 50
+	)
+	image := pushImage(t, h, repository, "v1", []byte(`{}`), []byte("concurrent tag layer"))
+	token, err := h.Registry().RequestToken(ctx, repository, "pull", "push")
+	require.NoError(t, err)
+
+	start := make(chan struct{})
+	pushErrors := make(chan error, concurrentPushes)
+	var workers sync.WaitGroup
+	workers.Add(concurrentPushes)
+	for range concurrentPushes {
+		go func() {
+			defer workers.Done()
+			<-start
+			_, err := h.Registry().PutManifestWithToken(ctx, repository, "v1", image.manifest, v1.MediaTypeImageManifest, token)
+			pushErrors <- err
+		}()
+	}
+
+	close(start)
+	workers.Wait()
+	close(pushErrors)
+
+	var failures []error
+	for err := range pushErrors {
+		if err != nil {
+			failures = append(failures, err)
+		}
+	}
+	require.NoError(t, errors.Join(failures...))
+
+	lastWriter := pushImage(t, h, repository, "v1", []byte(`{"generation":"last"}`), []byte("last writer layer"))
+	pulled, err := h.Registry().GetManifest(ctx, repository, "v1")
+	require.NoError(t, err)
+	assert.Equal(t, lastWriter.digest, pulled.Digest)
+	assert.Equal(t, lastWriter.manifest, pulled.Body)
 }
 
 func TestRegistryCatalogIsRejected(t *testing.T) {

--- a/internal/e2e/mirrorregistry/registry_protocol_test.go
+++ b/internal/e2e/mirrorregistry/registry_protocol_test.go
@@ -1,9 +1,11 @@
 package mirrorregistry_test
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -103,15 +105,26 @@ func TestRegistryConcurrentSameTagPushes(t *testing.T) {
 	token, err := h.Registry().RequestToken(ctx, repository, "pull", "push")
 	require.NoError(t, err)
 
+	var baseManifest v1.Manifest
+	require.NoError(t, json.Unmarshal(image.manifest, &baseManifest))
+	manifests := make([][]byte, concurrentPushes)
+	for i := range concurrentPushes {
+		manifest := baseManifest
+		manifest.Annotations = map[string]string{"test.generation": strconv.Itoa(i)}
+		manifests[i], err = json.Marshal(manifest)
+		require.NoError(t, err)
+	}
+
 	start := make(chan struct{})
 	pushErrors := make(chan error, concurrentPushes)
 	var workers sync.WaitGroup
 	workers.Add(concurrentPushes)
-	for range concurrentPushes {
+	for i := range concurrentPushes {
+		manifest := manifests[i]
 		go func() {
 			defer workers.Done()
 			<-start
-			_, err := h.Registry().PutManifestWithToken(ctx, repository, "v1", image.manifest, v1.MediaTypeImageManifest, token)
+			_, err := h.Registry().PutManifestWithToken(ctx, repository, "v1", manifest, v1.MediaTypeImageManifest, token)
 			pushErrors <- err
 		}()
 	}


### PR DESCRIPTION
## Summary

- prevent concurrent same-tag manifest pushes from returning HTTP 500 when tag history timestamps collide
- choose a unique transaction-bound transition timestamp and use it for both the previous tag's end and the replacement tag's start
- resolve occupied timestamps without sleeping inside SQLite's sole write transaction
- keep pull and tag listing consistent when clock rollback produces future-relative history timestamps
- apply the same expiration path to tag replacement and deletion

## Testing

- `go test ./internal/dal/metastore -run '^TestExpireActiveTagWaitsForUnusedLifetimeEnd$' -count=10` — passed
- `go test ./internal/dal/metastore -count=1` — passed
- `go test ./internal/e2e/mirrorregistry -run '^TestRegistryConcurrentSameTagPushes$' -count=10` — passed
- `go test ./...` — passed (30 packages; 4 packages had no tests)
- `go test -race ./internal/dal/metastore -count=1` — passed
- `go test -race ./internal/e2e/mirrorregistry/...` — passed
- `go vet ./...` — passed
- `golangci-lint run --timeout=5m` — passed with 0 issues
- `sqlc generate` — passed
