### PR TITLE
PROJQUAY-12485: feat(auth): add workload identity config schema

### DIFF
--- a/config.py
+++ b/config.py
@@ -905,6 +905,12 @@ class DefaultConfig(ImmutableConfig):
 
     # Feature Flag: Controls programmatic bootstrap token provisioning.
     FEATURE_PROGRAMMATIC_BOOTSTRAP = False
+
+    # Feature Flag: Controls Kubernetes ServiceAccount workload identity bootstrap.
+    FEATURE_KUBERNETES_SA_BOOTSTRAP = False
+    KUBERNETES_SA_BOOTSTRAP_CONFIG: Optional[Dict[str, Any]] = None
+
+    # Shared owner for bootstrap OAuth applications and tokens.
     BOOTSTRAP_TOKEN_OWNER: Optional[str] = None
     BOOTSTRAP_TOKEN_PATH = "/var/lib/quay/quay-machine-token.json"
     PROGRAMMATIC_TOKEN_K8S_SECRET: Optional[str] = None

--- a/features/__init__.pyi
+++ b/features/__init__.pyi
@@ -239,3 +239,6 @@ OTEL_TRACING: FeatureNameValue
 
 # Feature Flag: If set to true, enables programmatic bootstrap token provisioning.
 PROGRAMMATIC_BOOTSTRAP: FeatureNameValue
+
+# Feature Flag: If set to true, enables Kubernetes ServiceAccount workload identity bootstrap.
+KUBERNETES_SA_BOOTSTRAP: FeatureNameValue

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -135,6 +135,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_PARTIAL_USER_AUTOCOMPLETE":             true,
 	"FEATURE_PERMANENT_SESSIONS":                    true,
 	"FEATURE_PROGRAMMATIC_BOOTSTRAP":                true,
+	"FEATURE_KUBERNETES_SA_BOOTSTRAP":               true,
 	"FEATURE_PUBLIC_CATALOG":                        true,
 	"FEATURE_QUOTA_MANAGEMENT":                      true,
 	"FEATURE_QUOTA_NOTIFICATIONS":                   true,
@@ -164,8 +165,9 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_USERNAME_CONFIRMATION":                 true,
 	"FEATURE_VERIFY_QUOTA":                          true,
 
-	// Programmatic bootstrap token config
+	// Bootstrap token config
 	"BOOTSTRAP_TOKEN_OWNER":            true,
