### PR TITLE
NO-ISSUE: fix(ci): install surge globally in playwright report deploy

### DIFF
--- a/.github/workflows/playwright-report-deploy.yaml
+++ b/.github/workflows/playwright-report-deploy.yaml
@@ -52,6 +52,10 @@ jobs:
         PR_NUMBER=$(cat pr-info/pr_number.txt)
         echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
+    - name: Install Surge CLI
+      if: steps.download-report.outputs.found_artifact == 'true' && steps.download-pr-info.outputs.found_artifact == 'true'
+      run: npm install -g surge
+
     - name: Deploy to Surge
       id: deploy
       if: steps.download-report.outputs.found_artifact == 'true' && steps.download-pr-info.outputs.found_artifact == 'true'
@@ -60,8 +64,7 @@ jobs:
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       run: |
         DEPLOY_DOMAIN="quay-playwright-pr-${PR_NUMBER}.surge.sh"
-        cd playwright-report
-        npx surge . "$DEPLOY_DOMAIN" --token "$SURGE_TOKEN"
+        surge ./playwright-report "$DEPLOY_DOMAIN" --token "$SURGE_TOKEN"
         echo "url=https://$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
 
     - name: Comment PR with report URL


### PR DESCRIPTION
## Summary
- Install surge globally (`npm install -g surge`) instead of relying on `npx` for the playwright report deployment
- Invoke surge from the workspace root with an explicit path to the report directory, rather than `cd`ing into it

## Test plan
- [ ] Verify a PR with web changes triggers the playwright report deploy workflow
- [ ] Confirm the report is deployed successfully to `quay-playwright-pr-*.surge.sh`
- [ ] Confirm the PR comment is posted with the report URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)