### PR TITLE
PROJQUAY-12843: fix: use --nobest flag for microdnf update and clean metadata before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV PYTHONUSERBASE=/app
 ENV TZ=UTC
 RUN set -ex\
 	; microdnf -y module enable nginx:1.24 \
-	; microdnf update -y \
+	; microdnf update -y --nobest \
+	; microdnf clean all \
 	; microdnf -y --setopt=tsflags=nodocs install \
 		dnsmasq \
 		memcached \
@@ -122,7 +123,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:8eb2830d0936237fc13a
 ENV OS=linux
 ARG PUSHGATEWAY_VERSION=1.11.1
 RUN set -ex\
-	; microdnf update -y \
+	; microdnf update -y --nobest \
+	; microdnf clean all \
 	; microdnf -y --setopt=tsflags=nodocs install tar gzip \
 	; ARCH=$(uname -m) ; echo $ARCH \
 	; if [ "$ARCH" == "x86_64" ] ; then ARCH="amd64" ; elif [ "$ARCH" == "aarch64" ] ; then ARCH="arm64" ; fi \


### PR DESCRIPTION
## Summary

- Add `--nobest` flag to `microdnf update -y` in both the `base` and `pushgateway` Dockerfile stages to prevent build failures caused by UBI9 RPM repo mirror propagation lag
- Add `microdnf clean all` between update and install steps to clear stale metadata

## Context

Recurring `quay-py3-on-push` pipeline failures traced to UBI9 RPM repository inconsistencies on Konflux (`kflux-prd-rh02`), where repo metadata references package versions whose dependencies have not fully propagated across all mirrors. The `--nobest` flag allows microdnf to fall back to the next best resolvable version instead of aborting the entire build.

This is the same root cause affecting other teams (RHOAIENG-81135, [RHOAIENG-87035](https://redhat.atlassian.net/browse/RHOAIENG-87035)) and the same mitigation being applied across Konflux.

Related Jira: [PROJQUAY-12843](https://redhat.atlassian.net/browse/PROJQUAY-12843)

Supersedes #6999

## Test plan

- [ ] Verify `quay-py3-on-pull-request` Konflux build passes
- [ ] Verify all CI checks pass (conventional commit, pre-commit, CodeQL, Prow)
- [ ] After merge, verify `quay-py3-on-push` pipeline succeeds


Made with [Cursor](https://cursor.com)