+	"KUBERNETES_SA_BOOTSTRAP_CONFIG":   true,
 	"BOOTSTRAP_TOKEN_EXPIRATION":       true,
 	"BOOTSTRAP_TOKEN_PATH":             true,
 	"BOOTSTRAP_TOKEN_SCOPE":            true,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -126,14 +126,32 @@ CONFIG_SCHEMA = {
     "allOf": [
         {
             "if": {
-                "properties": {"FEATURE_PROGRAMMATIC_BOOTSTRAP": {"const": True}},
-                "required": ["FEATURE_PROGRAMMATIC_BOOTSTRAP"],
+                "anyOf": [
+                    {
+                        "properties": {"FEATURE_PROGRAMMATIC_BOOTSTRAP": {"const": True}},
+                        "required": ["FEATURE_PROGRAMMATIC_BOOTSTRAP"],
+                    },
+                    {
+                        "properties": {"FEATURE_KUBERNETES_SA_BOOTSTRAP": {"const": True}},
+                        "required": ["FEATURE_KUBERNETES_SA_BOOTSTRAP"],
+                    },
+                ]
             },
             "then": {
                 "required": ["BOOTSTRAP_TOKEN_OWNER"],
                 "properties": {"BOOTSTRAP_TOKEN_OWNER": {"type": "string", "minLength": 1}},
             },
-        }
+        },
+        {
+            "if": {
+                "properties": {"FEATURE_KUBERNETES_SA_BOOTSTRAP": {"const": True}},
+                "required": ["FEATURE_KUBERNETES_SA_BOOTSTRAP"],
+            },
+            "then": {
+                "required": ["KUBERNETES_SA_BOOTSTRAP_CONFIG"],
+                "properties": {"KUBERNETES_SA_BOOTSTRAP_CONFIG": {"type": "object"}},
+            },
+        },
     ],
     "properties": {
         "REGISTRY_STATE": {
@@ -1554,11 +1572,123 @@ CONFIG_SCHEMA = {
             "description": "Feature flag for programmatic bootstrap token provisioning. Defaults to False.",
             "x-example": False,
         },
+        "FEATURE_KUBERNETES_SA_BOOTSTRAP": {
+            "type": "boolean",
+            "description": "Feature flag for exchanging Kubernetes ServiceAccount credentials for scoped Quay OAuth tokens. Defaults to False.",
+            "x-example": False,
+        },
+        "KUBERNETES_SA_BOOTSTRAP_CONFIG": {
+            "type": ["object", "null"],
+            "additionalProperties": False,
+            "required": ["ISSUERS", "AUTHORIZED_SUBJECTS"],
+            "properties": {
+                "REQUIRED_AUDIENCE": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "quay-bootstrap",
+                    "description": "Audience required in Kubernetes ServiceAccount JWTs. Defaults to quay-bootstrap.",
+                    "x-example": "quay-bootstrap",
+                },
+                "ISSUERS": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": "Trusted Kubernetes token issuers and their optional discovery configuration.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["ISSUER"],
+                        "properties": {
+                            "ISSUER": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                                "description": "Exact issuer expected in the ServiceAccount JWT iss claim.",
+                                "x-example": "https://kubernetes.default.svc",
+                            },
+                            "DISCOVERY_ENDPOINT": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                                "description": "Optional network endpoint for OIDC discovery when it differs from ISSUER.",
+                                "x-example": "https://api.cluster.example.com:6443",
+                            },
+                            "CA_CERT_PATH": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^/[^\x00]*$",
+                                "description": "Optional absolute path to a CA certificate used for discovery TLS verification.",
+                                "x-example": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                            },
+                            "BEARER_TOKEN_PATH": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^/[^\x00]*$",
+                                "description": "Optional absolute path to a bearer token used to authenticate discovery requests. The credential itself is not stored in configuration.",
+                                "x-example": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                            },
+                        },
+                        "allOf": [
+                            {
+                                "if": {"required": ["BEARER_TOKEN_PATH"]},
+                                "then": {"required": ["CA_CERT_PATH"]},
+                            }
+                        ],
+                    },
+                },
+                "AUTHORIZED_SUBJECTS": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": "Exact Kubernetes issuer and ServiceAccount subjects authorized to request bounded Quay scopes.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["ISSUER", "SUBJECT", "SCOPES"],
+                        "properties": {
+                            "ISSUER": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                            },
+                            "SUBJECT": {
+                                "type": "string",
+                                "pattern": r"^system:serviceaccount:[^:\s]+:[^:\s]+$",
+                                "description": "Exact Kubernetes ServiceAccount JWT subject.",
+                                "x-example": "system:serviceaccount:quay-operator:controller-manager",
+                            },
+                            "SCOPES": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 1024,
+                                "pattern": r"^(org:admin|repo:(admin|create|read|write)|super:user|user:(admin|read))( (org:admin|repo:(admin|create|read|write)|super:user|user:(admin|read)))*$",
+                                "description": "Space-separated Quay OAuth scopes this subject may request.",
+                                "x-example": "org:admin repo:create repo:read repo:write",
+                            },
+                        },
+                    },
+                },
+                "JWKS_CACHE_TTL_SECONDS": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 3600,
+                    "description": "JWKS cache lifetime in seconds. Defaults to 3600.",
+                    "x-example": 3600,
+                },
+                "BOOTSTRAP_TOKEN_MAX_TTL": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 86400,
+                    "description": "Maximum lifetime in seconds for OAuth tokens issued through workload identity exchange. Defaults to 86400.",
+                    "x-example": 86400,
+                },
+            },
+        },
         "BOOTSTRAP_TOKEN_OWNER": {
             "type": ["string", "null"],
             "minLength": 1,
             "maxLength": 255,
-            "description": "Username that owns the programmatic bootstrap OAuth application and tokens. Required when FEATURE_PROGRAMMATIC_BOOTSTRAP is enabled, and the user must also be listed in SUPER_USERS.",
+            "description": "Username that owns bootstrap OAuth applications and tokens. Required when programmatic or Kubernetes ServiceAccount bootstrap is enabled, and the user must also be listed in SUPER_USERS.",
             "x-example": "admin",
         },
         "BOOTSTRAP_TOKEN_PATH": {

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -33,28 +33,190 @@ def test_oauth_application_maximum_token_count_is_optional_positive_integer():
             validate(value, schema)
 
 
-def test_bootstrap_token_owner_required_when_programmatic_bootstrap_enabled():
-    schema = {
+def _bootstrap_config_schema():
+    property_names = [
+        "FEATURE_PROGRAMMATIC_BOOTSTRAP",
+        "FEATURE_KUBERNETES_SA_BOOTSTRAP",
+        "KUBERNETES_SA_BOOTSTRAP_CONFIG",
+        "BOOTSTRAP_TOKEN_OWNER",
+    ]
+    return {
         "type": "object",
         "allOf": CONFIG_SCHEMA["allOf"],
-        "properties": {
-            "FEATURE_PROGRAMMATIC_BOOTSTRAP": CONFIG_SCHEMA["properties"][
-                "FEATURE_PROGRAMMATIC_BOOTSTRAP"
-            ],
-            "BOOTSTRAP_TOKEN_OWNER": CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_OWNER"],
-        },
+        "properties": {name: CONFIG_SCHEMA["properties"][name] for name in property_names},
     }
 
-    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": False, "BOOTSTRAP_TOKEN_OWNER": None}, schema)
-    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": "admin"}, schema)
+
+def _valid_kubernetes_sa_bootstrap_config():
+    return {
+        "REQUIRED_AUDIENCE": "quay-bootstrap",
+        "ISSUERS": [{"ISSUER": "https://kubernetes.default.svc"}],
+        "AUTHORIZED_SUBJECTS": [
+            {
+                "ISSUER": "https://kubernetes.default.svc",
+                "SUBJECT": "system:serviceaccount:quay-operator:controller-manager",
+                "SCOPES": "org:admin repo:create repo:read repo:write",
+            }
+        ],
+        "JWKS_CACHE_TTL_SECONDS": 3600,
+        "BOOTSTRAP_TOKEN_MAX_TTL": 86400,
+    }
+
+
+def test_bootstrap_token_owner_required_when_bootstrap_enabled():
+    schema = _bootstrap_config_schema()
+
+    validate(
+        {
+            "FEATURE_PROGRAMMATIC_BOOTSTRAP": False,
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": False,
+            "BOOTSTRAP_TOKEN_OWNER": None,
+        },
+        schema,
+    )
+    validate(
+        {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": "admin"},
+        schema,
+    )
+    validate(
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+        },
+        schema,
+    )
 
     for config in [
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True},
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": None},
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": ""},
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+        },
     ]:
         with pytest.raises(ValidationError):
             validate(config, schema)
