### PR TITLE
[redhat-3.17] NO-ISSUE: fix(config): map FEATURE_ENABLE_STALE_MPU_CLEANUP as known-unmapped

### DIFF
--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -110,6 +110,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_BLACKLISTED_EMAILS":                    true,
 	"FEATURE_DISABLE_OIDC_FALLBACK_GROUPS_CREATION": true,
 	"FEATURE_EDIT_QUOTA":                            true,
+	"FEATURE_ENABLE_STALE_MPU_CLEANUP":              true,
 	"FEATURE_ENTITLEMENT_RECONCILIATION":            true,
 	"FEATURE_EXPORT_COMPLIANCE":                     true,
 	"FEATURE_EXTENDED_REPOSITORY_NAMES":             true,


### PR DESCRIPTION
The master merge of #6885 added FEATURE_ENABLE_STALE_MPU_CLEANUP to the Python config schema. TestSchemaFieldCoverage fails on any Python-only key absent from knownUnmapped. The Go migrate tooling does not consume this flag, so list it as intentionally unmapped alongside the other Python-only FEATURE_* flags.