### PR TITLE
NO-ISSUE: fix(cve): CVE-2026-69152 - brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,9 +1175,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12971,9 +12971,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -17384,7 +17384,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^1.1.18"
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "qs": "^6.14.0",
     "tmp": "^0.2.6",
     "form-data": "^2.5.6",
+    "brace-expansion": "^1.1.18",
     "browserslist": ">=4.28.7"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5025,8 +5025,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -139,6 +139,7 @@
     "svgo": "4.0.1",
     "immutable": "^5.1.5",
     "fast-uri": "^3.1.4",
+    "brace-expansion": "^1.1.18",
     "browserslist": ">=4.28.7"
   },
   "pnpm": {
@@ -157,6 +158,7 @@
       "svgo": "4.0.1",
       "immutable": "^5.1.5",
       "fast-uri": "^3.1.4",
+      "brace-expansion": "^1.1.18",
       "browserslist": ">=4.28.7"
     }
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   svgo: 4.0.1
   immutable: ^5.1.5
   fast-uri: ^3.1.4
+  brace-expansion: ^1.1.18
   browserslist: '>=4.28.7'
 
 importers:
@@ -2133,7 +2134,7 @@ packages:
   axios-mock-adapter@1.22.0:
     resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
     peerDependencies:
-      axios: ^1.16.1
+      axios: ^1.19.0
 
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
@@ -2207,8 +2208,8 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8317,7 +8318,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10735,7 +10736,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Summary

```
Security fix for # CVE-2026-69152 affecting brace-expansion
```

Details

```
CVE: # CVE-2026-69152
Severity: Important (CVSSv3: 7.5)
Impact: # Denial of Service via unbounded intermediate arrays
Component: brace-expansion
Old Version: 1.1.16
New Version: 1.1.18
```

Changes

```
Updated brace-expansion from 1.1.16 to 1.1.18 in web/package.json
Updated brace-expansion from 1.1.16 to 1.1.18 in web/package-lock.json
Updated brace-expansion from 1.1.16 to 1.1.18 in package.json
Updated brace-expansion from 1.1.16 to 1.1.18 in package-lock.json
```

References

```
https://www.cve.org/CVERecord?id=CVE-2026-69152
https://www.npmjs.com/package/brace-expansion
```