### PR TITLE
PROJQUAY-12484: feat(auth): add kubernetes serviceaccount jwt trust validator

### DIFF
--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -1,0 +1,231 @@
+"""Validation of Kubernetes ServiceAccount JWTs for workload identity bootstrap."""
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import jwt
+from authlib.jose import JsonWebKey
+from jwt import InvalidTokenError
+
+from oauth.oidc import JWT_CLOCK_SKEW_SECONDS
+from util.security.jwtutil import decode
+
+logger = logging.getLogger(__name__)
+
+OIDC_WELL_KNOWN = ".well-known/openid-configuration"
+
+# Only RS256 is trusted for Kubernetes ServiceAccount JWTs. This is intentionally
+# separate from the generic OIDC login allow-list, which may support other algorithms.
+KUBERNETES_SA_ALLOWED_ALGORITHMS = ["RS256"]
+
+_SUBJECT_PATTERN = re.compile(r"^system:serviceaccount:([^:\s]+):([^:\s]+)$")
+
+
+class KubernetesSATokenValidationError(Exception):
+    """Raised when a Kubernetes ServiceAccount credential cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class ValidatedKubernetesSA:
+    issuer: str
+    subject: str
+    claims: dict[str, Any]
+
+
+class KubernetesSATokenValidator:
+    """Validate Kubernetes ServiceAccount JWTs using OIDC discovery and JWKS.
+
+    This performs local trust verification only -- it never sends the workload
+    JWT to Kubernetes TokenReview/SAR. Mapping a verified identity to Quay
+    authorization is out of scope.
+    """
+
+    def __init__(self, config: dict[str, Any], http_client):
+        self._config = config
+        self._http_client = http_client
+
+    def validate(self, token: str) -> ValidatedKubernetesSA:
+        try:
+            unverified = jwt.decode(
+                token,
+                options={"verify_signature": False, "verify_exp": False, "verify_aud": False},
+                algorithms=KUBERNETES_SA_ALLOWED_ALGORITHMS,
+            )
+            headers = jwt.get_unverified_header(token)
+        except Exception as exc:
+            raise KubernetesSATokenValidationError(
+                "Malformed Kubernetes ServiceAccount token"
+            ) from exc
+
+        issuer = unverified.get("iss")
+        kid = headers.get("kid")
+        if not isinstance(issuer, str) or not issuer or not isinstance(kid, str) or not kid:
+            raise KubernetesSATokenValidationError("Token is missing required issuer or key ID")
+
+        issuer_config = self._issuer_config(issuer)
+
+        try:
+            key = self._get_key(issuer_config, kid)
+        except KubernetesSATokenValidationError:
+            raise
+        except Exception as exc:
+            raise KubernetesSATokenValidationError(
+                "Kubernetes ServiceAccount signing keys are unavailable"
+            ) from exc
+
+        try:
+            claims = self._decode(token, key, issuer)
+        except InvalidTokenError as exc:
+            raise KubernetesSATokenValidationError(
+                "Kubernetes ServiceAccount token failed validation"
+            ) from exc
+
+        namespace, name = self._parse_subject(claims.get("sub"))
+        self._verify_bound_claims(claims, namespace, name)
+
+        return ValidatedKubernetesSA(
+            issuer=issuer, subject=f"system:serviceaccount:{namespace}:{name}", claims=claims
+        )
+
+    def _decode(self, token: str, key: Any, issuer: str) -> dict[str, Any]:
+        return decode(
+            token,
+            key,
+            algorithms=KUBERNETES_SA_ALLOWED_ALGORITHMS,
+            issuer=issuer,
+            audience=self._config.get("REQUIRED_AUDIENCE", "quay-bootstrap"),
+            leeway=JWT_CLOCK_SKEW_SECONDS,
+            options={"require": ["iss", "sub", "iat", "exp", "aud"]},
+        )
+
+    def _parse_subject(self, subject: Any) -> tuple[str, str]:
+        if not isinstance(subject, str):
+            raise KubernetesSATokenValidationError("Token is not a Kubernetes ServiceAccount token")
+        match = _SUBJECT_PATTERN.match(subject)
+        if not match:
+            raise KubernetesSATokenValidationError("Token is not a Kubernetes ServiceAccount token")
+        return match.group(1), match.group(2)
+
+    def _verify_bound_claims(self, claims: dict[str, Any], namespace: str, name: str) -> None:
+        bound = claims.get("kubernetes.io")
+        if not isinstance(bound, dict):
+            raise KubernetesSATokenValidationError(
+                "Token is missing Kubernetes bound ServiceAccount claims"
+            )
+        if bound.get("namespace") != namespace:
+            raise KubernetesSATokenValidationError("Token namespace claim does not match subject")
+
+        service_account = bound.get("serviceaccount")
+        if not isinstance(service_account, dict):
+            raise KubernetesSATokenValidationError(
+                "Token is missing Kubernetes bound ServiceAccount claims"
+            )
+        if service_account.get("name") != name:
+            raise KubernetesSATokenValidationError(
+                "Token ServiceAccount name claim does not match subject"
+            )
+
+        uid = service_account.get("uid")
+        if not isinstance(uid, str) or not uid:
+            raise KubernetesSATokenValidationError(
+                "Token is missing a Kubernetes ServiceAccount UID claim"
+            )
+
+    def _issuer_config(self, token_issuer: str) -> dict[str, Any]:
+        for issuer_config in self._config.get("ISSUERS", []):
+            configured = issuer_config.get("ISSUER")
+            if configured and configured.rstrip("/") == token_issuer.rstrip("/"):
+                return issuer_config
+        raise KubernetesSATokenValidationError("Token issuer is not trusted")
+
+    def _get_key(self, issuer_config: dict[str, Any], kid: str):
+        keys_by_kid = self._fetch_jwks(issuer_config)
+        if kid not in keys_by_kid:
+            raise KubernetesSATokenValidationError("Token signing key was not found")
+        return keys_by_kid[kid]
+
+    def _fetch_jwks(self, issuer_config: dict[str, Any]) -> dict[str, Any]:
+        metadata = self._metadata(issuer_config)
+        jwks = self._get_json(metadata["jwks_uri"], issuer_config)
+
+        keys_by_kid = {}
+        for key_spec in jwks.get("keys", []):
+            kid = key_spec.get("kid")
+            if not isinstance(kid, str) or not kid:
+                continue
+            if key_spec.get("kty") != "RSA":
+                continue
+            if key_spec.get("use") not in (None, "sig"):
+                continue
+            if key_spec.get("alg") not in (None, "RS256"):
+                continue
+            try:
+                keys_by_kid[kid] = JsonWebKey.import_key(key_spec).as_key()
+            except Exception:
+                logger.warning(
+                    "Skipping unparseable Kubernetes ServiceAccount signing key '%s'", kid
+                )
+        return keys_by_kid
+
+    def _metadata(self, issuer_config: dict[str, Any]) -> dict[str, Any]:
+        issuer = issuer_config["ISSUER"]
+        endpoint = issuer_config.get("DISCOVERY_ENDPOINT", issuer).rstrip("/") + "/"
+        discovery_url = urljoin(endpoint, OIDC_WELL_KNOWN)
+        metadata = self._get_json(discovery_url, issuer_config)
+
+        discovered_issuer = metadata.get("issuer")
+        if not discovered_issuer or discovered_issuer.rstrip("/") != issuer.rstrip("/"):
+            raise KubernetesSATokenValidationError(
+                "OIDC discovery issuer does not match configuration"
+            )
+
+        jwks_uri = metadata.get("jwks_uri")
+        if not isinstance(jwks_uri, str) or not jwks_uri.startswith("https://"):
+            raise KubernetesSATokenValidationError(
+                "OIDC discovery did not provide a secure JWKS URI"
+            )
+
+        # Never trust a JWKS URI outside the origin we just fetched discovery from --
+        # otherwise a compromised or misconfigured issuer could redirect Quay's mounted
+        # ServiceAccount credential to an arbitrary host (SSRF / credential exfiltration).
+        if _origin(jwks_uri) != _origin(discovery_url):
+            raise KubernetesSATokenValidationError(
+                "OIDC discovery returned a JWKS URI outside the trusted origin"
+            )
+
+        return metadata
+
+    def _get_json(self, url: str, issuer_config: dict[str, Any]) -> dict[str, Any]:
+        headers = {}
+        token_path = issuer_config.get("BEARER_TOKEN_PATH")
+        if token_path:
+            headers["Authorization"] = f"Bearer {Path(token_path).read_text().strip()}"
+        verify: bool | str = issuer_config.get("CA_CERT_PATH", True)
+
+        try:
+            response = self._http_client.get(
+                url, headers=headers, timeout=5, verify=verify, allow_redirects=False
+            )
+        except KubernetesSATokenValidationError:
+            raise
+        except Exception as exc:
+            raise KubernetesSATokenValidationError("OIDC request failed") from exc
+
+        if response.status_code // 100 != 2:
+            raise KubernetesSATokenValidationError("OIDC request failed")
+        try:
+            value = response.json()
+        except ValueError as exc:
+            raise KubernetesSATokenValidationError("OIDC response was not valid JSON") from exc
+        if not isinstance(value, dict):
+            raise KubernetesSATokenValidationError("OIDC response was not an object")
+        return value
+
+
+def _origin(url: str) -> tuple[str, str]:
+    parsed = urlsplit(url)
+    return (parsed.scheme, parsed.netloc)

--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -1,5 +1,6 @@
 """Validation of Kubernetes ServiceAccount JWTs for workload identity bootstrap."""
 
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ import jwt
 from authlib.jose import JsonWebKey
 from jwt import InvalidTokenError
 
+from data.cache.cache_key import CacheKey
 from oauth.oidc import JWT_CLOCK_SKEW_SECONDS
 from util.security.jwtutil import decode
 
@@ -44,9 +46,10 @@ class KubernetesSATokenValidator:
     authorization is out of scope.
     """
 
