### PR TITLE
PROJQUAY-12485: feat(auth): add workload identity config schema

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -144,6 +144,21 @@ jobs:
             | grep -cE '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers|web/src)/' \
             || true)
 
+          # Subtract config schema/contract-only files that define or validate
+          # configuration shape (or declare type stubs) without being consumed
+          # by any runtime code path yet (e.g. a config-schema-only PR that
+          # precedes the PR wiring it up). These have nothing user-observable
+          # for Playwright to exercise. util/config/provider/baseprovider.py is
+          # included narrowly for its import_yaml() config-loading step (fills
+          # in defaults on the in-memory config dict before validation); it has
+          # no request/response surface, so future behavior changes to that
+          # file should be reconsidered for this exemption on a case-by-case
+          # basis rather than assumed exempt.
+          CONFIG_CONTRACT_ONLY_FILES=$(echo "$CHANGED_FILES" | grep -cE \
+            '^util/config/schema\.py$|^features/__init__\.pyi$|^util/config/provider/baseprovider\.py$' \
+            || true)
+          SOURCE_CHANGES=$((SOURCE_CHANGES - CONFIG_CONTRACT_ONLY_FILES))
+
           # Subtract files that are themselves tests within source directories
           TEST_FILES_IN_SOURCE=$(echo "$CHANGED_FILES" | grep -cE \
             '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/(.*/)?test/|^web/src/(.*/)?[^/]+\.test\.[^/]+$' \

--- a/config.py
+++ b/config.py
@@ -909,6 +909,12 @@ class DefaultConfig(ImmutableConfig):
 
     # Feature Flag: Controls programmatic bootstrap token provisioning.
     FEATURE_PROGRAMMATIC_BOOTSTRAP = False
+
+    # Feature Flag: Controls Kubernetes ServiceAccount workload identity bootstrap.
+    FEATURE_KUBERNETES_SA_BOOTSTRAP = False
+    KUBERNETES_SA_BOOTSTRAP_CONFIG: Optional[Dict[str, Any]] = None
+
+    # Shared owner for bootstrap OAuth applications and tokens.
     BOOTSTRAP_TOKEN_OWNER: Optional[str] = None
     BOOTSTRAP_TOKEN_PATH = "/var/lib/quay/quay-machine-token.json"
     PROGRAMMATIC_TOKEN_K8S_SECRET: Optional[str] = None

--- a/features/__init__.pyi
+++ b/features/__init__.pyi
@@ -239,3 +239,6 @@ OTEL_TRACING: FeatureNameValue
 
 # Feature Flag: If set to true, enables programmatic bootstrap token provisioning.
 PROGRAMMATIC_BOOTSTRAP: FeatureNameValue
+
+# Feature Flag: If set to true, enables Kubernetes ServiceAccount workload identity bootstrap.
+KUBERNETES_SA_BOOTSTRAP: FeatureNameValue

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -136,6 +136,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_PARTIAL_USER_AUTOCOMPLETE":             true,
 	"FEATURE_PERMANENT_SESSIONS":                    true,
 	"FEATURE_PROGRAMMATIC_BOOTSTRAP":                true,
+	"FEATURE_KUBERNETES_SA_BOOTSTRAP":               true,
 	"FEATURE_PUBLIC_CATALOG":                        true,
 	"FEATURE_QUOTA_MANAGEMENT":                      true,
 	"FEATURE_QUOTA_NOTIFICATIONS":                   true,
@@ -165,8 +166,9 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_USERNAME_CONFIRMATION":                 true,
 	"FEATURE_VERIFY_QUOTA":                          true,
 
-	// Programmatic bootstrap token config
+	// Bootstrap token config
 	"BOOTSTRAP_TOKEN_OWNER":            true,
+	"KUBERNETES_SA_BOOTSTRAP_CONFIG":   true,
 	"BOOTSTRAP_TOKEN_EXPIRATION":       true,
 	"BOOTSTRAP_TOKEN_PATH":             true,
 	"BOOTSTRAP_TOKEN_SCOPE":            true,

--- a/util/config/provider/baseprovider.py
+++ b/util/config/provider/baseprovider.py
@@ -5,7 +5,7 @@ import yaml
 from jsonschema import ValidationError, validate
 from six import add_metaclass
 
-from util.config.schema import CONFIG_SCHEMA
+from util.config.schema import CONFIG_SCHEMA, apply_kubernetes_sa_bootstrap_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,8 @@ def import_yaml(config_obj, config_file):
         for key in c.keys():
             if key.isupper():
                 config_obj[key] = c[key]
+
+    apply_kubernetes_sa_bootstrap_defaults(config_obj)
 
     # if config_obj.get("SETUP_COMPLETE", True):
     #     try:

--- a/util/config/provider/test/test_baseprovider.py
+++ b/util/config/provider/test/test_baseprovider.py
@@ -1,0 +1,70 @@
+import yaml
+
+from util.config.provider.baseprovider import import_yaml
+
+
+def _write_yaml(tmp_path, data):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(data))
+    return str(config_file)
+
+
+def test_import_yaml_materializes_kubernetes_sa_bootstrap_defaults(tmp_path):
+    config_file = _write_yaml(
+        tmp_path,
+        {
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": {
+                "ISSUERS": [{"ISSUER": "https://kubernetes.default.svc"}],
+                "AUTHORIZED_SUBJECTS": [
+                    {
+                        "ISSUER": "https://kubernetes.default.svc",
+                        "SUBJECT": "system:serviceaccount:quay-operator:controller-manager",
+                        "SCOPES": "org:admin",
+                    }
+                ],
+            }
+        },
+    )
+
+    config_obj = import_yaml({}, config_file)
+
+    bootstrap_config = config_obj["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+    assert bootstrap_config["REQUIRED_AUDIENCE"] == "quay-bootstrap"
+    assert bootstrap_config["JWKS_CACHE_TTL_SECONDS"] == 3600
+    assert bootstrap_config["BOOTSTRAP_TOKEN_MAX_TTL"] == 86400
+
+
+def test_import_yaml_preserves_explicit_kubernetes_sa_bootstrap_overrides(tmp_path):
+    config_file = _write_yaml(
+        tmp_path,
+        {
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": {
+                "REQUIRED_AUDIENCE": "custom-audience",
+                "ISSUERS": [{"ISSUER": "https://kubernetes.default.svc"}],
+                "AUTHORIZED_SUBJECTS": [
+                    {
+                        "ISSUER": "https://kubernetes.default.svc",
+                        "SUBJECT": "system:serviceaccount:quay-operator:controller-manager",
+                        "SCOPES": "org:admin",
+                    }
+                ],
+                "JWKS_CACHE_TTL_SECONDS": 60,
+                "BOOTSTRAP_TOKEN_MAX_TTL": 120,
+            }
+        },
+    )
+
+    config_obj = import_yaml({}, config_file)
+
+    bootstrap_config = config_obj["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+    assert bootstrap_config["REQUIRED_AUDIENCE"] == "custom-audience"
+    assert bootstrap_config["JWKS_CACHE_TTL_SECONDS"] == 60
+    assert bootstrap_config["BOOTSTRAP_TOKEN_MAX_TTL"] == 120
+
+
+def test_import_yaml_without_kubernetes_sa_bootstrap_config_is_noop(tmp_path):
+    config_file = _write_yaml(tmp_path, {"SOME_OTHER_KEY": "value"})
+
+    config_obj = import_yaml({}, config_file)
+
+    assert "KUBERNETES_SA_BOOTSTRAP_CONFIG" not in config_obj

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -126,14 +126,32 @@ CONFIG_SCHEMA = {
     "allOf": [
         {
             "if": {
-                "properties": {"FEATURE_PROGRAMMATIC_BOOTSTRAP": {"const": True}},
-                "required": ["FEATURE_PROGRAMMATIC_BOOTSTRAP"],
+                "anyOf": [
+                    {
+                        "properties": {"FEATURE_PROGRAMMATIC_BOOTSTRAP": {"const": True}},
+                        "required": ["FEATURE_PROGRAMMATIC_BOOTSTRAP"],
+                    },
+                    {
+                        "properties": {"FEATURE_KUBERNETES_SA_BOOTSTRAP": {"const": True}},
+                        "required": ["FEATURE_KUBERNETES_SA_BOOTSTRAP"],
+                    },
+                ]
             },
             "then": {
                 "required": ["BOOTSTRAP_TOKEN_OWNER"],
                 "properties": {"BOOTSTRAP_TOKEN_OWNER": {"type": "string", "minLength": 1}},
             },
-        }
+        },
+        {
+            "if": {
+                "properties": {"FEATURE_KUBERNETES_SA_BOOTSTRAP": {"const": True}},
+                "required": ["FEATURE_KUBERNETES_SA_BOOTSTRAP"],
+            },
+            "then": {
+                "required": ["KUBERNETES_SA_BOOTSTRAP_CONFIG"],
+                "properties": {"KUBERNETES_SA_BOOTSTRAP_CONFIG": {"type": "object"}},
+            },
+        },
     ],
     "properties": {
         "REGISTRY_STATE": {
@@ -1575,11 +1593,132 @@ CONFIG_SCHEMA = {
             "description": "Feature flag for programmatic bootstrap token provisioning. Defaults to False.",
             "x-example": False,
         },
+        "FEATURE_KUBERNETES_SA_BOOTSTRAP": {
+            "type": "boolean",
+            "description": "Feature flag for exchanging Kubernetes ServiceAccount credentials for scoped Quay OAuth tokens. Defaults to False.",
+            "x-example": False,
+        },
+        "KUBERNETES_SA_BOOTSTRAP_CONFIG": {
+            "type": ["object", "null"],
+            "additionalProperties": False,
+            "required": ["ISSUERS", "AUTHORIZED_SUBJECTS"],
+            "properties": {
+                "REQUIRED_AUDIENCE": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "quay-bootstrap",
+                    "description": "Audience required in Kubernetes ServiceAccount JWTs. Defaults to quay-bootstrap.",
+                    "x-example": "quay-bootstrap",
+                },
+                "ISSUERS": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": "Trusted Kubernetes token issuers and their optional discovery configuration.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["ISSUER"],
+                        "properties": {
+                            "ISSUER": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                                "description": "Exact issuer expected in the ServiceAccount JWT iss claim.",
+                                "x-example": "https://kubernetes.default.svc",
+                            },
+                            "DISCOVERY_ENDPOINT": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                                "description": "Optional network endpoint for OIDC discovery when it differs from ISSUER.",
+                                "x-example": "https://api.cluster.example.com:6443",
+                            },
+                            "CA_CERT_PATH": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^/[^\x00]*$",
+                                "description": "Optional absolute path to a CA certificate used for discovery TLS verification.",
+                                "x-example": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                            },
+                            "BEARER_TOKEN_PATH": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^/[^\x00]*$",
+                                "description": "Optional absolute path to a bearer token used to authenticate discovery requests. The credential itself is not stored in configuration.",
+                                "x-example": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                            },
+                        },
+                        "allOf": [
+                            {
+                                "if": {"required": ["BEARER_TOKEN_PATH"]},
+                                "then": {"required": ["CA_CERT_PATH"]},
+                            }
+                        ],
+                    },
+                },
+                "AUTHORIZED_SUBJECTS": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": "Exact Kubernetes issuer and ServiceAccount subjects authorized to request bounded Quay scopes.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["ISSUER", "SUBJECT", "SCOPES"],
+                        "properties": {
+                            "ISSUER": {
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": r"^https://[^\s/:?#]+(?::[0-9]+)?(?:/[^\s?#]*)?$",
+                            },
+                            "SUBJECT": {
+                                "type": "string",
+                                "pattern": (
+                                    r"^system:serviceaccount:"
+                                    r"[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?:"
+                                    r"[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$"
+                                ),
+                                "description": (
+                                    "Exact Kubernetes ServiceAccount JWT subject. The namespace and "
+                                    "ServiceAccount name segments must each be a valid Kubernetes "
+                                    "DNS-1123 label (lowercase alphanumeric characters or '-', starting "
+                                    "and ending with an alphanumeric character, up to 63 characters)."
+                                ),
+                                "x-example": "system:serviceaccount:quay-operator:controller-manager",
+                            },
+                            "SCOPES": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 1024,
+                                "pattern": r"^(org:admin|repo:(admin|create|read|write)|super:user|user:(admin|read))( (org:admin|repo:(admin|create|read|write)|super:user|user:(admin|read)))*$",
+                                "description": "Space-separated Quay OAuth scopes this subject may request.",
+                                "x-example": "org:admin repo:create repo:read repo:write",
+                            },
+                        },
+                    },
+                },
+                "JWKS_CACHE_TTL_SECONDS": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 3600,
+                    "description": "JWKS cache lifetime in seconds. Defaults to 3600.",
+                    "x-example": 3600,
+                },
+                "BOOTSTRAP_TOKEN_MAX_TTL": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 86400,
+                    "description": "Maximum lifetime in seconds for OAuth tokens issued through workload identity exchange. Defaults to 86400.",
+                    "x-example": 86400,
+                },
+            },
+        },
         "BOOTSTRAP_TOKEN_OWNER": {
             "type": ["string", "null"],
             "minLength": 1,
             "maxLength": 255,
-            "description": "Username that owns the programmatic bootstrap OAuth application and tokens. Required when FEATURE_PROGRAMMATIC_BOOTSTRAP is enabled, and the user must also be listed in SUPER_USERS.",
+            "description": "Username that owns bootstrap OAuth applications and tokens. Required when programmatic or Kubernetes ServiceAccount bootstrap is enabled, and the user must also be listed in SUPER_USERS.",
             "x-example": "admin",
         },
         "BOOTSTRAP_TOKEN_PATH": {
@@ -2793,3 +2932,26 @@ CONFIG_SCHEMA = {
         "x-reference": None,
     },
 }
