### PR TITLE
[redhat-3.16] PROJQUAY-11682: fix(autoprune): re-land Cosign tag exclusion with race-safe cascade

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -41,6 +41,7 @@ component_management:
     statuses:
       - type: project
         target: auto
+        threshold: 1%
   individual_components:
     - component_id: backend
       name: Backend (Python)

--- a/data/database.py
+++ b/data/database.py
@@ -1,10 +1,12 @@
 # pylint: disable=old-style-class,no-init
 from __future__ import annotations
 
+import hashlib
 import inspect
 import logging
 import os
 import string
+import struct
 import sys
 import time
 import uuid
@@ -219,6 +221,37 @@ SCHEME_SPECIALIZED_FOR_UPDATE = {
 }
 
 
+def real_advisory_xact_lock(lock_id):
+    """Acquire a PostgreSQL transaction-scoped advisory lock.
+
+    The lock is automatically released when the transaction ends (commit or rollback).
+    Unlike row-level locks (SELECT FOR UPDATE), advisory locks do not block readers
+    and do not require locking an actual row.
+    """
+    db.execute_sql("SELECT pg_advisory_xact_lock(%s)", (lock_id,))
+
+
+def null_advisory_xact_lock(lock_id):
+    """No-op advisory lock for databases that don't support it (e.g. SQLite)."""
+    pass
+
+
+def compute_advisory_lock_id(namespace, key):
+    """Compute a deterministic 64-bit signed integer lock ID from a namespace string and
+    an integer key. The namespace prevents collisions between different lock use cases.
+
+    Returns a value in the range of a PostgreSQL bigint (-2^63 to 2^63-1).
+    """
+    h = hashlib.sha256(f"{namespace}:{key}".encode()).digest()
+    # Unpack as signed 64-bit integer to match PostgreSQL bigint range
+    return struct.unpack(">q", h[:8])[0]
+
+
+SCHEME_SPECIALIZED_ADVISORY_LOCK = {
+    "sqlite": null_advisory_xact_lock,
+}
+
+
 class CallableProxy(Proxy):
     def __call__(self, *args, **kwargs):
         if self.obj is None:
@@ -388,6 +421,7 @@ db_disallow_replica_use = CallableProxy()
 db_concat_func = CallableProxy()
 db_encrypter = Proxy()
 db_count_estimator = CallableProxy()
+db_advisory_xact_lock = CallableProxy()
 ensure_under_transaction = CallableProxy()
 
 
@@ -623,6 +657,9 @@ def configure(config_object, testing=False):
     )
     db_concat_func.initialize(
         SCHEME_SPECIALIZED_CONCAT.get(parsed_write_uri.drivername, function_concat)
+    )
+    db_advisory_xact_lock.initialize(
+        SCHEME_SPECIALIZED_ADVISORY_LOCK.get(parsed_write_uri.drivername, real_advisory_xact_lock)
     )
     db_encrypter.initialize(FieldEncrypter(config_object.get("DATABASE_SECRET_KEY")))
     db_count_estimator.initialize(SCHEME_ESTIMATOR_FUNCTION[parsed_write_uri.drivername])

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import re
 import uuid
 from calendar import timegm
 
@@ -36,6 +37,51 @@ from util.timedeltastring import convert_to_timedelta
 logger = logging.getLogger(__name__)
 
 GC_CANDIDATE_COUNT = 500  # repositories
+
+COSIGN_TAG_SCHEMA_PATTERN = r"^sha256-[a-f0-9]{64}\.(sig|att|sbom)$"
+COSIGN_TAG_SCHEMA_RE = re.compile(COSIGN_TAG_SCHEMA_PATTERN)
+COSIGN_TAG_SCHEMA_PREFIX = "sha256-"
+COSIGN_TAG_SCHEMA_DIGEST_LEN = 64
+COSIGN_TAG_SCHEMA_SUFFIXES = ("sig", "att", "sbom")
+
+
+def is_cosign_tag_schema(tag_name):
+    return bool(COSIGN_TAG_SCHEMA_RE.fullmatch(tag_name))
+
+
+def _lowercase_hex_digest_clause(digest_expr):
+    """True when digest_expr is exactly lowercase hexadecimal (empty after stripping hex digits)."""
+    stripped = digest_expr
+    for ch in "0123456789abcdef":
+        stripped = fn.REPLACE(stripped, ch, "")
+    return stripped == ""
+
+
+def _not_cosign_tag_schema_clause(model=Tag):
+    """
+    SQL clause matching is_cosign_tag_schema without REGEXP (SQLite-safe).
+
+    Requires sha256- prefix, exactly 64 lowercase hex digest chars, and a supported suffix.
+    Uses SUBSTR equality so prefix/suffix checks are case-sensitive (unlike LIKE).
+    Accepts a Tag model or alias so the clause can be used in subqueries.
+    """
+    prefix = COSIGN_TAG_SCHEMA_PREFIX
+    digest_len = COSIGN_TAG_SCHEMA_DIGEST_LEN
+    digest_expr = fn.SUBSTR(model.name, len(prefix) + 1, digest_len)
+    hex_digest = _lowercase_hex_digest_clause(digest_expr)
+    prefix_match = fn.SUBSTR(model.name, 1, len(prefix)) == prefix
+    suffix_clauses = []
+    for suffix in COSIGN_TAG_SCHEMA_SUFFIXES:
+        expected_len = len(prefix) + digest_len + 1 + len(suffix)
+        suffix_start = len(prefix) + digest_len + 1
+        suffix_clauses.append(
+            (fn.LENGTH(model.name) == expected_len)
+            & (fn.SUBSTR(model.name, suffix_start, 1 + len(suffix)) == f".{suffix}")
+        )
+    suffix_match = suffix_clauses[0]
+    for clause in suffix_clauses[1:]:
+        suffix_match = suffix_match | clause
+    return ~(prefix_match & hex_digest & suffix_match)
 
 
 class RetargetTagException(Exception):