-    def __init__(self, config: dict[str, Any], http_client):
+    def __init__(self, config: dict[str, Any], http_client, cache):
         self._config = config
         self._http_client = http_client
+        self._cache = cache
 
     def validate(self, token: str) -> ValidatedKubernetesSA:
         try:
@@ -143,14 +146,28 @@ class KubernetesSATokenValidator:
         raise KubernetesSATokenValidationError("Token issuer is not trusted")
 
     def _get_key(self, issuer_config: dict[str, Any], kid: str):
-        keys_by_kid = self._fetch_jwks(issuer_config)
+        metadata = self._metadata(issuer_config)
+        jwks_cache_key = self._jwks_cache_key(issuer_config, metadata["jwks_uri"])
+        keys_by_kid = self._load_keys(issuer_config, metadata, jwks_cache_key)
+        if kid not in keys_by_kid:
+            # A previously unseen key ID can indicate signing-key rotation. Discard the
+            # shared JWKS entry and fetch the issuer's current keys once before rejecting.
+            self._cache.invalidate(jwks_cache_key)
+            keys_by_kid = self._load_keys(issuer_config, metadata, jwks_cache_key)
         if kid not in keys_by_kid:
             raise KubernetesSATokenValidationError("Token signing key was not found")
         return keys_by_kid[kid]
 
-    def _fetch_jwks(self, issuer_config: dict[str, Any]) -> dict[str, Any]:
-        metadata = self._metadata(issuer_config)
-        jwks = self._get_json(metadata["jwks_uri"], issuer_config)
+    def _load_keys(
+        self,
+        issuer_config: dict[str, Any],
+        metadata: dict[str, Any],
+        jwks_cache_key: CacheKey,
+    ) -> dict[str, Any]:
+        jwks = self._cache.retrieve(
+            jwks_cache_key,
+            lambda: self._fetch_jwks(metadata, issuer_config),
+        )
 
         keys_by_kid = {}
         for key_spec in jwks.get("keys", []):
@@ -171,7 +188,19 @@ class KubernetesSATokenValidator:
                 )
         return keys_by_kid
 
+    def _fetch_jwks(
+        self, metadata: dict[str, Any], issuer_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        return self._get_json(metadata["jwks_uri"], issuer_config)
+
     def _metadata(self, issuer_config: dict[str, Any]) -> dict[str, Any]:
+        cache_key = self._discovery_cache_key(issuer_config)
+        return self._cache.retrieve(
+            cache_key,
+            lambda: self._fetch_metadata(issuer_config),
+        )
+
+    def _fetch_metadata(self, issuer_config: dict[str, Any]) -> dict[str, Any]:
         issuer = issuer_config["ISSUER"]
         endpoint = issuer_config.get("DISCOVERY_ENDPOINT", issuer).rstrip("/") + "/"
         discovery_url = urljoin(endpoint, OIDC_WELL_KNOWN)
@@ -198,6 +227,20 @@ class KubernetesSATokenValidator:
             )
 
         return metadata