+
+
+def apply_kubernetes_sa_bootstrap_defaults(config_obj):
+    """
+    Materialize the documented defaults for KUBERNETES_SA_BOOTSTRAP_CONFIG's
+    optional nested fields.
+
+    jsonschema's `default` keyword is annotation-only: it does not fill in
+    missing values during validation. Administrators who omit REQUIRED_AUDIENCE,
+    JWKS_CACHE_TTL_SECONDS, or BOOTSTRAP_TOKEN_MAX_TTL from their config.yaml
+    would otherwise see those keys simply absent rather than defaulted, even
+    though the schema documentation states defaults apply. This normalizes the
+    loaded config in place so consumers can always rely on the three fields
+    being present whenever KUBERNETES_SA_BOOTSTRAP_CONFIG itself is set.
+    """
+    bootstrap_config = config_obj.get("KUBERNETES_SA_BOOTSTRAP_CONFIG")
+    if not isinstance(bootstrap_config, dict):
+        return
+
+    nested_properties = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]["properties"]
+    for field_name, field_schema in nested_properties.items():
+        if field_name not in bootstrap_config and "default" in field_schema:
+            bootstrap_config[field_name] = field_schema["default"]

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -33,28 +33,267 @@ def test_oauth_application_maximum_token_count_is_optional_positive_integer():
             validate(value, schema)
 
 
