### PR TITLE
NO-ISSUE: optimize: Minimize contention on database connection pool

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -503,26 +503,15 @@ class ObservablePooledDatabase(ObservableDatabase):
                 f"Unable to obtain healthy connection after {max_retries} attempts"
             )
 
-        try:
-            conn = super(ObservablePooledDatabase, self)._connect()
-        except MaxConnectionsExceeded:
-            # Pool exhausted - wait with exponential backoff before retrying
-            # Base delay: 10ms, max delay: 200ms to prevent long waits
-            delay = min(0.01 * (2**_retry_count), 0.2)
-            # Add jitter to prevent thundering herd (±25% randomization)
-            jitter = delay * (0.75 + uniform(0, 0.5))
-            logger.debug(
-                "Connection pool exhausted (attempt %d/%d), retrying after %.3fs",
-                _retry_count + 1,
-                max_retries,
-                jitter,
-            )
-            time.sleep(jitter)
-            return self._connect(_retry_count=_retry_count + 1)
+        # try and establish a connection
+        # if the call fails, the exception will propagate downwards, which is what we want
+        conn = super(ObservablePooledDatabase, self)._connect()
 
         try:
             with conn.cursor() as cursor:
                 cursor.execute("SELECT 1")
+                # roll back the request immediately so it doesn't end in IDLE_IN_TRANSACTION
+                conn.rollback()
             return conn  # Connection is healthy
         except Exception as e:
             # Catch ALL exceptions during liveness check - includes ProtocolViolation,
@@ -554,7 +543,30 @@ class ObservablePooledDatabase(ObservableDatabase):
             return self._connect(_retry_count=_retry_count + 1)
 
     def connect(self, reuse_if_open=False):
-        ret = super(ObservablePooledDatabase, self).connect(reuse_if_open)
+        max_retries = 7
+        for attempt in range(max_retries):
+            try:
+                ret = super(ObservablePooledDatabase, self).connect(reuse_if_open)
+                break
+            except MaxConnectionsExceeded as e:
+                if attempt == max_retries - 1:
+                    logger.warning(
+                        f"Could not get a healthy connection after {max_retries} attempts: {e}"
+                    )
+                    raise
+                # Pool exhausted - wait with exponential backoff before retrying
+                # Base delay: 10ms, max delay: 200ms to prevent long waits
+                delay = min(0.01 * (2**attempt), 0.2)
+                # Add jitter to prevent thundering herd (±25% randomization)
+                jitter = delay * (0.75 + uniform(0, 0.5))
+                logger.debug(
+                    "Connection pool exhausted (attempt %d/%d), retrying after %.3fs",
+                    attempt + 1,
+                    max_retries,
+                    jitter,
+                )
+                time.sleep(jitter)
+
         db_pooled_connections_in_use.set(len(self._in_use))
         db_pooled_connections_available.set(len(self._connections))
         return ret

--- a/data/database.py
+++ b/data/database.py
@@ -534,11 +534,6 @@ class ObservablePooledDatabase(ObservableDatabase):
             except Exception as ex:
                 logger.debug("Error closing stale connection: %s", ex)
 
-            # Small delay before retry to allow other requests to complete
-            if _retry_count > 0:
-                delay = min(0.01 * _retry_count, 0.05)  # 10-50ms
-                time.sleep(delay)
-
             # Recursively retry - pool will provide another connection (or create new one)
             return self._connect(_retry_count=_retry_count + 1)
 

--- a/data/test/test_database_pooling.py
+++ b/data/test/test_database_pooling.py
@@ -4,7 +4,7 @@ import pytest
 from peewee import InterfaceError, OperationalError, SqliteDatabase
 from playhouse.pool import MaxConnectionsExceeded, PooledSqliteDatabase
 
-from data.database import ObservablePooledDatabase
+from data.database import ObservableDatabase, ObservablePooledDatabase
 
 
 # Create a concrete test database class combining the mixin with SQLite
@@ -127,6 +127,20 @@ class TestObservablePooledDatabase:
                 # Should still create and return fresh connection
                 assert result == fresh_conn
 
+    def test_connect_propagates_pool_exhaustion(self):
+        """
+        Verifies that db.connect() catches the propagated MaxConnectionsExceeded exception properly
+        and handles it.
+        """
+        db = _TestPooledDB(":memory:")
+        with patch.object(
+            PooledSqliteDatabase, "_connect", side_effect=MaxConnectionsExceeded("exhausted")
+        ):
+            with patch("data.database.time.sleep") as mock_sleep:
+                with pytest.raises(MaxConnectionsExceeded):
+                    db._connect()
+                mock_sleep.assert_not_called()
+
     def test_connect_handles_pool_exhaustion_with_backoff(self):
         """Test that MaxConnectionsExceeded triggers exponential backoff retry."""
         db = _TestPooledDB(":memory:")
