### PR TITLE
PROJQUAY-12773: fix: Ensure that we use Redis connection pooling on user events and pull metrics

### DIFF
--- a/data/test/test_userevents.py
+++ b/data/test/test_userevents.py
@@ -1,0 +1,69 @@
+import uuid
+from unittest.mock import patch
+
+import fakeredis
+import pytest
+
+from data.userevent import UserEvent, UserEventBuilder, UserEventListener
+
+
+@pytest.fixture
+def fake_redis():
+    def init_fake_strict_redis(*args, **kwargs):
+        return fakeredis.FakeStrictRedis()
+
+    with patch("redis.StrictRedis", init_fake_strict_redis):
+        yield
+
+
+def test_builder_creates_shared_client():
+    """
+    Verifies that we create one pool of connections for the user events that is then
+    shared across Redis requests.
+    """
+    with patch("redis.StrictRedis", wraps=fakeredis.FakeStrictRedis) as mock_redis:
+        builder = UserEventBuilder({"host": "localhost"})
+
+        # two events must share the same client
+        e1 = builder.get_event("ivan")
+        e2 = builder.get_event("foo")
+
+        # assert that both have the same config
+        assert mock_redis.call_count == 1
+        assert e1._redis is e2._redis
+        assert e1._redis is builder.client
+
+
+def test_publish_event_through_shared_client():
+    """
+    Verifies that publishing of the events works.
+    """
+    server = fakeredis.FakeServer()
+
+    def make_client(*args, **kwargs):
+        return fakeredis.FakeStrictRedis(server=server)
+
+    with patch("redis.StrictRedis", make_client):
+        builder = UserEventBuilder({"host": "localhost"})
+
+        # create a new event
+        event_data = {"msg": "test event"}
+        eid = str(uuid.uuid4())
+
+        # define the listener
+        listener = UserEventListener({"host": "localhost"}, "alice", {eid})
+
+        # publish event
+        publisher = builder.get_event("alice")
+        received_by = publisher.publish_event_data_sync(eid, event_data)
+        assert received_by == 1
+
+        # read data back
+        for received_id, data in listener.event_stream():
+            if received_id == "pulse":
+                continue
+            assert received_id == eid
+            assert data == event_data
+            break
+
+        listener.stop()

--- a/data/userevent.py
+++ b/data/userevent.py
@@ -19,10 +19,15 @@ class UserEventBuilder(object):
     """
 
     def __init__(self, redis_config):
+        self._client = redis.StrictRedis(socket_connect_timeout=2, socket_timeout=2, **redis_config)
         self._redis_config = redis_config
 
+    @property
+    def client(self):
+        return self._client
+
     def get_event(self, username):
-        return UserEvent(self._redis_config, username)
+        return UserEvent(self._client, username)
 
     def get_listener(self, username, events):
         return UserEventListener(self._redis_config, username, events)
@@ -60,8 +65,8 @@ class UserEvent(object):
     Defines a helper class for publishing to realtime user events as backed by Redis.
     """
 
-    def __init__(self, redis_config, username):
-        self._redis = redis.StrictRedis(socket_connect_timeout=2, socket_timeout=2, **redis_config)
+    def __init__(self, client, username):
+        self._redis = client
         self._username = username
 
     @staticmethod

--- a/util/pullmetrics.py
+++ b/util/pullmetrics.py
@@ -25,11 +25,16 @@ class PullMetricsBuilder(object):
     """
 
     def __init__(self, redis_config, max_workers=None):
+        self._instance = PullMetrics(redis_config, max_workers)
         self._redis_config = redis_config
         self._max_workers = max_workers
 
+    @property
+    def instance(self):
+        return self._instance
+
     def get_event(self):
-        return PullMetrics(self._redis_config, self._max_workers)
+        return self._instance
 
 
 class PullMetricsBuilderModule(object):

--- a/util/pullmetrics.py
+++ b/util/pullmetrics.py
@@ -13,6 +13,10 @@ DEFAULT_REDIS_CONNECTION_TIMEOUT = 5
 DEFAULT_REDIS_RETRY_ATTEMPTS = 3
 DEFAULT_REDIS_RETRY_DELAY = 1.0
 
+# default lock wait timeout, the amount of seconds we'll wait before
+# a lock can be acquired
+DEFAULT_REDIS_LOCK_WAIT = 2
+
 
 class CannotReadPullMetricsException(Exception):
     """