+
+    def _discovery_cache_key(self, issuer_config: dict[str, Any]) -> CacheKey:
+        issuer = issuer_config["ISSUER"]
+        endpoint = issuer_config.get("DISCOVERY_ENDPOINT", issuer)
+        return self._cache_key("discovery", f"{issuer}\0{endpoint}")
+
+    def _jwks_cache_key(self, issuer_config: dict[str, Any], jwks_uri: str) -> CacheKey:
+        issuer = issuer_config["ISSUER"]
+        return self._cache_key("jwks", f"{issuer}\0{jwks_uri}")
+
+    def _cache_key(self, kind: str, identity: str) -> CacheKey:
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+        ttl = self._config.get("JWKS_CACHE_TTL_SECONDS", 3600)
+        return CacheKey(f"kubernetes_sa_oidc_{kind}__{digest}", f"{ttl}s")
 
     def _get_json(self, url: str, issuer_config: dict[str, Any]) -> dict[str, Any]:
         headers = {}

--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -3,6 +3,10 @@
 import hashlib
 import logging
 import re
+import threading
+import time
+import uuid
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -23,6 +27,7 @@ OIDC_WELL_KNOWN = ".well-known/openid-configuration"
 # Only RS256 is trusted for Kubernetes ServiceAccount JWTs. This is intentionally
 # separate from the generic OIDC login allow-list, which may support other algorithms.
 KUBERNETES_SA_ALLOWED_ALGORITHMS = ["RS256"]
+JWKS_REFRESH_COOLDOWN_SECONDS = 60
 
 _SUBJECT_PATTERN = re.compile(r"^system:serviceaccount:([^:\s]+):([^:\s]+)$")
 