@@ -140,7 +154,7 @@ class TestObservablePooledDatabase:
         # First two calls raise MaxConnectionsExceeded, third succeeds
         with patch.object(
             PooledSqliteDatabase,
-            "_connect",
+            "connect",
             side_effect=[
                 MaxConnectionsExceeded("Pool exhausted"),
                 MaxConnectionsExceeded("Pool exhausted"),
@@ -149,7 +163,7 @@ class TestObservablePooledDatabase:
         ):
             # Mock time.sleep to verify backoff is happening
             with patch("data.database.time.sleep") as mock_sleep:
-                result = db._connect()
+                result = db.connect()
 
                 # Verify sleep was called for backoff (2 times for 2 failures)
                 assert mock_sleep.call_count == 2
@@ -162,3 +176,17 @@ class TestObservablePooledDatabase:
 
                 # Verify fresh connection is eventually returned
                 assert result == fresh_conn
+
+    def test_connect_quits_after_exhausting_retries(self):
+        """
+        Verifies that db.connect() fails after 7 retries and does not go into an infinite
+        loop.
+        """
+        db = _TestPooledDB(":memory:")
+        with patch.object(
+            PooledSqliteDatabase, "connect", side_effect=MaxConnectionsExceeded("always full")
+        ):
+            with patch("data.database.time.sleep") as mock_sleep:
+                with pytest.raises(MaxConnectionsExceeded):
+                    db.connect()
+                assert mock_sleep.call_count == 6

--- a/endpoints/decorated.py
+++ b/endpoints/decorated.py
@@ -1,6 +1,7 @@
 import logging
 
 from flask import jsonify, make_response
+from playhouse.pool import MaxConnectionsExceeded
 from werkzeug.routing.exceptions import RequestRedirect
 
 from app import app
@@ -75,3 +76,12 @@ def handle_not_implemented_error(ex):
 @app.errorhandler(RequestRedirect)
 def handle_bad_redirect(ex):
     return ex.get_response()
+
+
+@app.errorhandler(MaxConnectionsExceeded)
+def handle_max_connections_count(ex):
+    logger.exception(ex)
+    response = jsonify({"message": "Service temporary unavailable due to high load. Please retry!"})
+    response.status_code = 503
+    response.headers["Retry-After"] = 1
+    return response

--- a/endpoints/test/test_decorators.py
+++ b/endpoints/test/test_decorators.py
@@ -2,10 +2,10 @@ import pytest
 from flask import url_for
 from playhouse.pool import MaxConnectionsExceeded
 
-import endpoints.decorated
 from data import model
 from endpoints.api import api
 from endpoints.api.repository import Repository
+from endpoints.decorated import handle_max_connections_count
 from endpoints.test.shared import conduct_call
 from test.fixtures import *
 
@@ -50,6 +50,8 @@ def test_MaxConnectionsExceeded_properly_returns_a_503_when_raised(app, client):
     Verifies that a 503 is returned back to the caller with a retry header if
     MaxConnectionsExceeded is raised by the app during access.
     """
+    app.register_error_handler(MaxConnectionsExceeded, handle_max_connections_count)
+
     with app.test_request_context("/v2/"):
         try:
             raise MaxConnectionsExceeded("pool full")

--- a/endpoints/test/test_decorators.py
+++ b/endpoints/test/test_decorators.py
@@ -1,11 +1,13 @@
-from test.fixtures import *
-
 import pytest
+from flask import url_for
+from playhouse.pool import MaxConnectionsExceeded
 
+import endpoints.decorated
 from data import model
 from endpoints.api import api
 from endpoints.api.repository import Repository
 from endpoints.test.shared import conduct_call
+from test.fixtures import *
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,18 @@ def test_require_xhr_from_browser(user_agent, include_header, expected_code, app
     conduct_call(
         client, Repository, api.url_for, "GET", params, headers=headers, expected_code=expected_code
     )
+
+
+def test_MaxConnectionsExceeded_properly_returns_a_503_when_raised(app, client):
+    """
+    Verifies that a 503 is returned back to the caller with a retry header if
+    MaxConnectionsExceeded is raised by the app during access.
+    """
+    with app.test_request_context("/v2/"):
+        try:
+            raise MaxConnectionsExceeded("pool full")
+        except Exception as e:
+            response = app.handle_user_exception(e)
+
+    assert response.status_code == 503
+    assert "Retry-After" in response.headers

--- a/endpoints/test/test_decorators.py
+++ b/endpoints/test/test_decorators.py
@@ -60,3 +60,4 @@ def test_MaxConnectionsExceeded_properly_returns_a_503_when_raised(app, client):
 
     assert response.status_code == 503
     assert "Retry-After" in response.headers
+    assert response.headers["Retry-After"] == "1"


### PR DESCRIPTION
The logic introduced in the previous PR concerning pooled connections is sound but it has a critical problem: the retry/backoff loop ran inside `_connect()`, which Peewee invokes when holding the pool's lock. When a greenlet hit pool exhaustion and slept through the backoff, it held that lock for the whole duration, blocking other greenlets from acquiring or releasing connections during that process. Closing the connection via `close()` is the only way to return the connection to the pool, meaning that holding the lock during this time is genuinely harmful: the pool can never recover while the lock is held, which can cause cascading failures within a worker: one greenlet will block other greenlets until they start raising exceptions, degrading overall registry performance.

For this reason, the following changes are done:
1. the retry-and-backoff loop has been moved out of the lock-holding `_connect()` into the `connect()` wrapper; the lock is held only for a brief moment of acquiring a connection, but not while a greenlet is sleeping.
2. delay in the `_connect()` is completely removed, we immediately retry the connection instead of waiting 10 to 50 ms before the next attempt.
3. If the connection pool is exhausted, instead of raising a `500 Internal Server Error` (forcing the clients to back off immediately), a new handler is registered that returns a `503 Service Unavailable` with a `Retry-After` header. This signals clients that the issue is transient and they should retry the request after the alotted time.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>