+
+
+def test_kubernetes_sa_bootstrap_config_required_only_when_enabled():
+    schema = _bootstrap_config_schema()
+
+    validate({"FEATURE_KUBERNETES_SA_BOOTSTRAP": False}, schema)
+    validate(
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+        },
+        schema,
+    )
+
+    for config in [
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+        },
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": None,
+        },
+    ]:
+        with pytest.raises(ValidationError):
+            validate(config, schema)
+
+
+def test_kubernetes_sa_bootstrap_config_accepts_supported_issuer_forms():
+    schema = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+    config = _valid_kubernetes_sa_bootstrap_config()
+    config["ISSUERS"].append(
+        {
+            "ISSUER": "https://cluster.example.com",
+            "DISCOVERY_ENDPOINT": "https://api.cluster.example.com:6443",
+            "CA_CERT_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+            "BEARER_TOKEN_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        }
+    )
+
+    validate(config, schema)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"ISSUERS": [], "AUTHORIZED_SUBJECTS": []},
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "http://insecure.example.com"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "https://cluster.example.com?unexpected=query"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "https://cluster.example.com:notaport"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "DISCOVERY_ENDPOINT": "https://api.cluster.example.com:notaport",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "BEARER_TOKEN_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "DISCOVERY_ENDPONT": "https://api.cluster.example.com:6443",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "default:builder",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:default:builder",
+                    "SCOPES": "repo:unknown",
+                }
+            ],
+        },
+        {**_valid_kubernetes_sa_bootstrap_config(), "JWKS_CACHE_TTL_SECONDS": 0},
+        {**_valid_kubernetes_sa_bootstrap_config(), "BOOTSTRAP_TOKEN_MAX_TTL": 0},
+        {**_valid_kubernetes_sa_bootstrap_config(), "UNKNOWN_SETTING": True},
+    ],
+)
+def test_kubernetes_sa_bootstrap_config_rejects_invalid_values(config):
+    schema = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+
+    with pytest.raises(ValidationError):
+        validate(config, schema)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add an opt-in feature flag and configuration block for Kubernetes ServiceAccount workload identity
- define structured trusted issuers, exact authorized subjects, OAuth scope limits, and token/JWKS TTL settings
- require the shared bootstrap token owner when workload identity is enabled
- reject malformed, incomplete, insecure, and unknown nested configuration values

## Stack

This is the first PR in the Workload Identity Authentication for Quay Management API stack.

1. **This PR** — administrator-facing workload identity configuration contract
2. Follow-up stories — Kubernetes JWT validation and token exchange runtime behavior

Parent epic: [PROJQUAY-12483](https://redhat.atlassian.net/browse/PROJQUAY-12483)
Enhancement: [quay/enhancements#45](https://github.com/quay/enhancements/pull/45)

## Scope

This PR defines and validates configuration only. It intentionally does not consume the configuration or implement JWT validation, JWKS discovery, or token exchange.

## Test results

- `TEST=true PYTHONPATH=. pytest util/config/test/test_schema.py -q` — passed, 64 tests
- `go test ./internal/config` — passed
- pre-commit hooks — passed