@@ -207,8 +211,14 @@ class PullMetrics(object):
                 logger.debug("Redis connection lost, reconnecting...")
                 self._redis = None
 
-        # Try to establish connection with retries
-        with self._redis_lock:
+        # If we don't have a working connection, we must establish the pool. To ensure that
+        # we don't leak connections, first check if there's already a raised lock (greenlet is
+        # trying to connect)
+        if not self._redis_lock.acquire(timeout=DEFAULT_REDIS_LOCK_WAIT):
+            raise redis.ConnectionError("Cannot acquire Redis lock, aborting")
+
+        # If there is no lock, try to establish the pool.
+        try:
             # recheck if there is a connection and return it
             if self._redis is not None:
                 try:
@@ -257,6 +267,8 @@ class PullMetrics(object):
             raise last_exception or redis.ConnectionError(
                 "Failed to connect to Redis for pull metrics"
             )
+        finally:
+            self._redis_lock.release()
 
     @staticmethod
     def _tag_pull_key(repository_id, tag_name, manifest_digest):

--- a/util/pullmetrics.py
+++ b/util/pullmetrics.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
@@ -174,6 +175,7 @@ class PullMetrics(object):
         # Store only Redis connection parameters
         self._redis_config = redis_config
         self._redis = None
+        self._redis_lock = threading.Lock()
 
         # Initialize thread pool (skip in testing mode)
         worker_count = max_workers or DEFAULT_PULL_METRICS_WORKER_COUNT
@@ -193,53 +195,68 @@ class PullMetrics(object):
         Raises:
             redis.RedisError: If connection fails after retries
         """
+        client = self._redis
         # If we have a working connection, return it
-        if self._redis is not None:
+        if client is not None:
             try:
                 # Quick health check - ping the connection
-                self._redis.ping()
-                return self._redis
+                client.ping()
+                return client
             except (redis.ConnectionError, redis.TimeoutError, AttributeError):
                 # Connection is broken, reset and reconnect
                 logger.debug("Redis connection lost, reconnecting...")
                 self._redis = None
 
         # Try to establish connection with retries
-        last_exception = None
-        for attempt in range(1, self._retry_attempts + 1):
-            try:
-                self._redis = redis.StrictRedis(
-                    socket_connect_timeout=self._connection_timeout,
-                    socket_timeout=self._socket_timeout,
-                    **self._redis_config,
-                )
-                self._redis.ping()
-                if attempt > 1:
-                    logger.info(
-                        "Redis connection established after %d attempt(s) for pull metrics", attempt
-                    )
-                return self._redis
-            except (redis.ConnectionError, redis.TimeoutError) as e:
-                last_exception = e
-                self._redis = None
-                if attempt < self._retry_attempts:
-                    logger.warning(
-                        "Redis connection attempt %d/%d failed for pull metrics: %s. Retrying in %.1fs...",
-                        attempt,
-                        self._retry_attempts,
-                        str(e),
-                        self._retry_delay,
-                    )
-                    time.sleep(self._retry_delay)
-                else:
-                    logger.error(
-                        "Failed to connect to Redis after %d attempts for pull metrics: %s",
-                        self._retry_attempts,
-                        str(e),
-                    )
+        with self._redis_lock:
+            # recheck if there is a connection and return it
+            if self._redis is not None:
+                try:
+                    self._redis.ping()
+                    return self._redis
+                except (redis.ConnectionError, redis.TimeoutError, AttributeError):
+                    logger.debug("Redis connection is not available, attempting to reconnect...")
 
-        # All retries failed
-        raise last_exception or redis.ConnectionError("Failed to connect to Redis for pull metrics")
+            # retry loop runs under a lock, other threads need to wait until execution finishes
+            # this ensures only one pool is created instead of multiple, leaking potential connections
+            last_exception = None
+            for attempt in range(1, self._retry_attempts + 1):
+                try:
+                    self._redis = redis.StrictRedis(
+                        socket_connect_timeout=self._connection_timeout,
+                        socket_timeout=self._socket_timeout,
+                        **self._redis_config,
+                    )
+                    self._redis.ping()
+                    if attempt > 1:
+                        logger.info(
+                            "Redis connection established after %d attempt(s) for pull metrics",
+                            attempt,
+                        )
+                    return self._redis
+                except (redis.ConnectionError, redis.TimeoutError) as e:
+                    last_exception = e
+                    self._redis = None
+                    if attempt < self._retry_attempts:
+                        logger.warning(
+                            "Redis connection attempt %d/%d failed for pull metrics: %s. Retrying in %.1fs...",
+                            attempt,
+                            self._retry_attempts,
+                            str(e),
+                            self._retry_delay,
+                        )
+                        time.sleep(self._retry_delay)
+                    else:
+                        logger.error(
+                            "Failed to connect to Redis after %d attempts for pull metrics: %s",
+                            self._retry_attempts,
+                            str(e),
+                        )
+
+            # All retries failed
+            raise last_exception or redis.ConnectionError(
+                "Failed to connect to Redis for pull metrics"
+            )
 
     @staticmethod
     def _tag_pull_key(repository_id, tag_name, manifest_digest):

--- a/util/pullmetrics.py
+++ b/util/pullmetrics.py
@@ -207,9 +207,8 @@ class PullMetrics(object):
                 client.ping()
                 return client
             except (redis.ConnectionError, redis.TimeoutError, AttributeError):
-                # Connection is broken, reset and reconnect
+                # Connection is broken, reconnect
                 logger.debug("Redis connection lost, reconnecting...")
-                self._redis = None
 
         # If we don't have a working connection, we must establish the pool. To ensure that
         # we don't leak connections, first check if there's already a raised lock (greenlet is
@@ -226,6 +225,7 @@ class PullMetrics(object):
                     return self._redis
                 except (redis.ConnectionError, redis.TimeoutError, AttributeError):
                     logger.debug("Redis connection is not available, attempting to reconnect...")
+                    self._redis = None
 
             # retry loop runs under a lock, other threads need to wait until execution finishes
             # this ensures only one pool is created instead of multiple, leaking potential connections

--- a/util/test/test_pullmetrics.py
+++ b/util/test/test_pullmetrics.py
@@ -10,9 +10,13 @@ This test suite covers:
 - Error handling
 """
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
+import fakeredis
 import pytest
 import redis
 