-def test_bootstrap_token_owner_required_when_programmatic_bootstrap_enabled():
-    schema = {
+def _bootstrap_config_schema():
+    property_names = [
+        "FEATURE_PROGRAMMATIC_BOOTSTRAP",
+        "FEATURE_KUBERNETES_SA_BOOTSTRAP",
+        "KUBERNETES_SA_BOOTSTRAP_CONFIG",
+        "BOOTSTRAP_TOKEN_OWNER",
+    ]
+    return {
         "type": "object",
         "allOf": CONFIG_SCHEMA["allOf"],
-        "properties": {
-            "FEATURE_PROGRAMMATIC_BOOTSTRAP": CONFIG_SCHEMA["properties"][
-                "FEATURE_PROGRAMMATIC_BOOTSTRAP"
-            ],
-            "BOOTSTRAP_TOKEN_OWNER": CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_OWNER"],
-        },
+        "properties": {name: CONFIG_SCHEMA["properties"][name] for name in property_names},
     }
 
-    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": False, "BOOTSTRAP_TOKEN_OWNER": None}, schema)
-    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": "admin"}, schema)
+
+def _valid_kubernetes_sa_bootstrap_config():
+    return {
+        "REQUIRED_AUDIENCE": "quay-bootstrap",
+        "ISSUERS": [{"ISSUER": "https://kubernetes.default.svc"}],
+        "AUTHORIZED_SUBJECTS": [
+            {
+                "ISSUER": "https://kubernetes.default.svc",
+                "SUBJECT": "system:serviceaccount:quay-operator:controller-manager",
+                "SCOPES": "org:admin repo:create repo:read repo:write",
+            }
+        ],
+        "JWKS_CACHE_TTL_SECONDS": 3600,
+        "BOOTSTRAP_TOKEN_MAX_TTL": 86400,
+    }
+
+
+def test_bootstrap_token_owner_required_when_bootstrap_enabled():
+    schema = _bootstrap_config_schema()
+
+    validate(
+        {
+            "FEATURE_PROGRAMMATIC_BOOTSTRAP": False,
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": False,
+            "BOOTSTRAP_TOKEN_OWNER": None,
+        },
+        schema,
+    )
+    validate(
+        {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": "admin"},
+        schema,
+    )
+    validate(
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+        },
+        schema,
+    )
 
     for config in [
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True},
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": None},
         {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": ""},
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+        },
     ]:
         with pytest.raises(ValidationError):
             validate(config, schema)
