### PR TITLE
QUAYIO-2183: fix(logging): downgrade client-caused bearer token errors from ERROR to WARNING

### DIFF
--- a/auth/registry_jwt_auth.py
+++ b/auth/registry_jwt_auth.py
@@ -101,7 +101,7 @@ def identity_from_bearer_token(bearer_header):
     try:
         payload = decode_bearer_header(bearer_header, instance_keys, app.config)
     except InvalidBearerTokenException as bte:
-        logger.exception("Invalid bearer token: %s", bte)
+        logger.warning("Invalid bearer token: %s", bte)
         raise InvalidJWTException(bte)
 
     loaded_identity = Identity(payload["sub"], "signed_jwt")

--- a/auth/test/test_registry_jwt.py
+++ b/auth/test/test_registry_jwt.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import time
 
 import jwt
@@ -250,3 +251,37 @@ def test_mixing_keys_e2e(initialized_db):
 def test_unicode_token(token):
     with pytest.raises(InvalidJWTException):
         _parse_token(token)
+
+
+@pytest.mark.parametrize(
+    "token, expected_message",
+    [
+        pytest.param("some random token", "Invalid bearer token format", id="bad format"),
+        pytest.param("Bearer: sometokenhere", "Invalid bearer token format", id="extra bearer"),
+        pytest.param(
+            _token(_token_data(), skip_header=True),
+            "Missing kid header",
+            id="no header",
+        ),
+        pytest.param(
+            _token(_token_data(), key_id="someunknownkey"),
+            "Unknown service key",
+            id="bad key",
+        ),
+    ],
+)
+def test_invalid_token_logs_at_warning_not_error(token, expected_message, caplog, initialized_db):
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(InvalidJWTException):
+            _parse_token(token)
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    error_records = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR
+        and r.name in ("auth.registry_jwt_auth", "util.security.registry_jwt")
+    ]
+
+    assert len(warning_records) > 0, "Expected WARNING-level log for invalid token"
+    assert len(error_records) == 0, "Invalid client tokens should not log at ERROR level"

--- a/util/http.py
+++ b/util/http.py
@@ -62,10 +62,7 @@ def abort(status_code, message=None, issue=None, headers=None, **kwargs):
         message = "%s (authorized: %s)" % (message, auth_context.description)
 
     # Log the abort.
-    if status_code < 500:
-        logger.warning("Error %s: %s; Arguments: %s" % (status_code, message, params))
-    else:
-        logger.error("Error %s: %s; Arguments: %s" % (status_code, message, params))
+    logger.error("Error %s: %s; Arguments: %s" % (status_code, message, params))
 
     # Create the final response data and message.
     data = {}

--- a/util/http.py
+++ b/util/http.py
@@ -62,7 +62,10 @@ def abort(status_code, message=None, issue=None, headers=None, **kwargs):
         message = "%s (authorized: %s)" % (message, auth_context.description)
 
     # Log the abort.
-    logger.error("Error %s: %s; Arguments: %s" % (status_code, message, params))
+    if status_code < 500:
+        logger.warning("Error %s: %s; Arguments: %s" % (status_code, message, params))
+    else:
+        logger.error("Error %s: %s; Arguments: %s" % (status_code, message, params))
 
     # Create the final response data and message.
     data = {}

--- a/util/security/registry_jwt.py
+++ b/util/security/registry_jwt.py
@@ -85,18 +85,18 @@ def decode_bearer_token(bearer_token, instance_keys, config):
     try:
         headers = jwt.get_unverified_header(bearer_token)
     except jwtutil.InvalidTokenError as ite:
-        logger.exception("Invalid token reason: %s", ite)
+        logger.warning("Invalid token reason: %s", ite)
         raise InvalidBearerTokenException(ite)
 
     kid = headers.get("kid", None)
     if kid is None:
-        logger.error("Missing kid header on encoded JWT")
+        logger.warning("Missing kid header on encoded JWT")
         raise InvalidBearerTokenException("Missing kid header")
 
     # Find the matching public key.
     public_key = instance_keys.get_service_key_public_key(kid)
     if public_key is None:
-        logger.error("Could not find requested service key %s with encoded JWT", kid)
+        logger.warning("Could not find requested service key %s with encoded JWT", kid)
         raise InvalidBearerTokenException("Unknown service key")
 
     # Load the JWT returned.
@@ -115,7 +115,7 @@ def decode_bearer_token(bearer_token, instance_keys, config):
             leeway=JWT_CLOCK_SKEW_SECONDS,
         )
     except jwtutil.InvalidTokenError as ite:
-        logger.exception("Invalid token reason: %s", ite)
+        logger.warning("Invalid token reason: %s", ite)
         raise InvalidBearerTokenException(ite)
 
     if not "sub" in payload:

--- a/web/playwright/e2e/api/api-v2.spec.ts
+++ b/web/playwright/e2e/api/api-v2.spec.ts
@@ -276,7 +276,9 @@ test.describe(
         // Filtered referrer queries must return only the requested artifact
         // type and use a cache entry distinct from the unfiltered result.
         const filtered = await request.get(
-          `${API_URL}/v2/${orgName}/${repoName}/referrers/${manifestDigest}?artifactType=${encodeURIComponent('application/spdx+json')}`,
+          `${API_URL}/v2/${orgName}/${repoName}/referrers/${manifestDigest}?artifactType=${encodeURIComponent(
+            'application/spdx+json',
+          )}`,
           {headers: {authorization: `Bearer ${v2Token}`}},
         );
         expect(filtered.status()).toBe(200);
@@ -686,6 +688,44 @@ test.describe(
         }
       },
     );
+  },
+);
+
+// ============================================================================
+// V2 Invalid Bearer Token (QUAYIO-2183)
+// ============================================================================
+
+test.describe(
+  'V2 Invalid Bearer Token',
+  {tag: ['@api', '@v2', '@auth:Database']},
+  () => {
+    test('malformed bearer token returns 401', async ({playwright}) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const resp = await request.get(`${API_URL}/v2/`, {
+          headers: {authorization: 'Bearer invalidtokenvalue'},
+        });
+        expect(resp.status()).toBe(401);
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('garbage authorization header returns 401', async ({playwright}) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const resp = await request.get(`${API_URL}/v2/`, {
+          headers: {authorization: 'Bearer: notavalidformat'},
+        });
+        expect(resp.status()).toBe(401);
+      } finally {
+        await request.dispose();
+      }
+    });
   },
 );
 


### PR DESCRIPTION
## Summary
- Downgrade invalid bearer token log statements from `ERROR`/`EXCEPTION` to `WARNING` in `util/security/registry_jwt.py` and `auth/registry_jwt_auth.py` — these are client-caused 401s, not application errors
- Differentiate 4xx (WARNING) vs 5xx (ERROR) in the shared `util/http.py` `abort()` helper, so all client errors log at WARNING while server errors remain at ERROR
- Keeps `logger.exception("We should not be minting invalid credentials")` at ERROR level since that indicates a genuine server-side bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)