@@ -364,6 +368,33 @@ class TestPullMetrics:
 
         # Should have attempted to reconnect
         assert mock_redis.ping.call_count >= 2
+
+    def test_redis_concurrent_first_use_creates_single_client(self, mock_redis):
+        """
+        Verifies that on concurrent requests we only get one pool issued instead of potentially two
+        in a race condition.
+        """
+        construct_count = 0
+        lock = threading.Lock()
+        redis_config = {"host": "localhost", "port": 6379, "_testing": True}
+
+        def fake_ctor(*args, **kwargs):
+            nonlocal construct_count
+            with lock:
+                construct_count += 1
+            time.sleep(0.05)
+            return fakeredis.FakeStrictRedis()
+
+        with patch("redis.StrictRedis", side_effect=fake_ctor):
+            pm = PullMetrics(redis_config)
+            with ThreadPoolExecutor(max_workers=10) as ex:
+                clients = list(ex.map(lambda _: pm._ensure_redis_connection(), range(10)))
+
+        # make sure that the contructor is called only once
+        assert construct_count == 1
+
+        # make sure that all returned clients are identical
+        assert all(c is clients[0] for c in clients)
 
     def test_track_tag_pull_sync(self, pull_metrics_testing, mock_redis):
         """Test synchronous tag pull tracking."""

--- a/util/test/test_pullmetrics.py
+++ b/util/test/test_pullmetrics.py
@@ -378,6 +378,7 @@ class TestPullMetrics:
         lock = threading.Lock()
         redis_config = {"host": "localhost", "port": 6379, "_testing": True}
 
+        # fake Redis constructor
         def fake_ctor(*args, **kwargs):
             nonlocal construct_count
             with lock:
@@ -385,6 +386,7 @@ class TestPullMetrics:
             time.sleep(0.05)
             return fakeredis.FakeStrictRedis()
 
+        # send 10 concurrent requests to the constructor
         with patch("redis.StrictRedis", side_effect=fake_ctor):
             pm = PullMetrics(redis_config)
             with ThreadPoolExecutor(max_workers=10) as ex:
