### PR TITLE
[redhat-3.17] PROJQUAY-11934: fix(ui): import patternfly-charts.css for dark mode chart support

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,6 +1,7 @@
 /* Global Styles */
 @import '~@patternfly/patternfly/patternfly.css';
 @import '~@patternfly/patternfly/patternfly-addons.css';
+@import '~@patternfly/patternfly/patternfly-charts.css';
 
 html, body, #root,  .App {
   height: 100%;

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
@@ -1,3 +1,0 @@
-.pf-v6-theme-dark {
-    --pf-v6-chart-donut--label--title--Fill: var(--pf-t--global--text--color--brand--hover);
-}

--- a/web/src/routes/UsageLogs/css/UsageLogs.scss
+++ b/web/src/routes/UsageLogs/css/UsageLogs.scss
@@ -11,7 +11,3 @@
   max-height: 200px;
   width: 1200px;
 }
-
-.pf-v6-theme-dark {
-  --pf-v6-chart-global--label--Fill: var(--pf-t--global--text--color--brand--hover);
-}


### PR DESCRIPTION
## Summary
- Backport #6215 to redhat-3.17.
- Import PatternFly chart styles for dark-mode chart labels.
- Remove the obsolete v5 chart-label overrides while preserving the usage-log legend container.

## Verification
- `npm ci && npm run build` (web)
- Confirmed no merge-conflict markers remain.