### PR TITLE
QUAYIO-2188: feat(secscan): skip Clair indexing for oci.empty artifacts

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -68,6 +68,16 @@ IndexReportState = namedtuple("IndexReportState", ["Index_Finished", "Index_Erro
     "IndexFinished", "IndexError"
 )
 
+# OCI "empty" config sentinel: an artifact carrying no real config blob.
+OCI_EMPTY_CONFIG_MEDIA_TYPE = "application/vnd.oci.empty.v1+json"
+
+# Config media types that provably identify a non-image artifact, letting us skip layer listing
+# and Clair. Kept as a denylist, not an image-config allowlist: config media type is verbatim
+# client input and many real images use non-standard values (e.g. "a"). `oci.empty` qualifies
+# because a real image always has a config blob, and these artifacts often reuse standard tar
+# layer types, so the `_has_container_layers` backstop misses them.
+NON_IMAGE_ARTIFACT_CONFIG_TYPES = frozenset((OCI_EMPTY_CONFIG_MEDIA_TYPE,))
+
 
 class ScanToken(namedtuple("NextScanToken", ["min_id"])):
     """
@@ -163,6 +173,14 @@ def _has_container_layers(layers):
             return False
 
     return True
+
+
+def _is_non_image_artifact_config(config_media_type):
+    """
+    True if the config media type provably identifies a non-image artifact Clair cannot index.
+    Anything else falls through to the `_has_container_layers` backstop.
+    """
+    return config_media_type in NON_IMAGE_ARTIFACT_CONFIG_TYPES
 
 
 def maybe_urlencoded(fixed_in: str) -> str:
@@ -576,6 +594,12 @@ class V4SecurityScanner(SecurityScannerInterface):
                 mark_manifest_unsupported(manifest)
                 continue
 
+            # Skip non-image artifacts before listing layers or calling Clair; the backstop below
+            # misses them when they reuse standard tar layer types.
+            if _is_non_image_artifact_config(manifest.config_media_type):
+                mark_manifest_unsupported(manifest)
+                continue
+
             layers = registry_model.list_manifest_layers(manifest, self.storage, True)
 
             if layers is None or len(layers) == 0:
@@ -654,7 +678,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                     continue
 
             try:
-                (report, state) = self._secscan_api.index(manifest, layers)
+                report, state = self._secscan_api.index(manifest, layers)
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.warning("Failed to perform indexing, invalid content sent")

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -16,7 +16,11 @@ from data.database import (
 from data.registry_model import registry_model
 from data.registry_model.datatypes import Manifest as ManifestDataType
 from data.secscan_model.interface import SecurityScannerIndexerInterface
-from data.secscan_model.secscan_v4_model import IndexReportState, _has_container_layers
+from data.secscan_model.secscan_v4_model import (
+    IndexReportState,
+    _has_container_layers,
+    _is_non_image_artifact_config,
+)
 from image.docker.schema1 import DOCKER_SCHEMA1_CONTENT_TYPES
 from util.metrics.prometheus import (
     secscan_v2_claim_status,
@@ -237,6 +241,13 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
         manifest = ManifestDataType.for_manifest(candidate, None)
 
         if manifest.is_manifest_list:
+            self._mark_unsupported(manifest)
+            secscan_v2_scan_result.labels(result="unsupported").inc()
+            return None
+
+        # Skip non-image artifacts before listing layers or calling Clair; the backstop below
+        # misses them when they reuse standard tar layer types.
+        if _is_non_image_artifact_config(manifest.config_media_type):
             self._mark_unsupported(manifest)
             secscan_v2_scan_result.labels(result="unsupported").inc()
             return None

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -40,18 +40,22 @@ from data.secscan_model.datatypes import (
     vulns_to_cves,
 )
 from data.secscan_model.secscan_v4_model import (
+    OCI_EMPTY_CONFIG_MEDIA_TYPE,
     IndexReportState,
     SecurityInformationLookupResult,
     V4SecurityScanner,
     _has_container_layers,
+    _is_non_image_artifact_config,
     features_for,
 )
 from image.docker.schema2 import (
+    DOCKER_SCHEMA2_CONFIG_CONTENT_TYPE,
     DOCKER_SCHEMA2_LAYER_CONTENT_TYPE,
     DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE,
     DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE,
 )
 from image.oci import (
+    OCI_IMAGE_CONFIG_CONTENT_TYPE,
     OCI_IMAGE_MANIFEST_CONTENT_TYPE,
     OCI_IMAGE_TAR_GZIP_LAYER_CONTENT_TYPE,
 )
@@ -1102,6 +1106,148 @@ def test_has_container_layers_no_media_type():
     layer = ManifestLayer(layer_info=layer_info, blob=None)
 
     assert not _has_container_layers([layer])
+
+
+@pytest.mark.parametrize(
+    "config_media_type, expected",
+    [
+        # Only denylisted non-image sentinels are treated as artifacts.
+        (OCI_EMPTY_CONFIG_MEDIA_TYPE, True),
+        # Real container images -> indexable, not an artifact.
+        (OCI_IMAGE_CONFIG_CONTENT_TYPE, False),
+        (DOCKER_SCHEMA2_CONFIG_CONTENT_TYPE, False),
+        # Custom-layer artifacts are handled by the `_has_container_layers` backstop, not here,
+        # so they are NOT denylisted by config type.
+        ("application/vnd.cncf.helm.config.v1+json", False),
+        ("application/vnd.cyclonedx+json", False),
+        ("application/vnd.in-toto+json", False),
+        # Non-standard / garbage config types belong to real, scannable images in production
+        # (e.g. the literal "a"); they must fall through to the layer backstop, not be gated.
+        ("a", False),
+        ("application/vnd.unknown.config.v1+json", False),
+        # Missing/empty config media type -> defer to the layer heuristic (not an artifact here).
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_non_image_artifact_config(config_media_type, expected):
+    assert _is_non_image_artifact_config(config_media_type) is expected
+
+
+def test_perform_indexing_skips_oci_artifact(initialized_db, set_secscan_config):
+    """
+    A non-image OCI artifact (identified by its config media type) is marked unsupported
+    before any layers are listed or any index request is sent to Clair.
+    """
+    user = model.user.get_user("devtable")
+    repo = model.repository.create_repository("devtable", "testociartifact", user)
+    repo_ref = RepositoryReference.for_repo_obj(repo)
+
+    tag_map = {}
+    structure = (3, [], ["latest"])
+    create_schema2_or_oci_manifest_for_testing(repo, structure, tag_map, schema_type="oci")
+
+    tag = registry_model.get_repo_tag(repo_ref, "latest")
+    manifest = registry_model.get_manifest_for_tag(tag)
+
+    # Force the stored manifest to look like an OCI artifact (empty config sentinel).
+    Manifest.update(config_media_type=OCI_EMPTY_CONFIG_MEDIA_TYPE).where(
+        Manifest.id == manifest._db_id
+    ).execute()
+
+    ManifestSecurityStatus.delete().execute()
+
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {
+            "err": None,
+            "state": IndexReportState.Index_Finished,
+        },
+        "abc",
+    )
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    artifact_db_id = manifest._db_id
+
+    # perform_indexing() processes every manifest in the test DB, so we spy on the real
+    # list_manifest_layers and assert only that it was never invoked for the artifact.
+    real_list_manifest_layers = registry_model.list_manifest_layers
+    listed_manifest_ids = []
+
+    def _spy_list_manifest_layers(m, *args, **kwargs):
+        listed_manifest_ids.append(m._db_id)
+        return real_list_manifest_layers(m, *args, **kwargs)
+
+    with mock.patch(
+        "data.secscan_model.secscan_v4_model.registry_model.list_manifest_layers",
+        side_effect=_spy_list_manifest_layers,
+    ):
+        secscan.perform_indexing()
+
+    # The artifact must be filtered out before its layers are ever listed.
+    assert artifact_db_id not in listed_manifest_ids
+
+    mss = ManifestSecurityStatus.get(manifest=artifact_db_id)
+    assert mss.index_status == IndexStatus.MANIFEST_UNSUPPORTED
+
+
+def test_perform_indexing_scans_image_with_nonstandard_config(initialized_db, set_secscan_config):
+    """
+    Regression guard: a real container image whose config media type is a non-standard/garbage
+    string (in production, many millions of scannable images carry the literal "a") must NOT be
+    treated as an artifact. Its layers must be listed and it must be indexed normally, because
+    the config-type gate is a denylist of known non-image sentinels, not an allowlist.
+    """
+    user = model.user.get_user("devtable")
+    repo = model.repository.create_repository("devtable", "testnonstdconfig", user)
+    repo_ref = RepositoryReference.for_repo_obj(repo)
+
+    tag_map = {}
+    structure = (3, [], ["latest"])
+    create_schema2_or_oci_manifest_for_testing(repo, structure, tag_map, schema_type="oci")
+
+    tag = registry_model.get_repo_tag(repo_ref, "latest")
+    manifest = registry_model.get_manifest_for_tag(tag)
+
+    # Force a garbage config media type on an otherwise-real image manifest.
+    Manifest.update(config_media_type="a").where(Manifest.id == manifest._db_id).execute()
+
+    ManifestSecurityStatus.delete().execute()
+
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {
+            "err": None,
+            "state": IndexReportState.Index_Finished,
+        },
+        "abc",
+    )
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    image_db_id = manifest._db_id
+
+    real_list_manifest_layers = registry_model.list_manifest_layers
+    listed_manifest_ids = []
+
+    def _spy_list_manifest_layers(m, *args, **kwargs):
+        listed_manifest_ids.append(m._db_id)
+        return real_list_manifest_layers(m, *args, **kwargs)
+
+    with mock.patch(
+        "data.secscan_model.secscan_v4_model.registry_model.list_manifest_layers",
+        side_effect=_spy_list_manifest_layers,
+    ):
+        secscan.perform_indexing()
+
+    # The image must have had its layers listed and been indexed, not gated as an artifact.
+    assert image_db_id in listed_manifest_ids
+
+    mss = ManifestSecurityStatus.get(manifest=image_db_id)
+    assert mss.index_status == IndexStatus.COMPLETED
 
 
 def test_perform_indexing_schema2_manifest(initialized_db, set_secscan_config):

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -701,6 +701,9 @@ class TestPerformIndexingCycle:
             mock_manifest = mock.Mock()
             mock_manifest.is_manifest_list = False
             mock_manifest.media_type = "application/vnd.oci.image.manifest.v1+json"
+            # A valid image config so the artifact config gate passes and we exercise the
+            # layer-based `_has_container_layers` backstop specifically.
+            mock_manifest.config_media_type = "application/vnd.oci.image.config.v1+json"
             mock_manifest._db_id = manifest_id
             mock_manifest.repository._db_id = repository_id
             mock_for_manifest.return_value = mock_manifest
@@ -720,6 +723,84 @@ class TestPerformIndexingCycle:
             ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,
         )
         assert updated.indexer_hash == "none"
+
+    def test_handles_oci_artifact_by_config(self, initialized_db, scanner):
+        """
+        A non-image OCI artifact (identified by its config media type) is marked unsupported
+        before layers are listed or Clair is called, even if its layers would otherwise pass
+        the `_has_container_layers` backstop.
+        """
+        mss = ManifestSecurityStatus.select().first()
+        manifest_id = mss.manifest_id
+        repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
+
+        ManifestSecurityStatus.update(
+            index_status=IndexStatus.IN_PROGRESS,
+        ).where(ManifestSecurityStatus.id == mss.id).execute()
+
+        with mock.patch(
+            "data.secscan_model.secscan_v4_model_v2.ManifestDataType.for_manifest"
+        ) as mock_for_manifest:
+            mock_manifest = mock.Mock()
+            mock_manifest.is_manifest_list = False
+            mock_manifest.media_type = "application/vnd.oci.image.manifest.v1+json"
+            mock_manifest.config_media_type = "application/vnd.oci.empty.v1+json"
+            mock_manifest._db_id = manifest_id
+            mock_manifest.repository._db_id = repository_id
+            mock_for_manifest.return_value = mock_manifest
+
+            with mock.patch.object(registry_model, "list_manifest_layers") as list_layers:
+                result = scanner._prepare_for_indexing(candidate)
+                # Filtered out before any layers are listed.
+                list_layers.assert_not_called()
+
+        assert result is None
+        updated = ManifestSecurityStatus.get(
+            ManifestSecurityStatus.manifest == manifest_id,
+            ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,
+        )
+        assert updated.indexer_hash == "none"
+
+    def test_indexes_image_with_nonstandard_config(self, initialized_db, scanner):
+        """
+        Regression guard: a real image whose config media type is a non-standard/garbage string
+        (in production, many millions of scannable images carry the literal "a") must NOT be
+        gated as an artifact. Its layers are listed and it proceeds to indexing, because the
+        config-type gate is a denylist of known non-image sentinels, not an allowlist.
+        """
+        mss = ManifestSecurityStatus.select().first()
+        manifest_id = mss.manifest_id
+        repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
+
+        fake_layer = mock.Mock()
+
+        with mock.patch(
+            "data.secscan_model.secscan_v4_model_v2.ManifestDataType.for_manifest"
+        ) as mock_for_manifest:
+            mock_manifest = mock.Mock()
+            mock_manifest.is_manifest_list = False
+            mock_manifest.media_type = "application/vnd.oci.image.manifest.v1+json"
+            mock_manifest.config_media_type = "a"
+            mock_manifest._db_id = manifest_id
+            mock_manifest.repository._db_id = repository_id
+            mock_for_manifest.return_value = mock_manifest
+
+            with mock.patch.object(
+                registry_model, "list_manifest_layers", return_value=[fake_layer]
+            ) as list_layers:
+                with mock.patch(
+                    "data.secscan_model.secscan_v4_model_v2._has_container_layers",
+                    return_value=True,
+                ):
+                    result = scanner._prepare_for_indexing(candidate)
+
+                # The image's layers must have been listed (not gated by config type).
+                list_layers.assert_called_once()
+
+        # Proceeds to indexing: returns (manifest, layers), not None.
+        assert result == (mock_manifest, [fake_layer])
 
     def test_scan_success_emits_notifications(self, initialized_db, scanner):
         from data.registry_model.datatypes import Manifest as ManifestDataType


### PR DESCRIPTION
Mark manifests whose config media type is the OCI "empty" sentinel (application/vnd.oci.empty.v1+json) as MANIFEST_UNSUPPORTED before listing layers or calling Clair. A real image always has a config blob, so this sentinel provably identifies a non-image artifact Clair cannot index.

These artifacts often reuse standard tar layer media types, so the existing _has_container_layers backstop misses them and they reach Clair anyway. Gating on config media type avoids those wasted round trips. Verified via the artifact_type column that no scannable images use this sentinel, so no vulnerability findings are lost.

Kept as a denylist rather than an image-config allowlist because config media type is verbatim client input and real images use non-standard values (e.g. "a"). Applied to both the v1 and v2 indexing paths, with regression tests confirming non-standard config media types still index.