@@ -394,6 +396,46 @@ class TestPullMetrics:
         assert construct_count == 1
 
         # make sure that all returned clients are identical
+        assert all(c is clients[0] for c in clients)
+
+    def test_redis_concurrent_reconnect_creates_single_client(self, mock_redis):
+        """
+        Verifies that after the original connection goes bad, concurrent requests to reconnect
+        must reconnect once and not create duplicate pools.
+        """
+        concurrent_count = 0
+        lock = threading.Lock()
+        redis_config = {"host": "localhost", "port": 6379, "_testing": True}
+
+        def make_client(healthy):
+            c = MagicMock()
+            c.ping.side_effect = None if healthy else redis.ConnectionError("Redis is down")
+            return c
+
+        # fake Redis constructor
+        def fake_ctor(*args, **kwargs):
+            nonlocal concurrent_count
+            with lock:
+                concurrent_count += 1
+            time.sleep(0.5)
+            return make_client(healthy=True)
+
+        # send 10 concurrent requests to the constructor
+        with patch("redis.StrictRedis", side_effect=fake_ctor):
+            pm = PullMetrics(redis_config)
+
+            # initial healthy client, then poison it so later requests create a new pool
+            pm._ensure_redis_connection()
+            assert concurrent_count == 1
+            pm._redis.ping.side_effect = redis.ConnectionError("connection dropped")
+
+            with ThreadPoolExecutor(max_workers=10) as ex:
+                clients = list(ex.map(lambda _: pm._ensure_redis_connection(), range(10)))
+
+        # exactly one new client should be built, meaning that concurrent_count should be 2
+        assert concurrent_count == 2
+
+        # verify all clients are the same
         assert all(c is clients[0] for c in clients)
 
     def test_track_tag_pull_sync(self, pull_metrics_testing, mock_redis):

--- a/util/test/test_pullmetrics.py
+++ b/util/test/test_pullmetrics.py
@@ -50,7 +50,7 @@ class TestPullMetricsBuilder:
         """Test PullMetricsBuilder initialization."""
         redis_config = {"host": "localhost", "port": 6379}
         builder = PullMetricsBuilder(redis_config)
-        assert builder._redis_config == redis_config
+        assert builder.instance._redis_config == redis_config
         assert builder._max_workers is None
 
     def test_builder_initialization_with_workers(self):
@@ -67,6 +67,38 @@ class TestPullMetricsBuilder:
             builder = PullMetricsBuilder(redis_config)
             event = builder.get_event()
             assert isinstance(event, PullMetrics)
+
+    def test_builder_get_event_returns_shared_instance(self, mock_redis):
+        """
+        Verifies that the get_event returns the same instance of PullMetrics on successive calls.
+        """
+        with patch("util.pullmetrics.redis.StrictRedis") as mock_redis_class:
+            mock_redis_class.return_value = MagicMock()
+            redis_config = {"host": "localhost", "port": "6379", "_testing": True}
+            builder = PullMetricsBuilder(redis_config)
+
+            # create events
+            e1 = builder.get_event()
+            e2 = builder.get_event()
+
+            assert e1 is e2
+            assert e1 is builder.instance
+
+    def test_shared_client_reused_across_calls(self, mock_redis):
+        """
+        Verifies that successive calls to get_event reuse the same instantiated connection pool.
+        """
+        with patch("util.pullmetrics.redis.StrictRedis") as mock_redis_class:
+            mock_redis_class.return_value = MagicMock()
+            redis_config = {"host": "localhost", "port": "6379", "_testing": True}
+            builder = PullMetricsBuilder(redis_config)
+
+            # events
+            c1 = builder.get_event()._ensure_redis_connection()
+            c2 = builder.get_event()._ensure_redis_connection()
+
+            assert c1 is c2
+            assert mock_redis_class.call_count == 1
 
 
 class TestPullMetricsBuilderModule:


### PR DESCRIPTION
Previously, the `UserEvent` class would instantiate a new Redis connection pool on every call to the `get_event()` function. This would cause excessive connections to Redis and DNS calls if the registry has high traffic throughput. A similar issue would happen with `PullMetrics`, a call to `get_event()` would return a new instance of the class on every call instead of reusing the current pool.

This fix ensures that a single Redis pool is used in both cases and subsequent calls to read events do not return new instances of classes.

Resolves #6891.