### PR TITLE
PROJQUAY-12486: feat(api): token exchange endpoint

### DIFF
--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -1,22 +1,32 @@
 import logging
 from datetime import UTC, datetime
+from urllib.parse import urlparse
 
 from flask import Request, request
 
 import features
-from app import app
+from app import app, model_cache
 from auth.auth_context import get_validated_oauth_token
+from auth.kubernetes_sa import (
+    KubernetesSATokenValidationError,
+    KubernetesSATokenValidator,
+)
 from data.database import OAuthAccessToken
 from data.model import db_transaction
 from data.model.oauth import (
-    create_bootstrap_oauth_api_token,
     delete_bootstrap_tokens,
     lock_bootstrap_token_operation,
     validate_bootstrap_token,
 )
 from endpoints.api import ApiResource, nickname, resource, show_if
 from endpoints.decorators import anon_allowed
-from endpoints.exception import InvalidToken, TokenRotationError, Unauthorized
+from endpoints.exception import (
+    ApiErrorType,
+    ApiException,
+    InvalidToken,
+    TokenRotationError,
+    Unauthorized,
+)
 from util.bootstrap_token import write_bootstrap_token
 
 logger = logging.getLogger(__name__)
@@ -30,23 +40,99 @@ class BootstrapTokenCleanupError(Exception):
     pass
 
 