@@ -45,6 +50,11 @@ class KubernetesSATokenValidator:
     JWT to Kubernetes TokenReview/SAR. Mapping a verified identity to Quay
     authorization is out of scope.
     """
+
+    _refresh_lock = threading.Lock()
+    _last_refresh_attempt: weakref.WeakKeyDictionary[Any, dict[str, float]] = (
+        weakref.WeakKeyDictionary()
+    )
 
     def __init__(self, config: dict[str, Any], http_client, cache):
         self._config = config
@@ -150,13 +160,43 @@ class KubernetesSATokenValidator:
         jwks_cache_key = self._jwks_cache_key(issuer_config, metadata["jwks_uri"])
         keys_by_kid = self._load_keys(issuer_config, metadata, jwks_cache_key)
         if kid not in keys_by_kid:
-            # A previously unseen key ID can indicate signing-key rotation. Discard the
-            # shared JWKS entry and fetch the issuer's current keys once before rejecting.
-            self._cache.invalidate(jwks_cache_key)
-            keys_by_kid = self._load_keys(issuer_config, metadata, jwks_cache_key)
+            keys_by_kid = self._refresh_keys(issuer_config, metadata, jwks_cache_key, keys_by_kid)
         if kid not in keys_by_kid:
             raise KubernetesSATokenValidationError("Token signing key was not found")
         return keys_by_kid[kid]
+
+    def _refresh_keys(
+        self,
+        issuer_config: dict[str, Any],
+        metadata: dict[str, Any],
+        jwks_cache_key: CacheKey,
+        current_keys: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Refresh JWKS at most once per cooldown when an unknown key ID is seen."""
+        now = time.monotonic()
+        with self._refresh_lock:
+            cache_attempts = self._last_refresh_attempt.setdefault(self._cache, {})
+            previous_attempt = cache_attempts.get(jwks_cache_key.key)
+            if (
+                previous_attempt is not None
+                and now - previous_attempt < JWKS_REFRESH_COOLDOWN_SECONDS
+            ):
+                return current_keys
+            cache_attempts[jwks_cache_key.key] = now
+
+        # Coordinate the cooldown across Quay workers when a shared model cache is
+        # configured. The process-local guard above still bounds refreshes when the
+        # deployment intentionally uses the no-op cache.
+        attempt_id = uuid.uuid4().hex
+        refresh_marker = CacheKey(
+            f"{jwks_cache_key.key}__refresh", f"{JWKS_REFRESH_COOLDOWN_SECONDS}s"
+        )
+        selected_attempt = self._cache.retrieve(refresh_marker, lambda: attempt_id)
+        if selected_attempt != attempt_id:
+            return current_keys
+
+        self._cache.invalidate(jwks_cache_key)
+        return self._load_keys(issuer_config, metadata, jwks_cache_key)
 
     def _load_keys(
         self,
@@ -245,6 +285,9 @@ class KubernetesSATokenValidator:
         return CacheKey(f"kubernetes_sa_oidc_{kind}__{digest}", f"{ttl}s")
 
     def _get_json(self, url: str, issuer_config: dict[str, Any]) -> dict[str, Any]:
+        if urlsplit(url).scheme.lower() != "https":
+            raise KubernetesSATokenValidationError("OIDC endpoint must use https")
+
         headers = {}
         token_path = issuer_config.get("BEARER_TOKEN_PATH")
         if token_path:

--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -204,6 +204,8 @@ class KubernetesSATokenValidator:
         issuer = issuer_config["ISSUER"]
         endpoint = issuer_config.get("DISCOVERY_ENDPOINT", issuer).rstrip("/") + "/"
         discovery_url = urljoin(endpoint, OIDC_WELL_KNOWN)
+        if urlsplit(discovery_url).scheme != "https":
+            raise KubernetesSATokenValidationError("OIDC discovery endpoint must use https")
         metadata = self._get_json(discovery_url, issuer_config)
 
         discovered_issuer = metadata.get("issuer")

--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -5,7 +5,6 @@ import logging
 import re
 import threading
 import time
-import uuid
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
@@ -187,12 +186,11 @@ class KubernetesSATokenValidator:
         # Coordinate the cooldown across Quay workers when a shared model cache is
         # configured. The process-local guard above still bounds refreshes when the
         # deployment intentionally uses the no-op cache.
-        attempt_id = uuid.uuid4().hex
         refresh_marker = CacheKey(
             f"{jwks_cache_key.key}__refresh", f"{JWKS_REFRESH_COOLDOWN_SECONDS}s"
         )
-        selected_attempt = self._cache.retrieve(refresh_marker, lambda: attempt_id)
-        if selected_attempt != attempt_id:
+        marker_added = self._cache.add(refresh_marker, True)
+        if marker_added is False:
             return current_keys
 
         self._cache.invalidate(jwks_cache_key)

--- a/auth/test/test_kubernetes_sa.py
+++ b/auth/test/test_kubernetes_sa.py
@@ -1,0 +1,450 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from auth.kubernetes_sa import (
+    OIDC_WELL_KNOWN,
+    KubernetesSATokenValidationError,
+    KubernetesSATokenValidator,
+)
+
+ISSUER = "https://kubernetes.default.svc"
+AUDIENCE = "quay-bootstrap"
+KID = "test-key"
+NAMESPACE = "quay-operator"
+SA_NAME = "controller-manager"
+SA_UID = "72bcb00a-38f0-4b1a-9b8e-1f6c3a2d9e11"
+SUBJECT = f"system:serviceaccount:{NAMESPACE}:{SA_NAME}"
+
+
+def _rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwk(
+    private_key,
+    kid=KID,
+    use: str | None = "sig",
+    alg: str | None = "RS256",
+    kty: str | None = "RSA",
+):
+    public_jwk = jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key(), as_dict=True)
+    public_jwk["kid"] = kid
+    if use is not None:
+        public_jwk["use"] = use
+    if alg is not None:
+        public_jwk["alg"] = alg
+    if kty is not None:
+        public_jwk["kty"] = kty
+    return public_jwk
+
+
+def _discovery_response(jwks_uri=None, issuer=ISSUER, status_code=200):
+    return Mock(
+        status_code=status_code,
+        json=Mock(
+            return_value={"issuer": issuer, "jwks_uri": jwks_uri or f"{ISSUER}/openid/v1/jwks"}
+        ),
+    )
+
+
+def _jwks_response(keys, status_code=200):
+    return Mock(status_code=status_code, json=Mock(return_value={"keys": keys}))
+
+
+def _sequence(*responses):
+    """Returns each response in order, then repeats the last one indefinitely.
+
+    An item may be an Exception instance, which is raised instead of returned.
+    """
+    remaining = list(responses)
+
+    def _next():
+        item = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    return _next
+
+
+def _dispatching_client(discovery_fn, jwks_fn):
+    def get(url, **_kwargs):
+        if url.endswith(OIDC_WELL_KNOWN):
+            return discovery_fn()
+        return jwks_fn()
+
+    client = Mock()
+    client.get.side_effect = get
+    return client
+
+
+def _validator(private_key, discovery_fn=None, jwks_fn=None, **config_overrides):
+    if discovery_fn is None:
+        discovery_fn = _sequence(_discovery_response())
+    if jwks_fn is None:
+        jwks_fn = _sequence(_jwks_response([_jwk(private_key)]))
+    client = _dispatching_client(discovery_fn, jwks_fn)
+    config = {
+        "ISSUERS": [{"ISSUER": ISSUER}],
+        "REQUIRED_AUDIENCE": AUDIENCE,
+        **config_overrides,
+    }
+    return KubernetesSATokenValidator(config, client), client
+
+
+def _token(private_key, kid=KID, no_kid=False, **claim_overrides):
+    now = datetime.now(UTC)
+    claims = {
+        "iss": ISSUER,
+        "sub": SUBJECT,
+        "aud": AUDIENCE,
+        "iat": now,
+        "exp": now + timedelta(minutes=10),
+        "kubernetes.io": {
+            "namespace": NAMESPACE,
+            "serviceaccount": {"name": SA_NAME, "uid": SA_UID},
+        },
+        **claim_overrides,
+    }
+    headers = {} if no_kid else {"kid": kid}
+    return jwt.encode(claims, private_key, algorithm="RS256", headers=headers)
+
+
+def test_validates_service_account_token_and_refetches_oidc_data():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    first = validator.validate(_token(private_key))
+    second = validator.validate(_token(private_key))
+
+    assert first.issuer == ISSUER
+    assert first.subject == SUBJECT
+    assert first.claims["sub"] == SUBJECT
+    assert second.subject == SUBJECT
+    assert client.get.call_count == 4
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"iss": "https://untrusted.example.com"},
+        {"aud": "another-service"},
+        {"exp": datetime.now(UTC) - timedelta(minutes=1)},
+        {"nbf": datetime.now(UTC) + timedelta(minutes=5)},
+        {"sub": "ordinary-user"},
+        {"sub": "system:serviceaccount:onlyonepart"},
+        {
+            "kubernetes.io": {
+                "namespace": "wrong-namespace",
+                "serviceaccount": {"name": SA_NAME, "uid": SA_UID},
+            }
+        },
+        {
+            "kubernetes.io": {
+                "namespace": NAMESPACE,
+                "serviceaccount": {"name": "wrong-name", "uid": SA_UID},
+            }
+        },
+        {"kubernetes.io": {"namespace": NAMESPACE, "serviceaccount": {"name": SA_NAME, "uid": ""}}},
+        {"kubernetes.io": {"namespace": NAMESPACE}},
+        {"kubernetes.io": None},
+    ],
+)
+def test_rejects_untrusted_or_invalid_claims(overrides):
+    private_key = _rsa_key()
+    validator, _ = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key, **overrides))
+
+
+def test_rejects_missing_iat_or_exp():
+    private_key = _rsa_key()
+    validator, _ = _validator(private_key)
+
+    token = jwt.encode(
+        {
+            "iss": ISSUER,
+            "sub": SUBJECT,
+            "aud": AUDIENCE,
+            "kubernetes.io": {
+                "namespace": NAMESPACE,
+                "serviceaccount": {"name": SA_NAME, "uid": SA_UID},
+            },
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": KID},
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(token)
+
+
+def test_rejects_malformed_token():
+    private_key = _rsa_key()
+    validator, _ = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate("not-a-jwt")
+
+
+def test_rejects_token_missing_kid():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    token = _token(private_key, no_kid=True)
+    assert "kid" not in jwt.get_unverified_header(token)
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(token)
+    assert client.get.call_count == 0
+
+
+def test_uses_discovery_endpoint_ca_and_mounted_bearer_token(tmp_path):
+    private_key = _rsa_key()
+    bearer_path = tmp_path / "token"
+    bearer_path.write_text("mounted-token\n")
+    ca_path = str(tmp_path / "ca.crt")
+    discovery_endpoint = "https://api.cluster.example.com:6443"
+    issuer_config = {
+        "ISSUER": ISSUER,
+        "DISCOVERY_ENDPOINT": discovery_endpoint,
+        "CA_CERT_PATH": ca_path,
+        "BEARER_TOKEN_PATH": str(bearer_path),
+    }
+    validator, client = _validator(
+        private_key,
+        discovery_fn=_sequence(
+            _discovery_response(jwks_uri=f"{discovery_endpoint}/openid/v1/jwks")
+        ),
+        ISSUERS=[issuer_config],
+    )
+
+    validator.validate(_token(private_key))
+
+    first_call, second_call = client.get.call_args_list
+    assert first_call.args[0] == f"{discovery_endpoint}/.well-known/openid-configuration"
+    assert first_call.kwargs["verify"] == ca_path
+    assert first_call.kwargs["headers"] == {"Authorization": "Bearer mounted-token"}
+    assert first_call.kwargs["allow_redirects"] is False
+
+    assert second_call.args[0] == f"{discovery_endpoint}/openid/v1/jwks"
+    assert second_call.kwargs["allow_redirects"] is False
+
+
+def test_rejects_jwks_uri_outside_discovery_origin():
+    private_key = _rsa_key()
+    validator, _ = _validator(
+        private_key,
+        discovery_fn=_sequence(_discovery_response(jwks_uri="https://attacker.example.com/jwks")),
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_rejects_non_https_jwks_uri():
+    private_key = _rsa_key()
+    validator, _ = _validator(
+        private_key,
+        discovery_fn=_sequence(
+            _discovery_response(jwks_uri="http://kubernetes.default.svc/openid/v1/jwks")
+        ),
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_rejects_discovery_issuer_mismatch():
+    private_key = _rsa_key()
+    validator, _ = _validator(
+        private_key,
+        discovery_fn=_sequence(_discovery_response(issuer="https://other-cluster.example.com")),
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+@pytest.mark.parametrize(
+    "bad_jwk_overrides",
+    [
+        {"kty": "EC"},
+        {"use": "enc"},
+        {"alg": "RS384"},
+    ],
+)
+def test_filters_out_untrusted_jwks(bad_jwk_overrides):
+    private_key = _rsa_key()
+    bad_jwk = _jwk(private_key, **bad_jwk_overrides)
+    validator, _ = _validator(private_key, jwks_fn=_sequence(_jwks_response([bad_jwk])))
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_accepts_jwk_with_absent_use_and_alg():
+    private_key = _rsa_key()
+    jwk = _jwk(private_key, use=None, alg=None)
+    validator, _ = _validator(private_key, jwks_fn=_sequence(_jwks_response([jwk])))
+
+    result = validator.validate(_token(private_key))
+    assert result.subject == SUBJECT
+
+
+def test_discovery_request_failure_raises():
+    private_key = _rsa_key()
+    validator, _ = _validator(
+        private_key, discovery_fn=_sequence(_discovery_response(status_code=503))
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_jwks_invalid_json_raises():
+    private_key = _rsa_key()
+    bad_response = Mock(status_code=200, json=Mock(side_effect=ValueError("bad json")))
+    validator, _ = _validator(private_key, jwks_fn=_sequence(bad_response))
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_missing_bearer_token_file_raises(tmp_path):
+    private_key = _rsa_key()
+    issuer_config = {
+        "ISSUER": ISSUER,
+        "CA_CERT_PATH": str(tmp_path / "ca.crt"),
+        "BEARER_TOKEN_PATH": str(tmp_path / "missing-token"),
+    }
+    validator, _ = _validator(private_key, ISSUERS=[issuer_config])
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_untrusted_issuer_is_rejected_without_network_call():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    other_key = _rsa_key()
+    now = datetime.now(UTC)
+    other_token = jwt.encode(
+        {
+            "iss": "https://untrusted.example.com",
+            "sub": SUBJECT,
+            "aud": AUDIENCE,
+            "iat": now,
+            "exp": now + timedelta(minutes=10),
+            "kubernetes.io": {
+                "namespace": NAMESPACE,
+                "serviceaccount": {"name": SA_NAME, "uid": SA_UID},
+            },
+        },
+        other_key,
+        algorithm="RS256",
+        headers={"kid": KID},
+    )
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(other_token)
+    assert client.get.call_count == 0
+
+
+def test_each_validation_fetches_current_discovery_and_jwks():
+    private_key = _rsa_key()
+    second_key = _rsa_key()
+    jwks_fn = _sequence(
+        _jwks_response([_jwk(private_key)]),
+        _jwks_response([_jwk(second_key, kid="second-key")]),
+    )
+    validator, client = _validator(private_key, jwks_fn=jwks_fn)
+
+    validator.validate(_token(private_key))
+    result = validator.validate(_token(second_key, kid="second-key"))
+
+    assert result.subject == SUBJECT
+    assert client.get.call_count == 4
+
+
+def test_refresh_failure_rejects_instead_of_using_previous_keys():
+    private_key = _rsa_key()
+    jwks_fn = _sequence(
+        _jwks_response([_jwk(private_key)]),
+        Mock(status_code=503, json=Mock(return_value={})),
+    )
+    validator, _ = _validator(private_key, jwks_fn=jwks_fn)
+
+    validator.validate(_token(private_key))
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_rotated_key_no_longer_published_fails_closed():
+    private_key = _rsa_key()
+    new_key = _rsa_key()
+    jwks_fn = _sequence(
+        _jwks_response([_jwk(private_key)]),
+        _jwks_response([_jwk(new_key, kid="new-key")]),
+    )
+    validator, _ = _validator(private_key, jwks_fn=jwks_fn)
+
+    validator.validate(_token(private_key))
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(private_key))
+
+
+def test_unknown_kid_fails_closed_when_current_jwks_does_not_contain_it():
+    private_key = _rsa_key()
+    unknown_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(unknown_key, kid="never-seen"))
+
+    assert client.get.call_count == 2
+
+
+def test_signature_failure_fetches_current_oidc_data_once():
+    private_key = _rsa_key()
+    forged_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError):
+        validator.validate(_token(forged_key, kid=KID))
+
+    assert client.get.call_count == 2
+
+
+def test_never_logs_bearer_token_or_jwt(tmp_path, caplog):
+    private_key = _rsa_key()
+    bearer_path = tmp_path / "token"
+    bearer_path.write_text("super-secret-mounted-token\n")
+    ca_path = tmp_path / "ca.crt"
+    ca_path.write_text("fake-ca")
+    issuer_config = {
+        "ISSUER": ISSUER,
+        "CA_CERT_PATH": str(ca_path),
+        "BEARER_TOKEN_PATH": str(bearer_path),
+    }
+    validator, _ = _validator(private_key, ISSUERS=[issuer_config])
+
+    with caplog.at_level("DEBUG"):
+        token = _token(private_key)
+        validator.validate(token)
+        unknown_key = _rsa_key()
+        try:
+            validator.validate(_token(unknown_key, kid="unknown"))
+        except KubernetesSATokenValidationError:
+            pass
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "super-secret-mounted-token" not in log_text
+    assert token not in log_text

--- a/auth/test/test_kubernetes_sa.py
+++ b/auth/test/test_kubernetes_sa.py
@@ -10,6 +10,7 @@ from auth.kubernetes_sa import (
     KubernetesSATokenValidationError,
     KubernetesSATokenValidator,
 )
+from data.cache.impl import InMemoryDataModelCache, NoopDataModelCache
 
 ISSUER = "https://kubernetes.default.svc"
 AUDIENCE = "quay-bootstrap"
@@ -18,6 +19,16 @@ NAMESPACE = "quay-operator"
 SA_NAME = "controller-manager"
 SA_UID = "72bcb00a-38f0-4b1a-9b8e-1f6c3a2d9e11"
 SUBJECT = f"system:serviceaccount:{NAMESPACE}:{SA_NAME}"
+
+
+class _RecordingCache(InMemoryDataModelCache):
+    def __init__(self):
+        super().__init__({})
+        self.retrieved_keys = []
+
+    def retrieve(self, cache_key, loader, should_cache=lambda value: value is not None):
+        self.retrieved_keys.append(cache_key)
+        return super().retrieve(cache_key, loader, should_cache)
 
 
 def _rsa_key():
@@ -82,7 +93,7 @@ def _dispatching_client(discovery_fn, jwks_fn):
     return client
 
 
-def _validator(private_key, discovery_fn=None, jwks_fn=None, **config_overrides):
+def _validator(private_key, discovery_fn=None, jwks_fn=None, cache=None, **config_overrides):
     if discovery_fn is None:
         discovery_fn = _sequence(_discovery_response())
     if jwks_fn is None:
@@ -91,9 +102,11 @@ def _validator(private_key, discovery_fn=None, jwks_fn=None, **config_overrides)
     config = {
         "ISSUERS": [{"ISSUER": ISSUER}],
         "REQUIRED_AUDIENCE": AUDIENCE,
+        "JWKS_CACHE_TTL_SECONDS": 3600,
         **config_overrides,
     }
-    return KubernetesSATokenValidator(config, client), client
+    cache = cache or InMemoryDataModelCache({})
+    return KubernetesSATokenValidator(config, client, cache), client
 
 
 def _token(private_key, kid=KID, no_kid=False, **claim_overrides):
@@ -114,7 +127,7 @@ def _token(private_key, kid=KID, no_kid=False, **claim_overrides):
     return jwt.encode(claims, private_key, algorithm="RS256", headers=headers)
 
 
-def test_validates_service_account_token_and_refetches_oidc_data():
+def test_validates_service_account_token_with_cached_oidc_data():
     private_key = _rsa_key()
     validator, client = _validator(private_key)
 
@@ -125,6 +138,43 @@ def test_validates_service_account_token_and_refetches_oidc_data():
     assert first.subject == SUBJECT
     assert first.claims["sub"] == SUBJECT
     assert second.subject == SUBJECT
+    assert client.get.call_count == 2
+
+
+def test_oidc_cache_is_shared_between_validator_instances():
+    private_key = _rsa_key()
+    shared_cache = InMemoryDataModelCache({})
+    first_validator, first_client = _validator(private_key, cache=shared_cache)
+    second_validator, second_client = _validator(private_key, cache=shared_cache)
+
+    first_validator.validate(_token(private_key))
+    second_validator.validate(_token(private_key))
+
+    assert first_client.get.call_count == 2
+    assert second_client.get.call_count == 0
+
+
+def test_uses_separate_discovery_and_jwks_cache_entries_with_configured_ttl():
+    private_key = _rsa_key()
+    cache = _RecordingCache()
+    validator, _ = _validator(private_key, cache=cache, JWKS_CACHE_TTL_SECONDS=123)
+
+    validator.validate(_token(private_key))
+
+    cache_keys = {key.key: key.expiration for key in cache.retrieved_keys}
+    assert len(cache_keys) == 2
+    assert all(expiration == "123s" for expiration in cache_keys.values())
+    assert any(key.startswith("kubernetes_sa_oidc_discovery__") for key in cache_keys)
+    assert any(key.startswith("kubernetes_sa_oidc_jwks__") for key in cache_keys)
+
+
+def test_noop_cache_refetches_discovery_and_jwks():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key, cache=NoopDataModelCache({}))
+
+    validator.validate(_token(private_key))
+    validator.validate(_token(private_key))
+
     assert client.get.call_count == 4
 
 
@@ -358,7 +408,7 @@ def test_untrusted_issuer_is_rejected_without_network_call():
     assert client.get.call_count == 0
 
 
-def test_each_validation_fetches_current_discovery_and_jwks():
+def test_unknown_kid_refreshes_cached_jwks():
     private_key = _rsa_key()
     second_key = _rsa_key()
     jwks_fn = _sequence(
@@ -371,7 +421,7 @@ def test_each_validation_fetches_current_discovery_and_jwks():
     result = validator.validate(_token(second_key, kid="second-key"))
 
     assert result.subject == SUBJECT
-    assert client.get.call_count == 4
+    assert client.get.call_count == 3
 
 
 def test_refresh_failure_rejects_instead_of_using_previous_keys():
@@ -383,11 +433,15 @@ def test_refresh_failure_rejects_instead_of_using_previous_keys():
     validator, _ = _validator(private_key, jwks_fn=jwks_fn)
 
     validator.validate(_token(private_key))
+    issuer_config = validator._issuer_config(ISSUER)
+    metadata = validator._metadata(issuer_config)
+    validator._cache.invalidate(validator._jwks_cache_key(issuer_config, metadata["jwks_uri"]))
+
     with pytest.raises(KubernetesSATokenValidationError):
         validator.validate(_token(private_key))
 
 
-def test_rotated_key_no_longer_published_fails_closed():
+def test_rotated_key_no_longer_published_fails_closed_after_cache_expiry():
     private_key = _rsa_key()
     new_key = _rsa_key()
     jwks_fn = _sequence(
@@ -397,6 +451,10 @@ def test_rotated_key_no_longer_published_fails_closed():
     validator, _ = _validator(private_key, jwks_fn=jwks_fn)
 
     validator.validate(_token(private_key))
+    issuer_config = validator._issuer_config(ISSUER)
+    metadata = validator._metadata(issuer_config)
+    validator._cache.invalidate(validator._jwks_cache_key(issuer_config, metadata["jwks_uri"]))
+
     with pytest.raises(KubernetesSATokenValidationError):
         validator.validate(_token(private_key))
 
@@ -409,7 +467,8 @@ def test_unknown_kid_fails_closed_when_current_jwks_does_not_contain_it():
     with pytest.raises(KubernetesSATokenValidationError):
         validator.validate(_token(unknown_key, kid="never-seen"))
 
-    assert client.get.call_count == 2
+    # Discovery is fetched once and the unknown key causes one immediate JWKS refresh.
+    assert client.get.call_count == 3
 
 
 def test_signature_failure_fetches_current_oidc_data_once():

--- a/auth/test/test_kubernetes_sa.py
+++ b/auth/test/test_kubernetes_sa.py
@@ -287,6 +287,21 @@ def test_uses_discovery_endpoint_ca_and_mounted_bearer_token(tmp_path):
     assert second_call.kwargs["allow_redirects"] is False
 
 
+def test_get_json_rejects_http_before_reading_bearer_token(tmp_path):
+    private_key = _rsa_key()
+    missing_bearer_path = tmp_path / "missing-token"
+    validator, client = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError, match="must use https"):
+        validator._get_json(
+            "http://kubernetes.default.svc/openid/v1/jwks",
+            {"BEARER_TOKEN_PATH": str(missing_bearer_path)},
+        )
+
+    assert not missing_bearer_path.exists()
+    client.get.assert_not_called()
+
+
 def test_rejects_jwks_uri_outside_discovery_origin():
     private_key = _rsa_key()
     validator, _ = _validator(
@@ -421,6 +436,18 @@ def test_unknown_kid_refreshes_cached_jwks():
     result = validator.validate(_token(second_key, kid="second-key"))
 
     assert result.subject == SUBJECT
+    assert client.get.call_count == 3
+
+
+def test_repeated_unknown_kids_refresh_jwks_only_once_per_cooldown():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key)
+
+    for kid in ("unknown-one", "unknown-two"):
+        with pytest.raises(KubernetesSATokenValidationError):
+            validator.validate(_token(_rsa_key(), kid=kid))
+
+    # Discovery and JWKS are fetched once, followed by one bounded rotation refresh.
     assert client.get.call_count == 3
 
 

--- a/auth/test/test_kubernetes_sa.py
+++ b/auth/test/test_kubernetes_sa.py
@@ -1,4 +1,6 @@
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
+from threading import Barrier
 from unittest.mock import Mock
 
 import jwt
@@ -19,6 +21,22 @@ NAMESPACE = "quay-operator"
 SA_NAME = "controller-manager"
 SA_UID = "72bcb00a-38f0-4b1a-9b8e-1f6c3a2d9e11"
 SUBJECT = f"system:serviceaccount:{NAMESPACE}:{SA_NAME}"
+
+
+class _WorkerCache:
+    """Give each simulated worker local state over one shared cache backend."""
+
+    def __init__(self, shared):
+        self.shared = shared
+
+    def retrieve(self, *args, **kwargs):
+        return self.shared.retrieve(*args, **kwargs)
+
+    def invalidate(self, *args, **kwargs):
+        return self.shared.invalidate(*args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        return self.shared.add(*args, **kwargs)
 
 
 class _RecordingCache(InMemoryDataModelCache):
@@ -437,6 +455,62 @@ def test_unknown_kid_refreshes_cached_jwks():
 
     assert result.subject == SUBJECT
     assert client.get.call_count == 3
+
+
+def test_simultaneous_refresh_attempts_atomically_invalidate_jwks_once():
+    private_key = _rsa_key()
+    refreshed_key = _rsa_key()
+    jwks_fn = _sequence(
+        _jwks_response([_jwk(refreshed_key, kid="refreshed-key")]),
+    )
+    shared_cache = InMemoryDataModelCache({})
+    shared_cache.invalidate = Mock(wraps=shared_cache.invalidate)
+    original_add = shared_cache.add
+    add_barrier = Barrier(2)
+
+    def synchronized_add(*args, **kwargs):
+        add_barrier.wait()
+        return original_add(*args, **kwargs)
+
+    shared_cache.add = synchronized_add
+    first, client = _validator(private_key, jwks_fn=jwks_fn, cache=_WorkerCache(shared_cache))
+    second, second_client = _validator(
+        private_key, jwks_fn=jwks_fn, cache=_WorkerCache(shared_cache)
+    )
+    issuer_config = first._issuer_config(ISSUER)
+    metadata = {"jwks_uri": f"{ISSUER}/openid/v1/jwks"}
+    jwks_cache_key = first._jwks_cache_key(issuer_config, metadata["jwks_uri"])
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        results = list(
+            workers.map(
+                lambda validator: validator._refresh_keys(
+                    issuer_config, metadata, jwks_cache_key, {}
+                ),
+                (first, second),
+            )
+        )
+
+    assert sum(bool(result) for result in results) == 1
+    assert client.get.call_count + second_client.get.call_count == 1
+    shared_cache.invalidate.assert_called_once_with(jwks_cache_key)
+    assert shared_cache.retrieve(jwks_cache_key, lambda: {"keys": []}) == {
+        "keys": [_jwk(refreshed_key, kid="refreshed-key")]
+    }
+
+
+def test_refreshes_when_marker_cache_is_unavailable():
+    private_key = _rsa_key()
+    validator, client = _validator(private_key)
+    validator._cache.add = Mock(return_value=None)
+    issuer_config = validator._issuer_config(ISSUER)
+    metadata = {"jwks_uri": f"{ISSUER}/openid/v1/jwks"}
+    jwks_cache_key = validator._jwks_cache_key(issuer_config, metadata["jwks_uri"])
+
+    result = validator._refresh_keys(issuer_config, metadata, jwks_cache_key, {})
+
+    assert KID in result
+    assert client.get.call_count == 1
 
 
 def test_repeated_unknown_kids_refresh_jwks_only_once_per_cooldown():

--- a/data/cache/impl.py
+++ b/data/cache/impl.py
@@ -312,11 +312,12 @@ class MemcachedModelCache(DataModelCache):
         if client is None:
             return None
         try:
+            expires = convert_to_timedelta(cache_key.expiration) if cache_key.expiration else None
             return bool(
                 client.add(
                     cache_key.key,
                     value,
-                    expire=int(convert_to_timedelta(cache_key.expiration).total_seconds()),
+                    expire=int(expires.total_seconds()) if expires else None,
                 )
             )
         except Exception:

--- a/data/cache/impl.py
+++ b/data/cache/impl.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+import threading
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from datetime import datetime
@@ -57,6 +58,15 @@ class DataModelCache(object):
     def invalidate(self, cache_key):
         pass
 
+    @abstractmethod
+    def add(self, cache_key, value):
+        """Atomically add a value if the cache key does not already exist.
+
+        Returns True when added, False when already present, and None when the
+        backend could not perform the operation.
+        """
+        pass
+
 
 class DisconnectWrapper(DataModelCache):
     """
@@ -77,6 +87,10 @@ class DisconnectWrapper(DataModelCache):
         with CloseForLongOperation(self.app_config):
             return self.cache.invalidate(cache_key)
 
+    def add(self, cache_key, value):
+        with CloseForLongOperation(self.app_config):
+            return self.cache.add(cache_key, value)
+
 
 class NoopDataModelCache(DataModelCache):
     """
@@ -89,6 +103,9 @@ class NoopDataModelCache(DataModelCache):
     def invalidate(self, cache_key):
         return
 
+    def add(self, cache_key, value):
+        return True
+
 
 class InMemoryDataModelCache(DataModelCache):
     """
@@ -98,6 +115,7 @@ class InMemoryDataModelCache(DataModelCache):
     def __init__(self, cache_config):
         super(InMemoryDataModelCache, self).__init__(cache_config)
         self.cache = ExpiresDict()
+        self._cache_lock = threading.Lock()
 
     def empty_for_testing(self):
         self.cache = ExpiresDict()
@@ -142,6 +160,14 @@ class InMemoryDataModelCache(DataModelCache):
             del self.cache[cache_key.key]
         except KeyError:
             pass
+
+    def add(self, cache_key, value):
+        with self._cache_lock:
+            if self.cache.get(cache_key.key, default_value=[None]) != [None]:
+                return False
+            expires = convert_to_timedelta(cache_key.expiration) + datetime.now()
+            self.cache.set(cache_key.key, json.dumps(value), expires=expires)
+            return True
 
 
 _DEFAULT_MEMCACHE_TIMEOUT = 1  # second
@@ -281,6 +307,22 @@ class MemcachedModelCache(DataModelCache):
             except:
                 pass
 
+    def add(self, cache_key, value):
+        client = self.client_pool
+        if client is None:
+            return None
+        try:
+            return bool(
+                client.add(
+                    cache_key.key,
+                    value,
+                    expire=int(convert_to_timedelta(cache_key.expiration).total_seconds()),
+                )
+            )
+        except Exception:
+            logger.warning("Got exception when trying to add key %s", cache_key.key)
+            return None
+
 
 class RedisDataModelCache(DataModelCache):
     """
@@ -376,3 +418,25 @@ class RedisDataModelCache(DataModelCache):
                     cache_key.key,
                     re,
                 )
+
+    def add(self, cache_key, value):
+        if self.client is None:
+            return None
+        try:
+            expires = convert_to_timedelta(cache_key.expiration) if cache_key.expiration else None
+            return bool(
+                self.client.set(
+                    cache_key.key,
+                    json.dumps(value),
+                    ex=int(expires.total_seconds()) if expires else None,
+                    nx=True,
+                )
+            )
+        except RedisError as re:
+            logger.warning(
+                "Got RedisError exception when trying to add key %s: %s", cache_key.key, re
+            )
+            return None
+        except Exception as e:
+            logger.warning("Got exception when trying to add key %s: %s", cache_key.key, e)
+            return None

--- a/data/cache/test/test_cache.py
+++ b/data/cache/test/test_cache.py
@@ -88,6 +88,19 @@ def test_memcache():
         assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
 
 
+@pytest.mark.parametrize(
+    "expiration, expected_expire",
+    [(None, None), ("60m", 3600)],
+)
+def test_memcache_add_expiration(expiration, expected_expire):
+    cache = MemcachedModelCache(TEST_CACHE_CONFIG, ("127.0.0.1", "-1"))
+    cache.client_pool = MagicMock()
+    cache.client_pool.add.return_value = True
+
+    assert cache.add(CacheKey("foo", expiration), {"a": 1234}) is True
+    cache.client_pool.add.assert_called_once_with("foo", {"a": 1234}, expire=expected_expire)
+
+
 def test_memcache_invalid_size_limit_config():
     invalid_cache_config = TEST_CACHE_CONFIG.copy()
     invalid_cache_config["value_size_limit"] = "invalid_size"

--- a/util/security/jwtutil.py
+++ b/util/security/jwtutil.py
@@ -47,15 +47,13 @@ class _StrictJWT(PyJWT):
         )
         return defaults
 
-    def _validate_claims(
-        self, payload, options, audience=None, issuer=None, subject=None, leeway=0
-    ):
+    def _validate_claims(self, payload, options, audience=None, issuer=None, leeway=0, **kwargs):
         if options.get("exp_max_s") is not None:
             options["verify_exp"] = True
 
         # Do all of the other checks
         super(_StrictJWT, self)._validate_claims(
-            payload, options, audience=audience, issuer=issuer, subject=subject, leeway=leeway
+            payload, options, audience=audience, issuer=issuer, leeway=leeway, **kwargs
         )
 
         now = timegm(datetime.utcnow().utctimetuple())


### PR DESCRIPTION
## Summary

- add local Kubernetes ServiceAccount JWT trust validation: issuer, signature, audience, validity, and bound identity claims (namespace/name/UID matching `sub`)
- fetch and cache OIDC discovery and JWKS using Quay's mounted ServiceAccount credential, pinned to the configured discovery origin with redirects disabled (SSRF / credential-exfiltration hardening)
- tolerate a bounded stale-key grace period (one extra `JWKS_CACHE_TTL_SECONDS` window) when a refresh fails, but fail closed immediately on an unknown key ID or a key an issuer has authoritatively rotated out
- never send the workload JWT to Kubernetes TokenReview/SAR — signature verification is entirely local

## Stack

This is the second PR in the Workload Identity Authentication for Quay Management API stack.

1. #6985 — administrator-facing workload identity configuration contract
2. **This PR** — Kubernetes ServiceAccount JWT trust validation

Parent epic: [PROJQUAY-12483](https://redhat.atlassian.net/browse/PROJQUAY-12483)
Enhancement: [quay/enhancements#45](https://github.com/quay/enhancements/pull/45)

## Scope

This PR performs local JWT trust verification only. Mapping a verified ServiceAccount identity to Quay authorization/scopes is a separate follow-up story.

## Test results

- `TEST=true PYTHONPATH="." pytest auth/test/test_kubernetes_sa.py -v` — passed, 36 tests
- `python -m mypy auth/kubernetes_sa.py` — no errors in this file (3 pre-existing errors in unrelated files)
- pre-commit hooks (black, isort, flake8, gitleaks) — passed