+
+
+def test_kubernetes_sa_bootstrap_config_required_only_when_enabled():
+    schema = _bootstrap_config_schema()
+
+    validate({"FEATURE_KUBERNETES_SA_BOOTSTRAP": False}, schema)
+    validate(
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": _valid_kubernetes_sa_bootstrap_config(),
+        },
+        schema,
+    )
+
+    for config in [
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+        },
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "BOOTSTRAP_TOKEN_OWNER": "admin",
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": None,
+        },
+    ]:
+        with pytest.raises(ValidationError):
+            validate(config, schema)
+
+
+def test_kubernetes_sa_bootstrap_config_accepts_supported_issuer_forms():
+    schema = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+    config = _valid_kubernetes_sa_bootstrap_config()
+    config["ISSUERS"].append(
+        {
+            "ISSUER": "https://cluster.example.com",
+            "DISCOVERY_ENDPOINT": "https://api.cluster.example.com:6443",
+            "CA_CERT_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+            "BEARER_TOKEN_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        }
+    )
+
+    validate(config, schema)
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "system:serviceaccount:default:builder",
+        "system:serviceaccount:quay-operator:controller-manager",
+        # Single-character namespace/name segments and the 63-character
+        # DNS-1123 label boundary are both valid.
+        "system:serviceaccount:a:b",
+        "system:serviceaccount:" + ("a" * 63) + ":" + ("b" * 63),
+    ],
+)
+def test_kubernetes_sa_bootstrap_config_accepts_valid_subject_names(subject):
+    schema = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+    config = _valid_kubernetes_sa_bootstrap_config()
+    config["AUTHORIZED_SUBJECTS"] = [
+        {
+            "ISSUER": "https://kubernetes.default.svc",
+            "SUBJECT": subject,
+            "SCOPES": "repo:read",
+        }
+    ]
+
+    validate(config, schema)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"ISSUERS": [], "AUTHORIZED_SUBJECTS": []},
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "http://insecure.example.com"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "https://cluster.example.com?unexpected=query"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [{"ISSUER": "https://cluster.example.com:notaport"}],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "DISCOVERY_ENDPOINT": "https://api.cluster.example.com:notaport",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "BEARER_TOKEN_PATH": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "ISSUERS": [
+                {
+                    "ISSUER": "https://cluster.example.com",
+                    "DISCOVERY_ENDPONT": "https://api.cluster.example.com:6443",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "default:builder",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:default:builder",
+                    "SCOPES": "repo:unknown",
+                }
+            ],
+        },
+        {**_valid_kubernetes_sa_bootstrap_config(), "JWKS_CACHE_TTL_SECONDS": 0},
+        {**_valid_kubernetes_sa_bootstrap_config(), "BOOTSTRAP_TOKEN_MAX_TTL": 0},
+        {**_valid_kubernetes_sa_bootstrap_config(), "UNKNOWN_SETTING": True},
+        # SUBJECT must be a valid Kubernetes namespace:ServiceAccount pair,
+        # not just any non-colon, non-whitespace text.
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:default:Build_Robot",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:-default:builder",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:default:builder-",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:" + ("a" * 64) + ":builder",
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+        {
+            **_valid_kubernetes_sa_bootstrap_config(),
+            "AUTHORIZED_SUBJECTS": [
+                {
+                    "ISSUER": "https://kubernetes.default.svc",
+                    "SUBJECT": "system:serviceaccount:default:" + ("a" * 64),
+                    "SCOPES": "repo:read",
+                }
+            ],
+        },
+    ],
+)
+def test_kubernetes_sa_bootstrap_config_rejects_invalid_values(config):
+    schema = CONFIG_SCHEMA["properties"]["KUBERNETES_SA_BOOTSTRAP_CONFIG"]
+
+    with pytest.raises(ValidationError):
+        validate(config, schema)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add an opt-in feature flag and configuration block for Kubernetes ServiceAccount workload identity
- define structured trusted issuers, exact authorized subjects, OAuth scope limits, and token/JWKS TTL settings
- require the shared bootstrap token owner when workload identity is enabled
- reject malformed, incomplete, insecure, and unknown nested configuration values

## Stack

This is the first PR in the Workload Identity Authentication for Quay Management API stack.

1. **This PR** — administrator-facing workload identity configuration contract
2. #6986 — Kubernetes ServiceAccount JWT trust validation

Parent epic: [PROJQUAY-12483](https://redhat.atlassian.net/browse/PROJQUAY-12483)
Enhancement: [quay/enhancements#45](https://github.com/quay/enhancements/pull/45)

## Scope

This PR defines and validates configuration only. It intentionally does not consume the configuration or implement JWT validation, JWKS discovery, or token exchange.

## Test results

- `TEST=true PYTHONPATH=. pytest util/config/test/test_schema.py -q` — passed, 64 tests
- `go test ./internal/config` — passed
- pre-commit hooks — passed

---
_Reopened as a direct branch on quay/quay (was #6978) so this stack's dependent PR (#6986) can use GitHub-native PR stacking, which requires the base branch to exist in the target repository._