@@ -474,7 +520,24 @@ def retarget_tag(
         existing_tag = get_tag(manifest.repository_id, tag_name)
         if existing_tag is not None:
             delete_tag_notifications_for_tag(existing_tag)
+            displaced_manifest = existing_tag.manifest
             Tag.update(lifetime_end_ms=now_ms).where(Tag.id == existing_tag.id).execute()
+
+            # Cascade Cosign cleanup for the displaced subject digest. Autoprune
+            # excludes Cosign-schema names, so orphans left by retarget would
+            # otherwise persist forever.
+            if (
+                displaced_manifest is not None
+                and not is_cosign_tag_schema(existing_tag.name)
+                and displaced_manifest.id != manifest.id
+            ):
+                _expire_cosign_sibling_tags(
+                    existing_tag.repository,
+                    displaced_manifest.digest,
+                    now_ms,
+                    subject_manifest=displaced_manifest,
+                    exclude_tag_id=existing_tag.id,
+                )
 
         # Create a new tag pointing to the manifest with a lifetime start of now.
         created = Tag.create(
@@ -490,6 +553,82 @@ def retarget_tag(
         return created
 
 
+def _expire_cosign_sibling_tags(
+    repository_id, manifest_digest, now_ms, *, subject_manifest=None, exclude_tag_id=None
+):
+    """
+    Expire alive, mutable Cosign tag-schema siblings for the given subject digest.
+
+    When subject_manifest is provided, matching rows are only expired if no other
+    visible, non-Cosign alive tag still references that manifest (excluding
+    exclude_tag_id when set). Returns the number of Cosign tags expired.
+
+    Must use the same ("retarget_tag", repository_id) advisory lock as retarget_tag
+    so the NOT EXISTS check cannot race with a concurrent push that creates a new
+    alive alias on this manifest. Re-acquiring from inside retarget_tag is safe
+    (pg_advisory_xact_lock is re-entrant within a transaction).
+
+    Each matching row gets a distinct lifetime_end_ms (<= now_ms), skipping any
+    end already used by a historical same-named Cosign row, to avoid IntegrityError
+    on Tag's unique (repository, name, lifetime_end_ms) index.
+    """
+    # Serialize with retarget_tag: same namespace+key closes the check-then-act race.
+    # Call sites may pass a Repository row or a raw id; lock key must be the integer id.
+    repo_id = getattr(repository_id, "id", repository_id)
+    lock_id = compute_advisory_lock_id("retarget_tag", repo_id)
+    db_advisory_xact_lock(lock_id)
+    cosign_tag_prefix = manifest_digest.replace(":", "-")
+    cosign_names = [f"{cosign_tag_prefix}.{suffix}" for suffix in COSIGN_TAG_SCHEMA_SUFFIXES]
+    conditions = [
+        Tag.repository == repo_id,
+        Tag.name.in_(cosign_names),
+        Tag.immutable == False,
+        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
+    ]
+    if subject_manifest is not None:
+        OtherTag = Tag.alias()
+        other_alive = OtherTag.select(1).where(
+            OtherTag.repository == repo_id,
+            OtherTag.manifest == subject_manifest,
+            OtherTag.hidden == False,
+            _not_cosign_tag_schema_clause(OtherTag),
+            (OtherTag.lifetime_end_ms >> None) | (OtherTag.lifetime_end_ms > now_ms),
+        )
+        if exclude_tag_id is not None:
+            other_alive = other_alive.where(OtherTag.id != exclude_tag_id)
+        conditions.append(~fn.EXISTS(other_alive))
+
+    matching_tags = list(Tag.select(Tag.id, Tag.name).where(*conditions))
+    updated = 0
+    increment = 0
+    for tag in matching_tags:
+        while True:
+            candidate_end = now_ms - increment
+            occupied = (
+                Tag.select(Tag.id)
+                .where(
+                    Tag.repository == repo_id,
+                    Tag.name == tag.name,
+                    Tag.lifetime_end_ms == candidate_end,
+                    Tag.id != tag.id,
+                )
+                .exists()
+            )
+            if not occupied:
+                break
+            increment += 1
+        updated += Tag.update(lifetime_end_ms=candidate_end).where(Tag.id == tag.id).execute()
+        increment += 1
+    if updated > 0:
+        logger.info(
+            "Expired %s Cosign sibling tag(s) for digest %s in repository %s",
+            updated,
+            manifest_digest,
+            repo_id,
+        )
+    return updated
+
+
 def delete_tag(repository_id, tag_name):
     """
     Deletes the alive tag with the given name in the specified repository and returns the deleted
@@ -503,7 +642,7 @@ def delete_tag(repository_id, tag_name):
     return _delete_tag(tag, get_epoch_timestamp_ms())
 
 
-def _delete_tag(tag, now_ms):
+def _delete_tag(tag, now_ms, expire_cosign=True):
     """
     Deletes the given tag by marking it as expired.
     """
@@ -526,6 +665,16 @@ def _delete_tag(tag, now_ms):
         if updated != 1:
             return None
 
+        # clean up cosign tags derived from the deleted image digest
+        if expire_cosign and not is_cosign_tag_schema(tag.name) and tag.manifest is not None:
+            _expire_cosign_sibling_tags(
+                tag.repository,
+                tag.manifest.digest,
+                now_ms,
+                subject_manifest=tag.manifest,
+                exclude_tag_id=tag.id,
+            )
+
         reset_child_manifest_expiration(tag.repository, tag.manifest)
         return tag
 
@@ -536,15 +685,33 @@ def delete_tags_for_manifest(manifest):
 
     Returns the list of tags deleted.
     """
-    query = Tag.select().where(Tag.manifest == manifest)
-    query = filter_to_alive_tags(query)
-
-    tags = list(query)
     now_ms = get_epoch_timestamp_ms()
 
     with db_transaction():
+        # Read alive tags inside the transaction so a tag retargeted/created onto
+        # this manifest between an earlier read and Cosign expiry cannot be missed.
+        query = filter_to_alive_tags(Tag.select().where(Tag.manifest == manifest))
+        tags = list(query)
+
         for tag in tags:
-            _delete_tag(tag, now_ms)
+            _delete_tag(tag, now_ms, expire_cosign=False)
+
+        # Expire Cosign siblings once after all aliases on this subject are removed.
+        subject_tag = next(
+            (
+                tag
+                for tag in tags
+                if not is_cosign_tag_schema(tag.name) and tag.manifest is not None
+            ),
+            None,
+        )
+        if subject_tag is not None:
+            _expire_cosign_sibling_tags(
+                subject_tag.repository,
+                subject_tag.manifest.digest,
+                now_ms,
+                subject_manifest=subject_tag.manifest,
+            )
 
     return tags
 
@@ -837,6 +1004,8 @@ def fetch_paginated_autoprune_repo_tags_by_number(
                 Tag.repository_id == repo_id,
                 (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
                 Tag.hidden == False,
+                Tag.immutable == False,
+                _not_cosign_tag_schema_clause(),
             )
             # TODO: Ignoring type error for now, but it seems order_by doesn't
             # return anything to be modified by offset. Need to investigate
@@ -844,7 +1013,7 @@ def fetch_paginated_autoprune_repo_tags_by_number(
         )
 
         if exclude_tags and len(exclude_tags) > 0:
-            query.where(Tag.name.not_in([tag.name for tag in exclude_tags]))
+            query = query.where(Tag.name.not_in([tag.name for tag in exclude_tags]))
 
         if tag_pattern is not None:
             query = db_regex_search(
@@ -883,6 +1052,8 @@ def fetch_paginated_autoprune_repo_tags_older_than_ms(
             (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
             (now_ms - Tag.lifetime_start_ms) > tag_lifetime_ms,
             Tag.hidden == False,
+            Tag.immutable == False,
+            _not_cosign_tag_schema_clause(),
         )
         if tag_pattern is not None:
             query = db_regex_search(

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -16,6 +16,8 @@ from data.database import (
     Tag,
     TagPullStatistics,
     User,
+    compute_advisory_lock_id,
+    db_advisory_xact_lock,
     db_random_func,
     db_regex_search,
     db_transaction,
@@ -453,15 +455,26 @@ def retarget_tag(
     now_ms = now_ms or get_epoch_timestamp_ms()
 
     with db_transaction():
-        # Lookup an existing tag in the repository with the same name and, if present, mark it
-        # as expired.
+        # Acquire an advisory lock keyed on the repository ID to serialize
+        # tag mutations for this repo. Unlike SELECT FOR UPDATE on the
+        # Repository row, advisory locks don't block unrelated reads and
+        # avoid lock-queue pileups under heavy push traffic.
+        lock_id = compute_advisory_lock_id("retarget_tag", manifest.repository_id)
+        db_advisory_xact_lock(lock_id)
+
+        try:
+            Repository.select(Repository.namespace_user).where(
+                Repository.id == manifest.repository_id
+            ).get()
+        except Repository.DoesNotExist:
+            if raise_on_error:
+                raise RetargetTagException("Repository no longer exists")
+            return None
+
         existing_tag = get_tag(manifest.repository_id, tag_name)
         if existing_tag is not None:
-            _, okay = set_tag_end_ms(existing_tag, now_ms)
-
-            # TODO: should we retry here and/or use a for-update?
-            if not okay:
-                return None
+            delete_tag_notifications_for_tag(existing_tag)
+            Tag.update(lifetime_end_ms=now_ms).where(Tag.id == existing_tag.id).execute()
 
         # Create a new tag pointing to the manifest with a lifetime start of now.
         created = Tag.create(

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -8,7 +8,7 @@ from playhouse.test_utils import assert_query_count
 
 from app import storage
 from data import model
-from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User
+from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User, db
 from data.model.blob import store_blob_record_and_temp_link
 from data.model.oci.manifest import get_or_create_manifest
 from data.model.oci.tag import (
@@ -45,6 +45,26 @@ from image.docker.schema2.list import DockerSchema2ManifestListBuilder
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from test.fixtures import *
 from util.bytes import Bytes
+
+
+def _force_delete_repository(repo_id):
+    """Delete a repository while bypassing FK constraints (works on SQLite and PostgreSQL).
+
+    Used to simulate a race condition where a repository is deleted between
+    manifest lookup and repository lookup inside retarget_tag.
+    """
+    is_sqlite = "sqlite" in type(db.obj).__name__.lower()
+    if is_sqlite:
+        db.execute_sql("PRAGMA foreign_keys = OFF")
+    else:
+        db.execute_sql("SET session_replication_role = 'replica'")
+    try:
+        Repository.delete().where(Repository.id == repo_id).execute()
+    finally:
+        if is_sqlite:
+            db.execute_sql("PRAGMA foreign_keys = ON")
+        else:
+            db.execute_sql("SET session_replication_role = 'origin'")
 
 
 def _populate_blob(content):
@@ -726,3 +746,88 @@ def _create_manifest_list(repository):
     assert created_tuple is not None
 
     return retarget_tag("manifestlist", created_tuple.manifest)
+
+
+class TestRetargetTagRaceCondition:
+    """Tests for retarget_tag race condition protection via repository locking."""
+
+    def test_retarget_tag_creates_single_active_tag(self, initialized_db):
+        """Test that multiple retarget_tag calls produce only one active tag."""
+        repo = model.repository.create_repository("devtable", "newrepo", None)
+        manifest1, _ = create_manifest_for_testing(repo, "race1")
+        manifest2, _ = create_manifest_for_testing(repo, "race2")
+
+        tag1 = retarget_tag("racelatest", manifest1.id)
+        assert tag1 is not None
+        assert tag1.lifetime_end_ms is None
+
+        tag2 = retarget_tag("racelatest", manifest2.id)
+        assert tag2 is not None
+        assert tag2.lifetime_end_ms is None
+
+        active_tags = list(
+            Tag.select().where(
+                Tag.repository == repo.id, Tag.name == "racelatest", Tag.lifetime_end_ms >> None
+            )
+        )
+        assert len(active_tags) == 1
+        assert active_tags[0].id == tag2.id
+
+        tag1_refreshed = Tag.get_by_id(tag1.id)
+        assert tag1_refreshed.lifetime_end_ms is not None
+
+    def test_retarget_tag_new_tag_no_duplicate(self, initialized_db):
+        """Test that creating a new tag doesn't create duplicates."""
+        repo = model.repository.create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "newtag1")
+
+        tag = retarget_tag("noduptag", manifest.id)
+        assert tag is not None
+        assert tag.lifetime_end_ms is None
+
+        active_tags = list(
+            Tag.select().where(
+                Tag.repository == repo.id, Tag.name == "noduptag", Tag.lifetime_end_ms >> None
+            )
+        )
+        assert len(active_tags) == 1
+
+    def test_retarget_tag_expires_previous_correctly(self, initialized_db):
+        """Test that previous tag is expired with correct timestamp."""
+        repo = model.repository.create_repository("devtable", "newrepo", None)
+        manifest1, _ = create_manifest_for_testing(repo, "expire1")
+        manifest2, _ = create_manifest_for_testing(repo, "expire2")
+
+        now_ms = get_epoch_timestamp_ms()
+        tag1 = retarget_tag("expiretag", manifest1.id, now_ms=now_ms)
+        assert tag1.lifetime_start_ms == now_ms
+
+        later_ms = now_ms + 10000
+        tag2 = retarget_tag("expiretag", manifest2.id, now_ms=later_ms)
+        assert tag2.lifetime_start_ms == later_ms
+
+        tag1_refreshed = Tag.get_by_id(tag1.id)
+        assert tag1_refreshed.lifetime_end_ms == later_ms
+
+    def test_retarget_tag_repository_not_found_returns_none(self, initialized_db):
+        """Test that retarget_tag returns None when repository no longer exists."""
+        repo = model.repository.create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "reponotfound1")
+
+        _force_delete_repository(repo.id)
+
+        result = retarget_tag("failingtag", manifest.id, raise_on_error=False)
+        assert result is None
+
+    def test_retarget_tag_repository_not_found_raises_exception(self, initialized_db):
+        """Test that retarget_tag raises exception when repository not found and raise_on_error=True."""
+        from data.model.oci.tag import RetargetTagException
+
+        repo = model.repository.create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "reponotfound2")
+
+        _force_delete_repository(repo.id)
+
+        with pytest.raises(RetargetTagException) as exc_info:
+            retarget_tag("failingtag", manifest.id, raise_on_error=True)
+        assert "Repository no longer exists" in str(exc_info.value)

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -1,22 +1,35 @@
 import json
+import os
+import threading
+import uuid
 from calendar import timegm
 from datetime import datetime, timedelta
 
 import pytest
-from mock import patch
+from mock import MagicMock, patch
+from peewee import fn
 from playhouse.test_utils import assert_query_count
 
 from app import storage
 from data import model
 from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User, db
-from data.model.blob import store_blob_record_and_temp_link
+from data.model.blob import (
+    store_blob_record_and_temp_link,
+    store_blob_record_and_temp_link_in_repo,
+)
 from data.model.oci.manifest import get_or_create_manifest
 from data.model.oci.tag import (
+    _delete_tag,
+    _expire_cosign_sibling_tags,
+    _lowercase_hex_digest_clause,
+    _not_cosign_tag_schema_clause,
     change_tag_expiration,
     create_temporary_tag_if_necessary,
     create_temporary_tag_outside_timemachine,
     delete_tag,
     delete_tags_for_manifest,
+    fetch_paginated_autoprune_repo_tags_by_number,
+    fetch_paginated_autoprune_repo_tags_older_than_ms,
     filter_to_alive_tags,
     filter_to_visible_tags,
     find_matching_tag,
@@ -28,6 +41,7 @@ from data.model.oci.tag import (
     get_most_recent_tag_lifetime_start,
     get_tag,
     get_tag_by_manifest_id,
+    is_cosign_tag_schema,
     list_alive_tags,
     list_repository_tag_history,
     lookup_alive_tags_shallow,
@@ -45,6 +59,9 @@ from image.docker.schema2.list import DockerSchema2ManifestListBuilder
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from test.fixtures import *
 from util.bytes import Bytes
+
+# Cosign cascade acquires pg_advisory_xact_lock on PostgreSQL (+1 SQL); SQLite lock is a no-op.
+_ADVISORY_LOCK_QUERY = 1 if os.environ.get("TEST_DATABASE_URI", "").startswith("postgresql") else 0
 
 
 def _force_delete_repository(repo_id):
@@ -369,7 +386,7 @@ def test_delete_tag(initialized_db):
             assert get_tag(repo, tag.name) == tag
             assert tag.lifetime_end_ms is None
 
-            with assert_query_count(5):
+            with assert_query_count(6 + _ADVISORY_LOCK_QUERY):
                 assert delete_tag(repo, tag.name) == tag
 
             assert get_tag(repo, tag.name) is None
@@ -391,7 +408,7 @@ def test_delete_tag_manifest_list(initialized_db):
             assert child_tag.name.startswith("$temp-")
             assert child_tag.lifetime_end_ms > get_epoch_timestamp_ms()
 
-        with assert_query_count(10):
+        with assert_query_count(11 + _ADVISORY_LOCK_QUERY):
             assert delete_tag(repository.id, tag.name) == tag
 
         # Assert temporary tags pointing to child manifest are now expired
@@ -409,7 +426,7 @@ def test_delete_tags_for_manifest(initialized_db):
             repo = tag.repository
             assert get_tag(repo, tag.name) == tag
 
-            with assert_query_count(7):
+            with assert_query_count(8 + _ADVISORY_LOCK_QUERY):
                 assert delete_tags_for_manifest(tag.manifest) == [tag]
 
             assert get_tag(repo, tag.name) is None
@@ -831,3 +848,666 @@ class TestRetargetTagRaceCondition:
         with pytest.raises(RetargetTagException) as exc_info:
             retarget_tag("failingtag", manifest.id, raise_on_error=True)
         assert "Repository no longer exists" in str(exc_info.value)
+
+
+def test_delete_tag_cascades_cosign_sig(initialized_db):
+    """Deleting an image tag should also expire the associated cosign .sig tag."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img1")
+        tag = retarget_tag("v1.0", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig1")
+        sig_tag = retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert sig_tag is not None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        delete_tag(repo.id, "v1.0")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tag_cascades_cosign_att_sbom(initialized_db):
+    """Deleting an image tag should also expire associated .att and .sbom tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img2")
+        tag = retarget_tag("v2.0", manifest.id)
+        assert tag is not None
+
+        digest_prefix = manifest.digest.replace(":", "-")
+        att_name = digest_prefix + ".att"
+        sbom_name = digest_prefix + ".sbom"
+        att_manifest, _ = create_manifest_for_testing(repo, "att1")
+        retarget_tag(att_name, att_manifest.id)
+        sbom_manifest, _ = create_manifest_for_testing(repo, "sbom1")
+        retarget_tag(sbom_name, sbom_manifest.id)
+        assert get_tag(repo.id, att_name) is not None
+        assert get_tag(repo.id, sbom_name) is not None
+
+        delete_tag(repo.id, "v2.0")
+        assert get_tag(repo.id, att_name) is None
+        assert get_tag(repo.id, sbom_name) is None
+
+
+def test_delete_cosign_tag_does_not_cascade_to_image(initialized_db):
+    """Deleting a .sig tag should NOT cascade back to the image tag."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img3")
+        tag = retarget_tag("v3.0", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig3")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        delete_tag(repo.id, cosign_tag_name)
+        assert get_tag(repo.id, "v3.0") is not None
+
+
+def test_stale_tag_delete_does_not_expire_cosign_tags(initialized_db):
+    """A stale optimistic delete must not expire Cosign sibling tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-stale")
+        tag = retarget_tag("v-stale", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-stale")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        # Make the in-memory tag stale: DB row already has a different lifetime_end_ms.
+        now_ms = get_epoch_timestamp_ms()
+        Tag.update(lifetime_end_ms=now_ms - 1).where(Tag.id == tag.id).execute()
+
+        assert _delete_tag(tag, now_ms) is None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_delete_tag_keeps_cosign_if_other_aliases_exist(initialized_db):
+    """Cosign siblings must remain while another alive alias still references the manifest."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-alias")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("latest", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-alias")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        delete_tag(repo.id, "v1.0")
+        assert get_tag(repo.id, cosign_tag_name) is not None
+        assert get_tag(repo.id, "latest") is not None
+
+        delete_tag(repo.id, "latest")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tag_skips_immutable_cosign_sibling(initialized_db):
+    """Immutable Cosign siblings must not be expired by cascade."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        with patch(
+            "data.model.oci.tag.features", MagicMock(IMMUTABLE_TAGS=True, IMAGE_PULL_STATS=False)
+        ):
+            repo = create_repository("devtable", "newrepo", None)
+            manifest, _ = create_manifest_for_testing(repo, "img-imm")
+            tag = retarget_tag("v-imm", manifest.id)
+            assert tag is not None
+
+            cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+            sig_manifest, _ = create_manifest_for_testing(repo, "sig-imm")
+            sig_tag = retarget_tag(cosign_tag_name, sig_manifest.id)
+            assert sig_tag is not None
+            Tag.update(immutable=True).where(Tag.id == sig_tag.id).execute()
+
+            delete_tag(repo.id, "v-imm")
+            assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_delete_tags_for_manifest_cascades_cosign_once(initialized_db):
+    """Deleting all aliases for a manifest expires Cosign siblings once."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-mtf")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("latest", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-mtf")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        deleted = delete_tags_for_manifest(manifest)
+        assert {t.name for t in deleted} == {"v1.0", "latest"}
+        assert get_tag(repo.id, "v1.0") is None
+        assert get_tag(repo.id, "latest") is None
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_sibling_tags_logs_when_rows_updated(initialized_db, caplog):
+    """Cascade logs when Cosign sibling tags are expired."""
+    import logging
+
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-log")
+        tag = retarget_tag("v-log", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-log")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        with caplog.at_level(logging.INFO, logger="data.model.oci.tag"):
+            updated = _expire_cosign_sibling_tags(
+                repo.id, manifest.digest, get_epoch_timestamp_ms()
+            )
+
+        assert updated == 1
+        assert "Expired 1 Cosign sibling tag(s)" in caplog.text
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_avoids_lifetime_end_ms_unique_collision(initialized_db):
+    """Expiring Cosign siblings must not collide with a historical same-named end.
+
+    Tag uniquely indexes (repository, name, lifetime_end_ms). Retargeting a .sig
+    at now_ms leaves a historical row ending at now_ms; cascade must still expire
+    the new alive generation without IntegrityError.
+    """
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-collision")
+        assert retarget_tag("v1.0", manifest.id) is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_old, _ = create_manifest_for_testing(repo, "sig-collision-old")
+        retarget_tag(cosign_tag_name, sig_old.id)
+
+        now_ms = get_epoch_timestamp_ms()
+        sig_new, _ = create_manifest_for_testing(repo, "sig-collision-new")
+        # Expires prior .sig generation to now_ms and creates a new alive row.
+        assert retarget_tag(cosign_tag_name, sig_new.id, now_ms=now_ms) is not None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+        assert (
+            Tag.select()
+            .where(
+                Tag.repository == repo.id,
+                Tag.name == cosign_tag_name,
+                Tag.lifetime_end_ms == now_ms,
+            )
+            .count()
+            == 1
+        )
+
+        updated = _expire_cosign_sibling_tags(repo.id, manifest.digest, now_ms)
+        assert updated == 1
+        assert get_tag(repo.id, cosign_tag_name) is None
+        # Historical row at now_ms remains; alive generation used a distinct end.
+        assert (
+            Tag.select()
+            .where(
+                Tag.repository == repo.id,
+                Tag.name == cosign_tag_name,
+                Tag.lifetime_end_ms == now_ms,
+            )
+            .count()
+            == 1
+        )
+        assert (
+            Tag.select()
+            .where(
+                Tag.repository == repo.id,
+                Tag.name == cosign_tag_name,
+                Tag.lifetime_end_ms == now_ms - 1,
+            )
+            .count()
+            == 1
+        )
+
+
+def test_expire_cosign_with_subject_manifest_without_exclude_id(initialized_db):
+    """NOT EXISTS guard works when subject_manifest is set without exclude_tag_id."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-noexcl")
+        retarget_tag("v-alive", manifest.id)
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-noexcl")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        now_ms = get_epoch_timestamp_ms()
+        # Alive alias still present: Cosign siblings must be kept.
+        assert (
+            _expire_cosign_sibling_tags(repo.id, manifest.digest, now_ms, subject_manifest=manifest)
+            == 0
+        )
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        # Soft-expire the only user-facing alias, then expire Cosign without exclude_tag_id.
+        Tag.update(lifetime_end_ms=now_ms).where(
+            Tag.repository == repo.id, Tag.name == "v-alive"
+        ).execute()
+        assert (
+            _expire_cosign_sibling_tags(repo.id, manifest.digest, now_ms, subject_manifest=manifest)
+            == 1
+        )
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_ignores_hidden_aliases(initialized_db):
+    """Hidden $temp-* tags must not block Cosign sibling expiration."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-hidden")
+        image_tag = retarget_tag("v-hidden", manifest.id)
+        assert image_tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-hidden")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        now_ms = get_epoch_timestamp_ms()
+        Tag.create(
+            name="$temp-keep-manifest",
+            repository=repo.id,
+            lifetime_start_ms=now_ms,
+            lifetime_end_ms=None,
+            reversion=False,
+            hidden=True,
+            manifest=manifest,
+            tag_kind=Tag.tag_kind.get_id("tag"),
+        )
+
+        delete_tag(repo.id, "v-hidden")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tags_for_manifest_skips_expire_when_only_cosign_tags(initialized_db):
+    """Cosign-only tags on a manifest should not trigger subject Cosign expire."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        image_manifest, _ = create_manifest_for_testing(repo, "img-only-cosign")
+        retarget_tag("v-image", image_manifest.id)
+
+        cosign_tag_name = image_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-only-cosign")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        # Deleting tags on the signature manifest itself: only Cosign-named tags.
+        deleted = delete_tags_for_manifest(sig_manifest)
+        assert {t.name for t in deleted} == {cosign_tag_name}
+        assert get_tag(repo.id, cosign_tag_name) is None
+        # Image tag must remain; no subject-digest Cosign cascade ran against it.
+        assert get_tag(repo.id, "v-image") is not None
+
+
+def test_delete_tags_for_manifest_keeps_cosign_if_alias_not_expired(initialized_db):
+    """If an alive alias is missed/not expired, Cosign siblings must not expire."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-missed")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("keep-alive", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-missed")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        import data.model.oci.tag as tag_module
+
+        real_delete = tag_module._delete_tag
+
+        def selective_delete(tag, now_ms, expire_cosign=True):
+            if tag.name == "keep-alive":
+                # Simulate a missed alias that stays alive through the Cosign expire call.
+                return tag
+            return real_delete(tag, now_ms, expire_cosign=False)
+
+        with patch("data.model.oci.tag._delete_tag", side_effect=selective_delete):
+            delete_tags_for_manifest(manifest)
+
+        assert get_tag(repo.id, "keep-alive") is not None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_retarget_tag_cascades_cosign_when_last_alias(initialized_db):
+    """Retargeting the last alias away from a manifest expires Cosign siblings."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        old_manifest, _ = create_manifest_for_testing(repo, "img-retarget-old")
+        new_manifest, _ = create_manifest_for_testing(repo, "img-retarget-new")
+        tag = retarget_tag("v1.0", old_manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = old_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        retarget_tag("v1.0", new_manifest.id)
+        assert get_tag(repo.id, "v1.0").manifest == new_manifest
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_retarget_tag_keeps_cosign_if_other_aliases_exist(initialized_db):
+    """Retargeting one alias must keep Cosign siblings while another alias remains."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        old_manifest, _ = create_manifest_for_testing(repo, "img-retarget-alias")
+        new_manifest, _ = create_manifest_for_testing(repo, "img-retarget-alias-new")
+        tag1 = retarget_tag("v1.0", old_manifest.id)
+        tag2 = retarget_tag("latest", old_manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = old_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-alias")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        retarget_tag("v1.0", new_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+        assert get_tag(repo.id, "latest") is not None
+
+        retarget_tag("latest", new_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_retarget_cosign_tag_does_not_cascade_as_subject(initialized_db):
+    """Retargeting a .sig tag must not treat its signature manifest as a Cosign subject."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        image_manifest, _ = create_manifest_for_testing(repo, "img-retarget-sig")
+        retarget_tag("v-image", image_manifest.id)
+
+        cosign_tag_name = image_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-subject")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        # Sibling named after the signature digest — would be wrongly expired if
+        # retarget treated the Cosign tag's manifest as a subject digest.
+        nested_cosign_name = sig_manifest.digest.replace(":", "-") + ".sig"
+        nested_sig_manifest, _ = create_manifest_for_testing(repo, "sig-nested")
+        retarget_tag(nested_cosign_name, nested_sig_manifest.id)
+        assert get_tag(repo.id, nested_cosign_name) is not None
+
+        new_sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-new")
+        retarget_tag(cosign_tag_name, new_sig_manifest.id)
+
+        assert get_tag(repo.id, "v-image") is not None
+        assert get_tag(repo.id, nested_cosign_name) is not None
+        assert get_tag(repo.id, cosign_tag_name).manifest == new_sig_manifest
+
+
+def test_is_cosign_tag_schema():
+    valid = "sha256-" + ("a" * 64) + ".sig"
+    assert is_cosign_tag_schema(valid)
+    assert is_cosign_tag_schema("sha256-" + ("b" * 64) + ".att")
+    assert is_cosign_tag_schema("sha256-" + ("c" * 64) + ".sbom")
+    assert not is_cosign_tag_schema("sha256-not-a-digest.sig")
+    assert not is_cosign_tag_schema("sha256-" + ("Z" * 64) + ".sig")
+    assert not is_cosign_tag_schema("SHA256-" + ("a" * 64) + ".sig")
+    assert not is_cosign_tag_schema("sha256-" + ("a" * 64) + ".SIG")
+    assert not is_cosign_tag_schema("sha256-" + ("a" * 64) + ".sig\n")
+    assert not is_cosign_tag_schema("latest")
+
+
+def test_lowercase_hex_digest_clause_builds_expression():
+    clause = _lowercase_hex_digest_clause(fn.SUBSTR(Tag.name, 8, 64))
+    assert clause is not None
+
+
+def test_not_cosign_tag_schema_clause_builds_expression(initialized_db):
+    clause = _not_cosign_tag_schema_clause()
+    assert clause is not None
+    # Alias form is used by the Cosign expire NOT EXISTS subquery.
+    assert _not_cosign_tag_schema_clause(Tag.alias()) is not None
+
+
+def test_autoprune_excludes_valid_cosign_tags(initialized_db):
+    """Valid Cosign tag-schema names are excluded from both autoprune fetchers."""
+    repo = create_repository("devtable", "newrepo", None)
+    image_manifest, _ = create_manifest_for_testing(repo, "img-ap1")
+    retarget_tag("v1", image_manifest.id)
+
+    cosign_sig = "sha256-" + ("a" * 64) + ".sig"
+    cosign_att = "sha256-" + ("b" * 64) + ".att"
+    cosign_sbom = "sha256-" + ("c" * 64) + ".sbom"
+    lookalike_short = "sha256-not-a-digest.sig"
+    lookalike_non_hex = "sha256-" + ("Z" * 64) + ".sig"
+    lookalike_upper_prefix = "SHA256-" + ("d" * 64) + ".sig"
+    lookalike_upper_suffix = "sha256-" + ("e" * 64) + ".SIG"
+    for name, blob_id in (
+        (cosign_sig, "sig-ap1"),
+        (cosign_att, "att-ap1"),
+        (cosign_sbom, "sbom-ap1"),
+        (lookalike_short, "lookalike-ap1"),
+        (lookalike_non_hex, "lookalike-nonhex-ap1"),
+        (lookalike_upper_prefix, "lookalike-upper-prefix-ap1"),
+        (lookalike_upper_suffix, "lookalike-upper-suffix-ap1"),
+    ):
+        manifest, _ = create_manifest_for_testing(repo, blob_id)
+        retarget_tag(name, manifest.id)
+
+    excluded = {cosign_sig, cosign_att, cosign_sbom}
+    included = {
+        "v1",
+        lookalike_short,
+        lookalike_non_hex,
+        lookalike_upper_prefix,
+        lookalike_upper_suffix,
+    }
+
+    # Keep 0 tags so every eligible tag is returned by the number-based fetcher.
+    by_number_names = {
+        tag.name for tag in fetch_paginated_autoprune_repo_tags_by_number(repo.id, 0, 100, 1)
+    }
+    assert included.issubset(by_number_names)
+    assert by_number_names.isdisjoint(excluded)
+
+    # Age threshold of 0 ms makes every alive tag eligible by creation date.
+    by_date_names = {
+        tag.name for tag in fetch_paginated_autoprune_repo_tags_older_than_ms(repo.id, 0, 100, 1)
+    }
+    assert included.issubset(by_date_names)
+    assert by_date_names.isdisjoint(excluded)
+
+
+def test_autoprune_by_number_exclude_tags(initialized_db):
+    """exclude_tags removes already-selected tags from the number-based fetcher."""
+    repo = create_repository("devtable", "newrepo", None)
+    m1, _ = create_manifest_for_testing(repo, "img-ex1")
+    m2, _ = create_manifest_for_testing(repo, "img-ex2")
+    t1 = retarget_tag("keep-me", m1.id)
+    retarget_tag("prune-me", m2.id)
+
+    tags = fetch_paginated_autoprune_repo_tags_by_number(repo.id, 0, 100, 1, exclude_tags=[t1])
+    names = {tag.name for tag in tags}
+    assert "keep-me" not in names
+    assert "prune-me" in names
+
+
+def test_autoprune_excludes_cosign_tags_with_pattern(initialized_db):
+    """Cosign tags stay excluded even when a tag_pattern would otherwise match them."""
+    repo = create_repository("devtable", "newrepo", None)
+    image_manifest, _ = create_manifest_for_testing(repo, "img-pat")
+    retarget_tag("sha256-image", image_manifest.id)
+
+    cosign_sig = "sha256-" + ("a" * 64) + ".sig"
+    sig_manifest, _ = create_manifest_for_testing(repo, "sig-pat")
+    retarget_tag(cosign_sig, sig_manifest.id)
+
+    by_number_names = {
+        tag.name
+        for tag in fetch_paginated_autoprune_repo_tags_by_number(
+            repo.id, 0, 100, 1, tag_pattern="sha256-.*"
+        )
+    }
+    assert "sha256-image" in by_number_names
+    assert cosign_sig not in by_number_names
+
+    by_date_names = {
+        tag.name
+        for tag in fetch_paginated_autoprune_repo_tags_older_than_ms(
+            repo.id, 0, 100, 1, tag_pattern="sha256-.*"
+        )
+    }
+    assert "sha256-image" in by_date_names
+    assert cosign_sig not in by_date_names
+
+
+def test_delete_tag_skips_cosign_cleanup_when_manifest_null(initialized_db):
+    """Tags without a manifest still expire; Cosign cascade is skipped."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        now_ms = get_epoch_timestamp_ms()
+        tag = Tag.create(
+            name="no-manifest",
+            repository=repo.id,
+            lifetime_start_ms=now_ms,
+            lifetime_end_ms=None,
+            reversion=False,
+            hidden=False,
+            manifest=None,
+            tag_kind=Tag.tag_kind.get_id("tag"),
+        )
+        deleted = _delete_tag(tag, now_ms)
+        assert deleted is not None
+        refreshed = Tag.get_by_id(tag.id)
+        assert refreshed.lifetime_end_ms == now_ms
+
+
+def _create_manifest_in_repo(repository, differentiation_field="1"):
+    """Like create_manifest_for_testing, but links blobs to ``repository`` (not hardcoded newrepo)."""
+    layer_json = json.dumps(
+        {
+            "config": {},
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [],
+        }
+    )
+    content = Bytes.for_string_or_unicode(layer_json).as_encoded_str()
+    config_digest = str(sha256_digest(content))
+    location = ImageStorageLocation.get(name="local_us")
+    blob = store_blob_record_and_temp_link_in_repo(
+        repository.id, config_digest, location, len(content), 120
+    )
+    storage.put_content(["local_us"], get_layer_path(blob), content)
+
+    remote_digest = sha256_digest(b"something")
+    builder = DockerSchema2ManifestBuilder()
+    builder.set_config_digest(config_digest, len(content))
+    builder.add_layer(remote_digest, 1234, urls=["http://hello/world" + differentiation_field])
+    manifest = builder.build()
+    created = get_or_create_manifest(repository, manifest, storage, raise_on_error=True)
+    assert created
+    return created.manifest, manifest
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URI", "").startswith("postgresql"),
+    reason="Advisory locks / multi-connection race coverage require PostgreSQL",
+)
+def test_cascade_serialized_with_concurrent_retarget(initialized_db):
+    """
+    Concurrent retarget that creates a new alive alias must prevent cascade from
+    expiring Cosign siblings. The shared advisory lock serializes the paths.
+
+    Setup is committed so worker-thread connections can see the fixtures;
+    initialized_db's savepoint would otherwise hide them from other sessions.
+    Cleanup uses purge_repository (same as test_gc) so committed CAS rows do not
+    poison later assert_gc_integrity checks.
+    """
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        # Unique name so a failed cleanup cannot pollute shared "newrepo" used by GC tests.
+        repo = create_repository("devtable", f"race-{uuid.uuid4().hex[:12]}", None)
+        assert repo is not None
+        repo_id = repo.id
+        try:
+            manifest, _ = _create_manifest_in_repo(repo, "img-race")
+            assert retarget_tag("v1.0", manifest.id) is not None
+            manifest_id = manifest.id
+
+            cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+            sig_manifest, _ = _create_manifest_in_repo(repo, "sig-race")
+            retarget_tag(cosign_tag_name, sig_manifest.id)
+            assert get_tag(repo_id, cosign_tag_name) is not None
+
+            # Publish fixtures to other connections (worker threads).
+            db.commit()
+
+            barrier = threading.Barrier(2, timeout=10)
+            retarget_done = threading.Event()
+            errors = []
+            results = {}
+            expire_tls = threading.local()
+            real_expire = _expire_cosign_sibling_tags
+
+            def expire_seam(*args, **kwargs):
+                # Only the delete worker sets wait_for_retarget; retarget path is unchanged.
+                if getattr(expire_tls, "wait_for_retarget", False):
+                    if not retarget_done.wait(timeout=10):
+                        raise TimeoutError("timed out waiting for concurrent retarget")
+                return real_expire(*args, **kwargs)
+
+            def thread_delete():
+                try:
+                    barrier.wait()
+                    expire_tls.wait_for_retarget = True
+                    with db.connection_context():
+                        results["deleted"] = delete_tag(repo_id, "v1.0")
+                except Exception as exc:  # pragma: no cover - surfaced via errors list
+                    errors.append(exc)
+
+            def thread_retarget():
+                try:
+                    barrier.wait()
+                    with db.connection_context():
+                        results["retarget"] = retarget_tag("v2.0", manifest_id)
+                    retarget_done.set()
+                except Exception as exc:  # pragma: no cover - surfaced via errors list
+                    errors.append(exc)
+                    retarget_done.set()
+
+            with patch(
+                "data.model.oci.tag._expire_cosign_sibling_tags",
+                side_effect=expire_seam,
+            ):
+                t_delete = threading.Thread(target=thread_delete)
+                t_retarget = threading.Thread(target=thread_retarget)
+                t_delete.start()
+                t_retarget.start()
+                t_delete.join(timeout=15)
+                t_retarget.join(timeout=15)
+                assert not t_delete.is_alive(), "delete worker did not finish within timeout"
+                assert not t_retarget.is_alive(), "retarget worker did not finish within timeout"
+
+            assert not errors, errors
+            assert results.get("deleted") is not None
+            assert results.get("retarget") is not None
+            assert get_tag(repo_id, "v2.0") is not None
+            assert get_tag(repo_id, cosign_tag_name) is not None
+        finally:
+            # Same path as test_gc: purge tags/manifests/blobs (incl. ImageStorage) then
+            # delete the repo. Commit so cleanup survives the fixture savepoint.
+            try:
+                repo_to_purge = Repository.get_by_id(repo_id)
+            except Repository.DoesNotExist:
+                repo_to_purge = None
+            if repo_to_purge is not None:
+                model.gc.purge_repository(repo_to_purge, force=True)
+            db.commit()

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -2,8 +2,13 @@ import datetime
 import inspect
 import os
 import shutil
+import subprocess
+import sys
 from collections import namedtuple
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+import psycopg2  # type: ignore[import]
 import pytest
 from filelock import FileLock
 from flask import Flask, jsonify
@@ -13,6 +18,7 @@ from flask_mail import Mail
 from flask_principal import Principal, identity_loaded
 from mock import patch
 from peewee import InternalError, SqliteDatabase
+from psycopg2 import sql
 
 import features
 
@@ -75,28 +81,101 @@ def _init_db_path(tmpdir_factory):
     return _init_db_path_sqlite(tmpdir_factory)
 
 
+def _test_database_schema():
+    """Return the isolated PostgreSQL schema for this pytest process."""
+    db_uri = os.environ.get("TEST_DATABASE_URI", "")
+    if not db_uri.startswith("postgresql"):
+        return None
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    return "quay_test_{}".format(worker_id.replace("-", "_"))
+
+
+def _database_uri_for_schema(db_uri, schema):
+    """Add a PostgreSQL search path for the isolated test schema."""
+    parsed = urlsplit(db_uri)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["options"] = "-c search_path={},public".format(schema)
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment)
+    )
+
+
+def _create_test_schema(db_uri, schema):
+    """Create a clean schema for one pytest-xdist worker."""
+    connection = psycopg2.connect(db_uri)
+    try:
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            identifier = sql.Identifier(schema)
+            cursor.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(identifier))
+            cursor.execute(sql.SQL("CREATE SCHEMA {}").format(identifier))
+            cursor.execute(
+                sql.SQL(
+                    "CREATE TABLE {}.alembic_version "
+                    "(version_num VARCHAR(32) NOT NULL, "
+                    "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+                ).format(identifier)
+            )
+    finally:
+        connection.close()
+
+
 def _init_db_path_real_db(db_uri):
     """
-    Initializes a real database for testing by populating it from scratch. Note that this does.
+    Initializes a real database for testing by populating it from scratch.
 
-    *not* add the tables (merely data). Callers must have migrated the database before calling
-    the test suite.
+    Each pytest-xdist worker gets a separate PostgreSQL schema. The schema is migrated before the
+    application connects so that all unqualified table names resolve inside that schema.
     """
+    schema = _test_database_schema()
+    if schema is None:
+        configure(
+            {
+                "DB_URI": db_uri,
+                "SECRET_KEY": "superdupersecret!!!1",
+                "DB_CONNECTION_ARGS": {
+                    "threadlocals": True,
+                    "autorollback": True,
+                },
+                "DB_TRANSACTION_FACTORY": _create_transaction,
+                "DATABASE_SECRET_KEY": "anothercrazykey!",  # gitleaks:allow
+            }
+        )
+        populate_database()
+        return db_uri
+
+    worker_db_uri = _database_uri_for_schema(db_uri, schema)
+    _create_test_schema(db_uri, schema)
+
+    migration_environment = os.environ.copy()
+    migration_environment["TEST_DATABASE_URI"] = worker_db_uri
+    migration_environment["DB_URI"] = worker_db_uri
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        check=True,
+        cwd=Path(__file__).resolve().parents[1],
+        env=migration_environment,
+        timeout=300,
+    )
+
+    connection_args = {
+        "threadlocals": True,
+        "autorollback": True,
+        "options": "-c search_path={},public".format(schema),
+    }
     configure(
         {
-            "DB_URI": db_uri,
+            "DB_URI": worker_db_uri,
             "SECRET_KEY": "superdupersecret!!!1",
-            "DB_CONNECTION_ARGS": {
-                "threadlocals": True,
-                "autorollback": True,
-            },
+            "DB_CONNECTION_ARGS": connection_args,
             "DB_TRANSACTION_FACTORY": _create_transaction,
-            "DATABASE_SECRET_KEY": "anothercrazykey!",
+            "DATABASE_SECRET_KEY": "anothercrazykey!",  # gitleaks:allow
         }
     )
 
     populate_database()
-    return db_uri
+    return worker_db_uri
 
 
 def _init_db_path_sqlite(tmpdir_factory):
@@ -110,7 +189,7 @@ def _init_db_path_sqlite(tmpdir_factory):
         "TESTING": True,
         "DEBUG": True,
         "SECRET_KEY": "superdupersecret!!!1",
-        "DATABASE_SECRET_KEY": "anothercrazykey!",
+        "DATABASE_SECRET_KEY": "anothercrazykey!",  # gitleaks:allow
         "DB_URI": sqlitedb,
     }
     os.environ["DB_URI"] = str(sqlitedb)
@@ -137,7 +216,7 @@ def database_uri(monkeypatch, init_db_path, sqlitedb_file):
     reference to the existing database URI is returned.
     """
     if os.environ.get("TEST_DATABASE_URI"):
-        db_uri = os.environ["TEST_DATABASE_URI"]
+        db_uri = init_db_path
         monkeypatch.setenv("DB_URI", db_uri)
         yield db_uri
     else:
@@ -178,10 +257,14 @@ def appconfig(database_uri):
         "DEBUG": True,
         "DB_URI": database_uri,
         "SECRET_KEY": "superdupersecret!!!1",
-        "DATABASE_SECRET_KEY": "anothercrazykey!",
         "DB_CONNECTION_ARGS": {
             "threadlocals": True,
             "autorollback": True,
+            **(
+                {"options": "-c search_path={},public".format(_test_database_schema())}
+                if database_uri.startswith("postgresql")
+                else {}
+            ),
         },
         "DB_TRANSACTION_FACTORY": _create_transaction,
         "DATA_MODEL_CACHE_CONFIG": {
@@ -190,7 +273,7 @@ def appconfig(database_uri):
         "USERFILES_PATH": "userfiles/",
         "MAIL_SERVER": "",
         "MAIL_DEFAULT_SENDER": "admin@example.com",
-        "DATABASE_SECRET_KEY": "anothercrazykey!",
+        "DATABASE_SECRET_KEY": "anothercrazykey!",  # gitleaks:allow
         "FEATURE_PROXY_CACHE": True,
         "ACTION_LOG_AUDIT_LOGINS": True,
         "ACTION_LOG_AUDIT_LOGIN_FAILURES": True,

--- a/test/test_fixtures.py
+++ b/test/test_fixtures.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+
+from data.database import db
+from test.fixtures import *
+from test.fixtures import _database_uri_for_schema, _test_database_schema
+
+
+def test_test_database_schema_uses_xdist_worker(monkeypatch):
+    monkeypatch.setenv("TEST_DATABASE_URI", "postgresql://quay:quay@localhost/quay_ci")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+
+    assert _test_database_schema() == "quay_test_gw3"
+
+
+def test_test_database_schema_uses_main_without_xdist(monkeypatch):
+    monkeypatch.setenv("TEST_DATABASE_URI", "postgresql://quay:quay@localhost/quay_ci")
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+    assert _test_database_schema() == "quay_test_main"
+
+
+def test_test_database_schema_is_disabled_for_mysql(monkeypatch):
+    monkeypatch.setenv("TEST_DATABASE_URI", "mysql://quay:quay@localhost/quay_ci")
+
+    assert _test_database_schema() is None
+
+
+def test_database_uri_for_schema_sets_postgresql_search_path():
+    uri = "postgresql://quay:quay@localhost/quay_ci?connect_timeout=5"
+
+    isolated_uri = _database_uri_for_schema(uri, "quay_test_gw0")
+
+    assert "connect_timeout=5" in isolated_uri
+    assert "options=-c+search_path%3Dquay_test_gw0%2Cpublic" in isolated_uri
+
+
+def test_postgresql_fixture_uses_worker_schema(initialized_db):
+    if not os.environ.get("TEST_DATABASE_URI", "").startswith("postgresql"):
+        pytest.skip("PostgreSQL-only fixture validation")
+
+    current_schema, search_path = db.obj.execute_sql(
+        "SELECT current_schema(), current_setting('search_path')"
+    ).fetchone()
+    manifest_schema = db.obj.execute_sql(
+        "SELECT table_schema FROM information_schema.tables "
+        "WHERE table_name = 'manifest' AND table_schema = current_schema()"
+    ).fetchone()[0]
+
+    assert current_schema == _test_database_schema()
+    assert search_path.split(",")[0].strip() == _test_database_schema()
+    assert manifest_schema == _test_database_schema()

--- a/web/playwright/e2e/repository/autopruning.spec.ts
+++ b/web/playwright/e2e/repository/autopruning.spec.ts
@@ -16,7 +16,32 @@
 
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImage, pushMultiArchImage} from '../../utils/container';
+import {ApiClient} from '../../utils/api';
+import {
+  pushImage,
+  pushMultiArchImage,
+  pushUniqueImage,
+} from '../../utils/container';
+
+/**
+ * Creates a Cosign tag-schema `.sig` tag for an image tag
+ * (`sha256-<hex>.sig` pointing at the image digest).
+ */
+async function createCosignSigTag(
+  api: ApiClient,
+  namespace: string,
+  repo: string,
+  imageTag: string,
+): Promise<string> {
+  const tags = await api.getTags(namespace, repo, {specificTag: imageTag});
+  if (tags.tags.length === 0) {
+    throw new Error(`Tag ${imageTag} not found in ${namespace}/${repo}`);
+  }
+  const digest = tags.tags[0].manifest_digest;
+  const sigName = `${digest.replace(':', '-')}.sig`;
+  await api.createTag(namespace, repo, sigName, digest);
+  return sigName;
+}
 
 test.describe(
   'Repository Auto-Prune Policies',
@@ -717,5 +742,113 @@ test.describe(
       expect(names).toContain('v3');
       expect(names).toContain('v4');
     });
+
+    test(
+      'tag-count pruning excludes cosign .sig tags and cascades on prune',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        test.slow();
+        const org = await api.organization('prunesigcnt');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        // Unique digests so each image tag gets a distinct Cosign .sig name
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+
+        const sigV1 = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+        const sigV2 = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v2',
+        );
+        expect(sigV1).not.toBe(sigV2);
+
+        const tagsBefore = await api.raw.getTags(org.name, repo.name);
+        expect(tagsBefore.tags).toHaveLength(4);
+
+        await api.repoAutoPrunePolicy(org.name, repo.name, {
+          method: 'number_of_tags',
+          value: 1,
+        });
+
+        // Keep-1 only counts image tags: prune v1 (and cascade its .sig), keep v2 + .sig
+        await expect(async () => {
+          const tags = await api.raw.getTags(org.name, repo.name);
+          const names = tags.tags.map((t) => t.name);
+          expect(names).toContain('v2');
+          expect(names).toContain(sigV2);
+          expect(names).not.toContain('v1');
+          expect(names).not.toContain(sigV1);
+          expect(tags.tags).toHaveLength(2);
+        }).toPass({timeout: 120_000, intervals: [5_000]});
+      },
+    );
+
+    test(
+      'creation-date pruning does not age-prune cosign .sig tags',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        test.slow();
+        const org = await api.organization('prunesigage');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const digest = v1Tags.tags[0].manifest_digest;
+
+        // Age both tags past the upcoming 60s policy threshold
+        await new Promise((r) => setTimeout(r, 70_000));
+
+        // Refresh only the image tag so it is young; .sig stays old
+        await api.raw.createTag(org.name, repo.name, 'v1', digest);
+
+        await api.repoAutoPrunePolicy(org.name, repo.name, {
+          method: 'creation_date',
+          value: '60s',
+        });
+
+        // One prune cycle: .sig (~115s) would age-prune without exclusion;
+        // refreshed v1 (~45s) stays under the 60s threshold
+        await new Promise((r) => setTimeout(r, 45_000));
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain(sigName);
+      },
+    );
   },
 );

--- a/web/playwright/e2e/repository/repository-delete.spec.ts
+++ b/web/playwright/e2e/repository/repository-delete.spec.ts
@@ -1,5 +1,28 @@
 import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
 import {API_URL} from '../../utils/config';
+import {pushImage, pushUniqueImage} from '../../utils/container';
+
+/**
+ * Creates a Cosign tag-schema `.sig` tag for an image tag
+ * (`sha256-<hex>.sig` pointing at the image digest).
+ */
+async function createCosignSigTag(
+  api: ApiClient,
+  namespace: string,
+  repo: string,
+  imageTag: string,
+): Promise<string> {
+  const tags = await api.getTags(namespace, repo, {specificTag: imageTag});
+  if (tags.tags.length === 0) {
+    throw new Error(`Tag ${imageTag} not found in ${namespace}/${repo}`);
+  }
+  const digest = tags.tags[0].manifest_digest;
+  const sigName = `${digest.replace(':', '-')}.sig`;
+  await api.createTag(namespace, repo, sigName, digest);
+  return sigName;
+}
 
 test.describe('Repository Delete', {tag: ['@repository']}, () => {
   test('deletes repository via settings page and verifies removal', async ({
@@ -160,3 +183,194 @@ test.describe('Repository Delete', {tag: ['@repository']}, () => {
     await expect(deleteButton).toBeEnabled();
   });
 });
+
+test.describe(
+  'Cosign tag cascade on delete and retarget',
+  {tag: ['@repository', '@container']},
+  () => {
+    const user = TEST_USERS.user;
+
+    test(
+      'deleting subject image tag cascades to cosign .sig tag',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigdel');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        const tagsBefore = await api.raw.getTags(org.name, repo.name);
+        expect(tagsBefore.tags.map((t) => t.name)).toEqual(
+          expect.arrayContaining(['v1', sigName]),
+        );
+
+        await api.raw.deleteTag(org.name, repo.name, 'v1');
+
+        const tagsAfter = await api.raw.getTags(org.name, repo.name);
+        const names = tagsAfter.tags.map((t) => t.name);
+        expect(names).not.toContain('v1');
+        expect(names).not.toContain(sigName);
+      },
+    );
+
+    test(
+      'deleting one alias keeps cosign .sig while another alias remains',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigalias');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const digest = v1Tags.tags[0].manifest_digest;
+        await api.raw.createTag(org.name, repo.name, 'latest', digest);
+
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await api.raw.deleteTag(org.name, repo.name, 'v1');
+
+        let tags = await api.raw.getTags(org.name, repo.name);
+        let names = tags.tags.map((t) => t.name);
+        expect(names).toContain('latest');
+        expect(names).toContain(sigName);
+        expect(names).not.toContain('v1');
+
+        await api.raw.deleteTag(org.name, repo.name, 'latest');
+
+        tags = await api.raw.getTags(org.name, repo.name);
+        names = tags.tags.map((t) => t.name);
+        expect(names).not.toContain('latest');
+        expect(names).not.toContain(sigName);
+      },
+    );
+
+    test(
+      'retargeting last alias cascades cosign .sig for displaced digest',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigretarget');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+        const v2Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v2',
+        });
+        const newDigest = v2Tags.tags[0].manifest_digest;
+
+        // Retarget v1 onto v2's digest (displaces the old subject)
+        await api.raw.createTag(org.name, repo.name, 'v1', newDigest);
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain('v2');
+        expect(names).not.toContain(sigName);
+
+        const v1After = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        expect(v1After.tags[0].manifest_digest).toBe(newDigest);
+      },
+    );
+
+    test(
+      'retargeting one alias keeps cosign .sig while another alias remains',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigretkeep');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const oldDigest = v1Tags.tags[0].manifest_digest;
+        await api.raw.createTag(org.name, repo.name, 'latest', oldDigest);
+
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+        const v2Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v2',
+        });
+        const newDigest = v2Tags.tags[0].manifest_digest;
+
+        // Retarget only v1; latest still references oldDigest
+        await api.raw.createTag(org.name, repo.name, 'v1', newDigest);
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain('latest');
+        expect(names).toContain(sigName);
+
+        const latestTags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'latest',
+        });
+        expect(latestTags.tags[0].manifest_digest).toBe(oldDigest);
+      },
+    );
+  },
+);


### PR DESCRIPTION
- Backport [#6041](https://github.com/quay/quay/pull/6041): serialize `retarget_tag` with PostgreSQL `pg_advisory_xact_lock` instead of `SELECT FOR UPDATE` on the repository row, so tag mutations do not block unrelated reads under heavy push traffic. SQLite keeps a no-op lock.
- Backport [#6788](https://github.com/quay/quay/pull/6788): exclude Cosign schema tags (`sha256-<digest>.sig|.att|.sbom`) from autoprune, and expire Cosign siblings when the last subject alias is deleted or retargeted. Cascade uses the same `("retarget_tag", repo_id)` advisory lock so it cannot race with a concurrent push. Also fixes `exclude_tags` (`query = query.where(...)`).

#6041 is required first so #6788 can use advisory locks (as on master / 3.18/.17) rather than row `FOR UPDATE`
#6623 Give pytest-xdist workers their own PostgreSQL schemas so parallel CI tests do not share one database and flake on races or leftover rows.