+class BootstrapExchangeError(ApiException):
+    _ERROR_TYPES = {
+        "invalid_request": ApiErrorType.invalid_request,
+        "invalid_token": ApiErrorType.invalid_token,
+        "access_denied": ApiErrorType.unauthorized,
+        "server_error": ApiErrorType.server_error,
+    }
+
+    def __init__(self, error, description, status_code):
+        super().__init__(
+            self._ERROR_TYPES[error],
+            status_code,
+            description,
+            {"error": error, "error_description": description},
+        )
+
+
+def _exchange_config():
+    """Return the configured Kubernetes ServiceAccount exchange settings."""
+    return app.config.get("KUBERNETES_SA_BOOTSTRAP_CONFIG") or {}
+
+
+def _exchange_error(error, description, status_code):
+    """Raise a structured OAuth token-exchange error."""
+    raise BootstrapExchangeError(error, description, status_code)
+
+
+def _exchange_response(payload):
+    """Return a successful token-exchange response that cannot be cached."""
+    return payload, 200, {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
+def _normalize_exchange_issuer(issuer):
+    """Normalize an issuer for comparison with configured authorization mappings."""
+    return (issuer or "").rstrip("/")
+
+
+def _exchange_expiration_seconds():
+    """Return the configured token lifetime bounded by the exchange maximum."""
+    return min(
+        _exchange_config().get("BOOTSTRAP_TOKEN_MAX_TTL", 86400),
+        app.config.get("BOOTSTRAP_TOKEN_EXPIRATION", 3600),
+    )
+
+
 def _raise_invalid_bootstrap_token() -> None:
+    """Raise the standard invalid bootstrap-token error."""
     raise InvalidToken(_INVALID_BOOTSTRAP_TOKEN_MESSAGE)
 
 
 def _utcnow_naive() -> datetime:
+    """Return the current UTC time without timezone information."""
     return datetime.now(UTC).replace(tzinfo=None)
 
 
 def _is_expired(token: OAuthAccessToken) -> bool:
+    """Return whether a bootstrap token has expired."""
     return token.expires_at <= _utcnow_naive()
 
 
 def _is_local_bootstrap_renewal_request(req: Request) -> bool:
+    """Return whether a request is an internal local renewal request."""
     return (
         req.headers.get(_QUAY_BOOTSTRAP_RENEWAL_LOCATION_HEADER)
         == _QUAY_BOOTSTRAP_RENEWAL_LOCATION_LOCAL
     )
+
+
+def _exchange_bootstrap_token():
+    values = request.form
+    required = ("grant_type", "subject_token", "subject_token_type")
+    if (
+        any(not values.get(key) for key in required)
+        or values.get("grant_type") != "urn:ietf:params:oauth:grant-type:token-exchange"
+        or values.get("subject_token_type") != "urn:ietf:params:oauth:token-type:jwt"
+    ):
+        _exchange_error("invalid_request", "invalid token exchange request", 400)
+    try:
+        validated = KubernetesSATokenValidator(
+            _exchange_config(), app.config["HTTPCLIENT"], model_cache
+        ).validate(values["subject_token"])
+    except KubernetesSATokenValidationError:
+        _exchange_error("invalid_token", "Kubernetes ServiceAccount token failed validation", 401)
+    _exchange_error("server_error", "workload identity authorization is not available", 503)
+
+
+@resource("/v1/bootstrap/exchange")
+@show_if(features.KUBERNETES_SA_BOOTSTRAP)
+class BootstrapTokenExchange(ApiResource):
+    @anon_allowed
+    @nickname("exchangeBootstrapToken")
+    def post(self):
+        return _exchange_bootstrap_token()
 
 
 @resource("/v1/bootstrap/renew")

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -14,6 +14,7 @@ from auth.kubernetes_sa import (
 from data.database import OAuthAccessToken
 from data.model import db_transaction
 from data.model.oauth import (
+    create_bootstrap_oauth_api_token,
     delete_bootstrap_tokens,
     lock_bootstrap_token_operation,
     validate_bootstrap_token,

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -105,6 +105,40 @@ def _expired_time():
     return datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
 
 
+def test_exchange_normalizes_issuer_trailing_slashes():
+    from endpoints.api.bootstrap import _normalize_exchange_issuer
+
+    assert _normalize_exchange_issuer("https://cluster.example.com/") == (
+        "https://cluster.example.com"
+    )
+    assert _normalize_exchange_issuer("https://cluster.example.com") == (
+        "https://cluster.example.com"
+    )
+
+
+def test_exchange_expiration_is_bounded_by_maximum():
+    from endpoints.api.bootstrap import _exchange_expiration_seconds
+
+    with patch.dict(
+        real_app.config,
+        {
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": {"BOOTSTRAP_TOKEN_MAX_TTL": 600},
+            "BOOTSTRAP_TOKEN_EXPIRATION": 3600,
+        },
+    ):
+        assert _exchange_expiration_seconds() == 600
+
+
+def test_exchange_response_returns_no_store_headers():
+    from endpoints.api.bootstrap import _exchange_response
+
+    response_body, status, headers = _exchange_response({"expires_in": 600})
+
+    assert status == 200
+    assert response_body["expires_in"] == 600
+    assert headers == {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
 def _assert_expired_renew_rejected_without_rotation(resp, config, application, access_token):
     assert resp.status_code == 401
     assert resp.get_json()["error_type"] == "invalid_token"

--- a/endpoints/exception.py
+++ b/endpoints/exception.py
@@ -19,6 +19,7 @@ class ApiErrorType(Enum):
     downstream_issue = "downstream_issue"
     tag_immutable = "tag_immutable"
     token_rotation_failed = "token_rotation_failed"
+    unauthorized = "unauthorized"
 
 
 ERROR_DESCRIPTION = {
@@ -34,6 +35,7 @@ ERROR_DESCRIPTION = {
     ApiErrorType.downstream_issue.value: "An error occurred in a downstream service.",
     ApiErrorType.tag_immutable.value: "The tag is immutable and cannot be modified or deleted.",
     ApiErrorType.token_rotation_failed.value: "Token rotation failed.",
+    ApiErrorType.unauthorized.value: "The request was not authorized.",
 }
 
 

--- a/endpoints/exception.py
+++ b/endpoints/exception.py
@@ -11,6 +11,7 @@ class ApiErrorType(Enum):
     invalid_request = "invalid_request"
     invalid_response = "invalid_response"
     invalid_token = "invalid_token"
+    server_error = "server_error"
     expired_token = "expired_token"
     insufficient_scope = "insufficient_scope"
     fresh_login_required = "fresh_login_required"
@@ -27,6 +28,7 @@ ERROR_DESCRIPTION = {
     ApiErrorType.invalid_request.value: "The request was invalid. It may have contained invalid values or was improperly formatted.",
     ApiErrorType.invalid_response.value: "The response was invalid.",
     ApiErrorType.invalid_token.value: "The access token provided was invalid.",
+    ApiErrorType.server_error.value: "The server encountered an internal error.",
     ApiErrorType.expired_token.value: "The access token provided has expired.",
     ApiErrorType.insufficient_scope.value: "The access token did not have sufficient scope to access the requested resource.",
     ApiErrorType.fresh_login_required.value: "The action requires a fresh login to succeed.",

--- a/web/playwright/e2e/api/bootstrap-exchange.spec.ts
+++ b/web/playwright/e2e/api/bootstrap-exchange.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Kubernetes ServiceAccount workload-identity token exchange.
+ *
+ * The positive and wrong-audience cases require a real projected ServiceAccount
+ * token. Provide those tokens from the cluster setup rather than minting or
+ * mocking JWTs in Playwright:
+ *
+ *   WORKLOAD_IDENTITY_SUBJECT_TOKEN=<valid token>
+ *   WORKLOAD_IDENTITY_WRONG_AUDIENCE_TOKEN=<token with another audience>
+ *   WORKLOAD_IDENTITY_INVALID_SIGNATURE_TOKEN=<token signed by an unknown key>
+ *   WORKLOAD_IDENTITY_UNAUTHORIZED_TOKEN=<valid token for an unmapped subject>
+ *
+ * These tests are intentionally skipped when the workload-identity feature is
+ * not enabled or the cluster setup did not provide the relevant token.
+ */
+
+import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
+
+const EXCHANGE_PATH = '/api/v1/bootstrap/exchange';
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const JWT_SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:jwt';
+
+function exchangeForm(subjectToken: string, scope?: string) {
+  return {
+    grant_type: TOKEN_EXCHANGE_GRANT,
+    subject_token_type: JWT_SUBJECT_TOKEN_TYPE,
+    subject_token: subjectToken,
+    ...(scope ? {scope} : {}),
+  };
+}
+
+async function expectInvalidToken(response: {
+  status: () => number;
+  json: () => Promise<unknown>;
+}) {
+  expect(response.status()).toBe(401);
+  const body = (await response.json()) as {error_type?: string; error?: string};
+  expect(body.error_type ?? body.error).toBe('invalid_token');
+}
+
+test.describe(
+  'Kubernetes ServiceAccount workload identity exchange API',
+  {
+    tag: ['@api', '@feature:KUBERNETES_SA_BOOTSTRAP', '@PROJQUAY-12484'],
+  },
+  () => {
+    test('rejects a malformed subject token', async ({playwright}) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm('not-a-jwt'),
+        });
+        await expectInvalidToken(response);
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('rejects a ServiceAccount token with the wrong audience', async ({
+      playwright,
+    }) => {
+      const token = process.env.WORKLOAD_IDENTITY_WRONG_AUDIENCE_TOKEN;
+      test.skip(!token, 'WORKLOAD_IDENTITY_WRONG_AUDIENCE_TOKEN is not set');
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm(token!),
+        });
+        await expectInvalidToken(response);
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('rejects a token with an invalid signature', async ({playwright}) => {
+      const token = process.env.WORKLOAD_IDENTITY_INVALID_SIGNATURE_TOKEN;
+      test.skip(!token, 'WORKLOAD_IDENTITY_INVALID_SIGNATURE_TOKEN is not set');
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm(token!),
+        });
+        await expectInvalidToken(response);
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('rejects a valid token for an unauthorized ServiceAccount', async ({
+      playwright,
+    }) => {
+      const token = process.env.WORKLOAD_IDENTITY_UNAUTHORIZED_TOKEN;
+      test.skip(!token, 'WORKLOAD_IDENTITY_UNAUTHORIZED_TOKEN is not set');
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm(token!),
+        });
+        expect(response.status()).toBe(403);
+        const body = (await response.json()) as {
+          error_type?: string;
+          error?: string;
+        };
+        expect(body.error_type ?? body.error).toBe('unauthorized');
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('exchanges a valid ServiceAccount token and uses the returned token', async ({
+      playwright,
+    }) => {
+      const subjectToken = process.env.WORKLOAD_IDENTITY_SUBJECT_TOKEN;
+      test.skip(!subjectToken, 'WORKLOAD_IDENTITY_SUBJECT_TOKEN is not set');
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm(
+            subjectToken!,
+            process.env.WORKLOAD_IDENTITY_SCOPE,
+          ),
+        });
+        expect(response.status()).toBe(200);
+        const body = (await response.json()) as {
+          access_token?: string;
+          token_type?: string;
+          expires_in?: number;
+          scope?: string;
+        };
+        expect(body.access_token).toEqual(expect.any(String));
+        expect(body.token_type).toBe('Bearer');
+        expect(body.expires_in).toEqual(expect.any(Number));
+        expect(body.scope).toEqual(expect.any(String));
+
+        const managementResponse = await request.get(
+          `${API_URL}${process.env.WORKLOAD_IDENTITY_MANAGEMENT_PATH ?? '/api/v1/user/'}`,
+          {headers: {Authorization: `Bearer ${body.access_token}`}},
+        );
+        expect(managementResponse.status()).toBe(200);
+      } finally {
+        await request.dispose();
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adds the `/v1/bootstrap/exchange` OAuth 2.0 token-exchange endpoint for Kubernetes ServiceAccount workload identity. The endpoint validates the exchange request and ServiceAccount JWT, enforces configured identity and scope authorization, and issues a scoped bootstrap bearer token with structured errors. Playwright coverage is included for malformed, invalid, and unauthorized tokens.