### PR TITLE
PROJQUAY-12540: feat(notifications): add tag-regex filter to vulnerability notifications

### DIFF
--- a/endpoints/api/repositorynotification.py
+++ b/endpoints/api/repositorynotification.py
@@ -20,7 +20,11 @@ from endpoints.api import (
 from endpoints.api.repositorynotification_models_pre_oci import pre_oci_model as model
 from endpoints.exception import NotFound
 from notifications.models_interface import Repository
-from notifications.notificationevent import NotificationEvent
+from notifications.notificationevent import (
+    InvalidNotificationEventConfigException,
+    InvalidNotificationEventException,
+    NotificationEvent,
+)
 from notifications.notificationmethod import (
     CannotValidateNotificationMethodException,
     NotificationMethod,
@@ -82,6 +86,20 @@ class RepositoryNotificationList(RepositoryParamResource):
             method_handler.validate(namespace_name, repository_name, parsed["config"])
         except CannotValidateNotificationMethodException as ex:
             raise request_error(message=str(ex))
+
+        # Validate the event-specific config (e.g. the vulnerability tag filter) up front so an
+        # invalid value is rejected here rather than silently breaking the notification when it
+        # later fires. Unknown event names are left to the model layer, as before.
+        try:
+            event_handler = NotificationEvent.get_event(parsed["event"])
+        except InvalidNotificationEventException:
+            event_handler = None
+
+        if event_handler is not None:
+            try:
+                event_handler.validate_event_config(parsed["eventConfig"] or {})
+            except InvalidNotificationEventConfigException as ex:
+                raise request_error(message=str(ex))
 
         new_notification = model.create_repo_notification(
             namespace_name,

--- a/endpoints/api/test/test_repositorynotification.py
+++ b/endpoints/api/test/test_repositorynotification.py
@@ -9,6 +9,7 @@ from endpoints.api.repositorynotification import (
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from notifications.notificationevent import MAX_TAG_REGEX_LENGTH
 from test.fixtures import *
 
 
@@ -85,6 +86,58 @@ def mock_get_notification(uuid):
                 title="test",
             ),
             201,
+        ),
+        # A valid vulnerability tag filter is accepted.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": "^prod-.+$"},
+                title="test",
+            ),
+            201,
+        ),
+        # A blank tag filter means "no filter" and is accepted.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": ""},
+                title="test",
+            ),
+            201,
+        ),
+        # An uncompilable tag filter is rejected at creation time.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": "]["},
+                title="test",
+            ),
+            400,
+        ),
+        # A tag filter beyond the length bound is rejected at creation time.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": "a" * (MAX_TAG_REGEX_LENGTH + 1)},
+                title="test",
+            ),
+            400,
         ),
     ],
 )

--- a/endpoints/api/test/test_repositorynotification.py
+++ b/endpoints/api/test/test_repositorynotification.py
@@ -164,6 +164,56 @@ def mock_get_notification(uuid):
             ),
             400,
         ),
+        # Falsey non-string tag filters (0, false, [], {}) must not be mistaken for "no filter";
+        # they are rejected at creation time like any other non-string value.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": 0},
+                title="test",
+            ),
+            400,
+        ),
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": False},
+                title="test",
+            ),
+            400,
+        ),
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": []},
+                title="test",
+            ),
+            400,
+        ),
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": {}},
+                title="test",
+            ),
+            400,
+        ),
     ],
 )
 def test_create_repo_notification(namespace, repository, body, expected_code, authd_client):

--- a/endpoints/api/test/test_repositorynotification.py
+++ b/endpoints/api/test/test_repositorynotification.py
@@ -139,6 +139,31 @@ def mock_get_notification(uuid):
             ),
             400,
         ),
+        # A non-string tag filter is rejected at creation time.
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": 123},
+                title="test",
+            ),
+            400,
+        ),
+        (
+            "devtable",
+            "simple",
+            dict(
+                config={"url": "http://example.com"},
+                event="vulnerability_found",
+                method="webhook",
+                eventConfig={"tag-regex": ["["]},
+                title="test",
+            ),
+            400,
+        ),
     ],
 )
 def test_create_repo_notification(namespace, repository, body, expected_code, authd_client):

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -2,6 +2,10 @@ import logging
 import re
 import time
 from datetime import datetime
+from functools import lru_cache
+
+import regex
+from regex import Pattern
 
 from notifications import build_namespace_event_data, build_repository_event_data
 from util.jinjautil import get_template_env
@@ -10,6 +14,21 @@ from util.secscan import PRIORITY_LEVELS, get_priority_for_index
 logger = logging.getLogger(__name__)
 
 TEMPLATE_ENV = get_template_env("events")
+
+# Upper bound on a configured vulnerability tag-filter pattern, mirroring the immutability
+# policy limit. A legitimate filter never needs to be larger, and bounding it reduces the
+# surface for catastrophic backtracking.
+MAX_TAG_REGEX_LENGTH = 256
+
+# Per-tag evaluation budget, in seconds, for the vulnerability tag filter. The `regex`
+# module aborts a match that exceeds this, protecting the notification worker from a crafted
+# ReDoS pattern (e.g. "^(a+)+$") that would otherwise pin CPU on a long non-matching tag.
+TAG_REGEX_MATCH_TIMEOUT = 1.0
+
+
+@lru_cache(maxsize=256)
+def _compile_tag_regex(pattern: str) -> Pattern[str]:
+    return regex.compile(pattern)
 
 
 class InvalidNotificationEventException(Exception):
@@ -209,17 +228,39 @@ class VulnerabilityFoundEvent(NotificationEvent):
         )
 
     def _matches_tag_filter(self, event_data, tag_regex):
+        # Reject overly long patterns outright: they only add to matching cost and a
+        # legitimate tag filter never needs to be this large.
+        pattern = str(tag_regex)
+        if len(pattern) > MAX_TAG_REGEX_LENGTH:
+            logger.warning(
+                "Vulnerability event tag filter pattern exceeds %d characters; not firing event",
+                MAX_TAG_REGEX_LENGTH,
+            )
+            return False
+
         # Try parsing the regex string as a regular expression. If we fail, we fail to fire
         # the event.
         try:
-            matcher = re.compile(str(tag_regex))
-        except Exception:
-            logger.warning("Regular expression error for vulnerability event filter: %s", tag_regex)
+            matcher = _compile_tag_regex(pattern)
+        except regex.error:
+            logger.warning("Regular expression error for vulnerability event filter: %s", pattern)
             return False
 
         # Only fire the event if at least one referencing tag matches the pattern. An empty
-        # tag list (or no tags at all) never matches.
-        return any(matcher.match(tag) for tag in event_data.get("tags", []))
+        # tag list (or no tags at all) never matches. Matching runs under a per-tag timeout so
+        # a crafted, catastrophically-backtracking pattern cannot exhaust worker CPU (ReDoS);
+        # on timeout we conservatively treat the tag as non-matching.
+        for tag in event_data.get("tags", []):
+            try:
+                if matcher.match(tag, timeout=TAG_REGEX_MATCH_TIMEOUT):
+                    return True
+            except TimeoutError:
+                logger.warning(
+                    "Regex match timed out for vulnerability event filter pattern %s against tag %s",
+                    pattern,
+                    tag,
+                )
+        return False
 
     def should_perform(self, event_data, notification_data):
         event_config = notification_data.event_config_dict

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -35,6 +35,12 @@ class InvalidNotificationEventException(Exception):
     pass
 
 
+class InvalidNotificationEventConfigException(Exception):
+    """Raised when a notification's event config fails validation at creation time."""
+
+    pass
+
+
 class NotificationEvent(object):
     def __init__(self):
         pass
@@ -75,6 +81,17 @@ class NotificationEvent(object):
         By default returns True.
         """
         return True
+
+    def validate_event_config(self, event_config):
+        """
+        Validates the event-specific config supplied when creating a notification.
+
+        Called at notification-creation time so that invalid config is rejected with an API
+        validation error rather than silently breaking the notification when it later fires.
+        Subclasses raise InvalidNotificationEventConfigException for invalid config. By default
+        there is nothing to validate.
+        """
+        pass
 
     @classmethod
     def event_name(cls):
@@ -226,6 +243,28 @@ class VulnerabilityFoundEvent(NotificationEvent):
                 },
             },
         )
+
+    def validate_event_config(self, event_config):
+        # Validate the optional tag filter up front so a bad pattern is rejected with an API
+        # error at creation time, instead of silently suppressing every notification when it
+        # later fails to compile or is refused for being too long at match time.
+        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX) or None
+        if tag_regex is None:
+            return
+
+        pattern = str(tag_regex)
+        if len(pattern) > MAX_TAG_REGEX_LENGTH:
+            raise InvalidNotificationEventConfigException(
+                "Tag filter regular expression exceeds the maximum length of %d characters"
+                % MAX_TAG_REGEX_LENGTH
+            )
+
+        try:
+            _compile_tag_regex(pattern)
+        except regex.error as ex:
+            raise InvalidNotificationEventConfigException(
+                "Invalid tag filter regular expression: %s" % ex
+            )
 
     def _matches_tag_filter(self, event_data, tag_regex):
         # Reject overly long patterns outright: they only add to matching cost and a

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -25,6 +25,14 @@ MAX_TAG_REGEX_LENGTH = 256
 # ReDoS pattern (e.g. "^(a+)+$") that would otherwise pin CPU on a long non-matching tag.
 TAG_REGEX_MATCH_TIMEOUT = 1.0
 
+# Mirrors the TAG_LIMIT the notification producers apply when calling
+# tag_names_for_manifest (workers/securityscanningnotificationworker.py and
+# data/secscan_model/secscan_v4_model*.py). When a manifest carries more referencing tags than
+# this, the producer truncates the list before it reaches the filter, so a matching tag beyond
+# the cap would be invisible here. Kept as a local copy to avoid importing the worker/secscan
+# modules (which would create an import cycle); it must stay in sync with those producers.
+PRODUCER_TAG_LIMIT = 100
+
 
 @lru_cache(maxsize=256)
 def _compile_tag_regex(pattern: str) -> Pattern[str]:
@@ -285,13 +293,24 @@ class VulnerabilityFoundEvent(NotificationEvent):
             logger.warning("Regular expression error for vulnerability event filter: %s", pattern)
             return False
 
-        # Only fire the event if at least one referencing tag matches the pattern. An empty
-        # tag list (or no tags at all) never matches. Matching runs under a per-tag timeout so
-        # a crafted, catastrophically-backtracking pattern cannot exhaust worker CPU (ReDoS);
-        # on timeout we conservatively treat the tag as non-matching.
-        for tag in event_data.get("tags", []):
+        # Only fire the event if at least one referencing tag matches the pattern as a whole.
+        # We use fullmatch (not match, which anchors only at the start, so "latest" would match
+        # "latest-extra") to keep the filter consistent with immutability tag patterns and the
+        # UI placeholder "(v2\..*)|(latest)", which imply whole-tag matching. An empty tag list
+        # (or no tags at all) never matches. Matching runs under a per-tag timeout so a crafted,
+        # catastrophically-backtracking pattern cannot exhaust worker CPU (ReDoS); on timeout we
+        # conservatively treat the tag as non-matching.
+        tags = event_data.get("tags", [])
+        for tag in tags:
+            # Producers substitute the manifest digest (e.g. "sha256:...") for the tag list when
+            # a manifest has no referencing tags. A digest is not a tag reference, and the UI
+            # promises matching against tag(s), so it must never satisfy the filter. Per the
+            # Docker tag grammar ([A-Za-z0-9_][A-Za-z0-9_.-]{0,127}) a tag can never contain a
+            # colon, so any entry with one is a digest (or otherwise not a tag) and is skipped.
+            if not isinstance(tag, str) or ":" in tag:
+                continue
             try:
-                if matcher.match(tag, timeout=TAG_REGEX_MATCH_TIMEOUT):
+                if matcher.fullmatch(tag, timeout=TAG_REGEX_MATCH_TIMEOUT):
                     return True
             except TimeoutError:
                 logger.warning(
@@ -299,6 +318,22 @@ class VulnerabilityFoundEvent(NotificationEvent):
                     pattern,
                     tag,
                 )
+
+        # Fail open on truncation. The producers cap the referencing tags at PRODUCER_TAG_LIMIT,
+        # so when the delivered list is at (or above) that cap a matching tag may have been
+        # dropped before it reached us. Silently suppressing a security notification is worse
+        # than a possible false positive, so in that case we fire anyway.
+        if len(tags) >= PRODUCER_TAG_LIMIT:
+            logger.warning(
+                "Vulnerability event tag filter %s matched none of %d tags, at or above the "
+                "producer tag limit of %d; firing anyway to avoid suppressing a security "
+                "notification whose matching tag may have been truncated",
+                pattern,
+                len(tags),
+                PRODUCER_TAG_LIMIT,
+            )
+            return True
+
         return False
 
     def should_perform(self, event_data, notification_data):

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -39,6 +39,15 @@ def _compile_tag_regex(pattern: str) -> Pattern[str]:
     return regex.compile(pattern)
 
 
+def _tag_filter_unset(tag_regex) -> bool:
+    # None (absent key) or "" (the React form posts an empty string when the field is left
+    # blank) means no tag filter is configured. Every other value, including a falsey
+    # non-string like 0, False, [] or {}, is a real (and, unless a str, invalid) filter and
+    # must not be collapsed to "unset" -- doing so would disable the filter and notify on
+    # every tag.
+    return tag_regex is None or tag_regex == ""
+
+
 class InvalidNotificationEventException(Exception):
     pass
 
@@ -256,8 +265,8 @@ class VulnerabilityFoundEvent(NotificationEvent):
         # Validate the optional tag filter up front so a bad pattern is rejected with an API
         # error at creation time, instead of silently suppressing every notification when it
         # later fails to compile or is refused for being too long at match time.
-        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX) or None
-        if tag_regex is None:
+        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX)
+        if _tag_filter_unset(tag_regex):
             return
 
         # Require a string. Without this, a non-string value (e.g. 123, ["["], {"x": "y"}) would
@@ -359,8 +368,8 @@ class VulnerabilityFoundEvent(NotificationEvent):
 
         # Filter on the referencing tags, if a tag pattern is configured. This is independent
         # of the severity level filter below; when both are set, both must pass.
-        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX) or None
-        if tag_regex is not None and not self._matches_tag_filter(event_data, tag_regex):
+        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX)
+        if not _tag_filter_unset(tag_regex) and not self._matches_tag_filter(event_data, tag_regex):
             return False
 
         if VulnerabilityFoundEvent.CONFIG_LEVEL not in event_config:

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -170,6 +170,7 @@ def _build_summary(event_data):
 
 class VulnerabilityFoundEvent(NotificationEvent):
     CONFIG_LEVEL = "level"
+    CONFIG_TAG_REGEX = "tag-regex"
     PRIORITY_KEY = "priority"
     VULNERABILITY_KEY = "vulnerability"
     MULTIPLE_VULNERABILITY_KEY = "vulnerabilities"
@@ -207,8 +208,28 @@ class VulnerabilityFoundEvent(NotificationEvent):
             },
         )
 
+    def _matches_tag_filter(self, event_data, tag_regex):
+        # Try parsing the regex string as a regular expression. If we fail, we fail to fire
+        # the event.
+        try:
+            matcher = re.compile(str(tag_regex))
+        except Exception:
+            logger.warning("Regular expression error for vulnerability event filter: %s", tag_regex)
+            return False
+
+        # Only fire the event if at least one referencing tag matches the pattern. An empty
+        # tag list (or no tags at all) never matches.
+        return any(matcher.match(tag) for tag in event_data.get("tags", []))
+
     def should_perform(self, event_data, notification_data):
         event_config = notification_data.event_config_dict
+
+        # Filter on the referencing tags, if a tag pattern is configured. This is independent
+        # of the severity level filter below; when both are set, both must pass.
+        tag_regex = event_config.get(VulnerabilityFoundEvent.CONFIG_TAG_REGEX) or None
+        if tag_regex is not None and not self._matches_tag_filter(event_data, tag_regex):
+            return False
+
         if VulnerabilityFoundEvent.CONFIG_LEVEL not in event_config:
             return True
 

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -20,9 +20,10 @@ TEMPLATE_ENV = get_template_env("events")
 # surface for catastrophic backtracking.
 MAX_TAG_REGEX_LENGTH = 256
 
-# Per-tag evaluation budget, in seconds, for the vulnerability tag filter. The `regex`
-# module aborts a match that exceeds this, protecting the notification worker from a crafted
-# ReDoS pattern (e.g. "^(a+)+$") that would otherwise pin CPU on a long non-matching tag.
+# Per-event evaluation budget, in seconds, for the vulnerability tag filter. This is a single
+# deadline for the whole tag loop, not a per-tag timeout: the `regex` module aborts any match
+# that would run past the remaining budget, protecting the notification worker from a crafted
+# ReDoS pattern (e.g. "^(a+)+$") that would otherwise pin CPU across many non-matching tags.
 TAG_REGEX_MATCH_TIMEOUT = 1.0
 
 # Mirrors the TAG_LIMIT the notification producers apply when calling
@@ -324,11 +325,12 @@ class VulnerabilityFoundEvent(NotificationEvent):
         # We use fullmatch (not match, which anchors only at the start, so "latest" would match
         # "latest-extra") to keep the filter consistent with immutability tag patterns and the
         # UI placeholder "(v2\..*)|(latest)", which imply whole-tag matching. An empty tag list
-        # (or no tags at all) never matches. Matching runs under a per-tag timeout so a crafted,
-        # catastrophically-backtracking pattern cannot exhaust worker CPU (ReDoS); on timeout we
-        # conservatively treat the tag as non-matching.
+        # (or no tags at all) never matches. The whole tag loop runs under a single deadline so a
+        # crafted, catastrophically-backtracking pattern cannot exhaust worker CPU (ReDoS) even
+        # across many non-matching tags; on timeout we conservatively treat the tag as non-matching.
         tags = event_data.get("tags", [])
-        for tag in tags:
+        deadline = time.monotonic() + TAG_REGEX_MATCH_TIMEOUT
+        for i, tag in enumerate(tags):
             # Producers substitute the manifest digest (e.g. "sha256:...") for the tag list when
             # a manifest has no referencing tags. A digest is not a tag reference, and the UI
             # promises matching against tag(s), so it must never satisfy the filter. Per the
@@ -336,8 +338,18 @@ class VulnerabilityFoundEvent(NotificationEvent):
             # colon, so any entry with one is a digest (or otherwise not a tag) and is skipped.
             if not isinstance(tag, str) or ":" in tag:
                 continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    "Regex match budget exhausted for vulnerability event filter pattern %s; "
+                    "%d of %d tags left unevaluated",
+                    pattern,
+                    len(tags) - i,
+                    len(tags),
+                )
+                break
             try:
-                if matcher.fullmatch(tag, timeout=TAG_REGEX_MATCH_TIMEOUT):
+                if matcher.fullmatch(tag, timeout=remaining):
                     return True
             except TimeoutError:
                 logger.warning(

--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -260,7 +260,15 @@ class VulnerabilityFoundEvent(NotificationEvent):
         if tag_regex is None:
             return
 
-        pattern = str(tag_regex)
+        # Require a string. Without this, a non-string value (e.g. 123, ["["], {"x": "y"}) would
+        # be coerced with str() and stored as a "regex" that can never behave as the caller
+        # intended.
+        if not isinstance(tag_regex, str):
+            raise InvalidNotificationEventConfigException(
+                "Tag filter regular expression must be a string"
+            )
+
+        pattern = tag_regex
         if len(pattern) > MAX_TAG_REGEX_LENGTH:
             raise InvalidNotificationEventConfigException(
                 "Tag filter regular expression exceeds the maximum length of %d characters"
@@ -275,9 +283,19 @@ class VulnerabilityFoundEvent(NotificationEvent):
             )
 
     def _matches_tag_filter(self, event_data, tag_regex):
+        # A non-string pattern cannot be a valid regex (validate_event_config now rejects one at
+        # creation time, but a config persisted before that check, or reached via another path,
+        # could still carry one). Treat it as no match rather than coercing it with str().
+        if not isinstance(tag_regex, str):
+            logger.warning(
+                "Vulnerability event tag filter is not a string (%s); not firing event",
+                type(tag_regex).__name__,
+            )
+            return False
+
         # Reject overly long patterns outright: they only add to matching cost and a
         # legitimate tag filter never needs to be this large.
-        pattern = str(tag_regex)
+        pattern = tag_regex
         if len(pattern) > MAX_TAG_REGEX_LENGTH:
             logger.warning(
                 "Vulnerability event tag filter pattern exceeds %d characters; not firing event",

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -344,6 +344,26 @@ def test_vulnerability_notification_tag_regex_redos_bounded():
     assert elapsed < 10
 
 
+def test_vulnerability_notification_tag_regex_total_time_bounded(monkeypatch):
+    # A single deadline caps the whole tag loop, not each tag: even a full PRODUCER_TAG_LIMIT
+    # list of evil tags against a backtracking pattern is evaluated within roughly one budget,
+    # not PRODUCER_TAG_LIMIT budgets. With the list at the cap, the loop then fails open and fires.
+    monkeypatch.setattr(notificationevent, "TAG_REGEX_MATCH_TIMEOUT", 0.2)
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "^(a+)+$"}})
+    evil_tags = ["a" * 40 + "!"] * PRODUCER_TAG_LIMIT
+    assert len(evil_tags) == PRODUCER_TAG_LIMIT
+
+    start = time.perf_counter()
+    result = VulnerabilityFoundEvent().should_perform({"tags": evil_tags}, notification_data)
+    elapsed = time.perf_counter() - start
+
+    # Per-tag timeouts would allow up to PRODUCER_TAG_LIMIT * 0.2 = 20s; the per-event deadline
+    # keeps the total well under that.
+    assert elapsed < 5
+    # The list is at the producer cap, so the fail-open rule fires even though nothing matched.
+    assert result
+
+
 def test_vulnerability_notification_tag_regex_whole_tag_match():
     # fullmatch semantics: a filter must match the whole tag, not just a prefix.
     notification_data = AttrDict({"event_config_dict": {"tag-regex": "latest"}})

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -2,8 +2,10 @@ import time
 
 import pytest
 
+import notifications.notificationevent as notificationevent
 from notifications.notificationevent import (
     MAX_TAG_REGEX_LENGTH,
+    PRODUCER_TAG_LIMIT,
     BuildSuccessEvent,
     InvalidNotificationEventConfigException,
     NotificationEvent,
@@ -340,6 +342,60 @@ def test_vulnerability_notification_tag_regex_redos_bounded():
     # Without the timeout this pattern runs for many seconds; allow generous headroom over the
     # 1.0s budget to stay stable in CI while still proving evaluation is bounded.
     assert elapsed < 10
+
+
+def test_vulnerability_notification_tag_regex_whole_tag_match():
+    # fullmatch semantics: a filter must match the whole tag, not just a prefix.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "latest"}})
+    assert VulnerabilityFoundEvent().should_perform({"tags": ["latest"]}, notification_data)
+    assert not VulnerabilityFoundEvent().should_perform(
+        {"tags": ["latest-extra"]}, notification_data
+    )
+
+
+def test_vulnerability_notification_tag_regex_skips_digest():
+    # Producers substitute the manifest digest for the tag list when a manifest has no tags. A
+    # broad filter must not match the digest, since it is not a tag reference.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": ".*"}})
+    assert not VulnerabilityFoundEvent().should_perform(
+        {"tags": ["sha256:" + "a" * 64]}, notification_data
+    )
+
+
+def test_vulnerability_notification_tag_regex_fails_open_at_producer_limit():
+    # A non-matching tag list at the producer cap may have had a matching tag truncated away, so
+    # the filter fails open and fires; just below the cap it does not.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "no-such-tag"}})
+
+    at_limit = ["tag-%d" % i for i in range(PRODUCER_TAG_LIMIT)]
+    assert len(at_limit) == PRODUCER_TAG_LIMIT
+    assert VulnerabilityFoundEvent().should_perform({"tags": at_limit}, notification_data)
+
+    below_limit = ["tag-%d" % i for i in range(PRODUCER_TAG_LIMIT - 1)]
+    assert not VulnerabilityFoundEvent().should_perform({"tags": below_limit}, notification_data)
+
+
+def test_validate_event_config_rejects_non_string_tag_regex():
+    for bad in (123, ["["], {"x": "y"}):
+        with pytest.raises(InvalidNotificationEventConfigException):
+            VulnerabilityFoundEvent().validate_event_config({"tag-regex": bad})
+
+
+def test_vulnerability_notification_non_string_tag_regex():
+    # A non-string pattern reaching the matcher (e.g. a config persisted before validation was
+    # added) is treated as no match rather than coerced.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": 123}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": ["123"]}, notification_data)
+
+
+def test_vulnerability_notification_tag_regex_timeout(monkeypatch):
+    # Deterministically exercise the timeout path: a catastrophically-backtracking pattern
+    # against a long non-matching tag with a tiny per-tag budget must abort and not fire, without
+    # raising.
+    monkeypatch.setattr(notificationevent, "TAG_REGEX_MATCH_TIMEOUT", 0.000001)
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "^(a+)+$"}})
+    evil_tag = "a" * 10000 + "b"
+    assert not VulnerabilityFoundEvent().should_perform({"tags": [evil_tag]}, notification_data)
 
 
 class TestQuotaWarningEvent:

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -5,6 +5,7 @@ import pytest
 from notifications.notificationevent import (
     MAX_TAG_REGEX_LENGTH,
     BuildSuccessEvent,
+    InvalidNotificationEventConfigException,
     NotificationEvent,
     QuotaErrorEvent,
     QuotaWarningEvent,
@@ -298,6 +299,24 @@ def test_vulnerability_notification_tag_regex_and_level():
     assert not VulnerabilityFoundEvent().should_perform(
         {"tags": ["v1.0"], "vulnerability": {"priority": "Critical"}}, notification_data
     )
+
+
+def test_validate_event_config_accepts_valid_tag_regex():
+    # A compilable, in-bounds pattern (and a blank/absent one) passes validation.
+    VulnerabilityFoundEvent().validate_event_config({"tag-regex": "^prod-.+$"})
+    VulnerabilityFoundEvent().validate_event_config({"tag-regex": ""})
+    VulnerabilityFoundEvent().validate_event_config({})
+
+
+def test_validate_event_config_rejects_uncompilable_tag_regex():
+    with pytest.raises(InvalidNotificationEventConfigException):
+        VulnerabilityFoundEvent().validate_event_config({"tag-regex": "]["})
+
+
+def test_validate_event_config_rejects_too_long_tag_regex():
+    long_pattern = "a" * (MAX_TAG_REGEX_LENGTH + 1)
+    with pytest.raises(InvalidNotificationEventConfigException):
+        VulnerabilityFoundEvent().validate_event_config({"tag-regex": long_pattern})
 
 
 def test_vulnerability_notification_tag_regex_too_long():

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -251,6 +251,52 @@ def test_vulnerability_notification_normal():
     assert VulnerabilityFoundEvent().should_perform(info, notification_data)
 
 
+def test_vulnerability_notification_no_tag_regex():
+    # No tag-regex configured: fire regardless of tags (backward compatible).
+    notification_data = AttrDict({"event_config_dict": {}})
+    assert VulnerabilityFoundEvent().should_perform({"tags": ["v1.0"]}, notification_data)
+
+
+def test_vulnerability_notification_matching_tag_regex():
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "v2\\..*"}})
+    assert VulnerabilityFoundEvent().should_perform({"tags": ["v1.0", "v2.0"]}, notification_data)
+
+
+def test_vulnerability_notification_nonmatching_tag_regex():
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "v2\\..*"}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": ["v1.0"]}, notification_data)
+
+
+def test_vulnerability_notification_empty_tags_with_regex():
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "v2\\..*"}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": []}, notification_data)
+    assert not VulnerabilityFoundEvent().should_perform({}, notification_data)
+
+
+def test_vulnerability_notification_invalid_tag_regex():
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "]["}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": ["v2.0"]}, notification_data)
+
+
+def test_vulnerability_notification_tag_regex_and_level():
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "v2\\..*", "level": 3}})
+
+    # Tag matches and severity within level: fire.
+    assert VulnerabilityFoundEvent().should_perform(
+        {"tags": ["v2.0"], "vulnerability": {"priority": "Critical"}}, notification_data
+    )
+
+    # Tag matches but severity below the configured level: do not fire.
+    assert not VulnerabilityFoundEvent().should_perform(
+        {"tags": ["v2.0"], "vulnerability": {"priority": "Negligible"}}, notification_data
+    )
+
+    # Severity within level but no matching tag: do not fire.
+    assert not VulnerabilityFoundEvent().should_perform(
+        {"tags": ["v1.0"], "vulnerability": {"priority": "Critical"}}, notification_data
+    )
+
+
 class TestQuotaWarningEvent:
     def test_event_name(self):
         assert QuotaWarningEvent.event_name() == "quota_warning"

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -1,6 +1,9 @@
+import time
+
 import pytest
 
 from notifications.notificationevent import (
+    MAX_TAG_REGEX_LENGTH,
     BuildSuccessEvent,
     NotificationEvent,
     QuotaErrorEvent,
@@ -295,6 +298,29 @@ def test_vulnerability_notification_tag_regex_and_level():
     assert not VulnerabilityFoundEvent().should_perform(
         {"tags": ["v1.0"], "vulnerability": {"priority": "Critical"}}, notification_data
     )
+
+
+def test_vulnerability_notification_tag_regex_too_long():
+    # A pattern beyond the length bound is rejected without attempting to match.
+    long_pattern = "a" * (MAX_TAG_REGEX_LENGTH + 1)
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": long_pattern}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": ["aaa"]}, notification_data)
+
+
+def test_vulnerability_notification_tag_regex_redos_bounded():
+    # A catastrophically-backtracking pattern against a long non-matching tag must not pin the
+    # CPU: the per-tag timeout aborts evaluation and the event does not fire, quickly.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": "^(a+)+$"}})
+    evil_tag = "a" * 40 + "!"
+
+    start = time.perf_counter()
+    result = VulnerabilityFoundEvent().should_perform({"tags": [evil_tag]}, notification_data)
+    elapsed = time.perf_counter() - start
+
+    assert not result
+    # Without the timeout this pattern runs for many seconds; allow generous headroom over the
+    # 1.0s budget to stay stable in CI while still proving evaluation is bounded.
+    assert elapsed < 10
 
 
 class TestQuotaWarningEvent:

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -388,6 +388,34 @@ def test_vulnerability_notification_non_string_tag_regex():
     assert not VulnerabilityFoundEvent().should_perform({"tags": ["123"]}, notification_data)
 
 
+@pytest.mark.parametrize("bad", [0, False, [], {}])
+def test_validate_event_config_rejects_falsey_non_string_tag_regex(bad):
+    # Falsey non-strings (0, False, [], {}) must not be mistaken for "no filter": they are
+    # rejected at creation time, just like any other non-string pattern.
+    with pytest.raises(InvalidNotificationEventConfigException):
+        VulnerabilityFoundEvent().validate_event_config({"tag-regex": bad})
+
+
+@pytest.mark.parametrize("bad", [0, False, [], {}])
+def test_vulnerability_notification_falsey_non_string_tag_regex(bad):
+    # A falsey non-string filter persisted before validation must not disable filtering (which
+    # would notify on every tag); it is treated as no match, so the event does not fire.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": bad}})
+    assert not VulnerabilityFoundEvent().should_perform({"tags": ["v1.0"]}, notification_data)
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_vulnerability_notification_empty_tag_regex_fires(empty):
+    # An empty string (the React form posts "" when the field is left blank) or an absent filter
+    # means no filter is configured, so the event fires regardless of tags.
+    notification_data = AttrDict({"event_config_dict": {"tag-regex": empty}})
+    assert VulnerabilityFoundEvent().should_perform({"tags": ["v1.0"]}, notification_data)
+    # Absent key behaves the same as an explicit empty value.
+    assert VulnerabilityFoundEvent().should_perform(
+        {"tags": ["v1.0"]}, AttrDict({"event_config_dict": {}})
+    )
+
+
 def test_vulnerability_notification_tag_regex_timeout(monkeypatch):
     # Deterministically exercise the timeout path: a catastrophically-backtracking pattern
     # against a long non-matching tag with a tiny per-tag budget must abort and not fire, without

--- a/static/js/services/external-notification-data.js
+++ b/static/js/services/external-notification-data.js
@@ -144,6 +144,15 @@ function(Config, Features, VulnerabilityService, DocumentationService) {
           'values': VulnerabilityService.LEVELS,
           'help_text': 'A vulnerability must have a severity of the chosen level (or higher) ' +
                       'for this notification to fire.',
+        },
+        {
+          'name': 'tag-regex',
+          'type': 'regex',
+          'title': 'matching tag(s)',
+          'help_text': 'An optional regular expression for matching the tag(s) referencing the ' +
+                       'vulnerable image. If left blank, the notification will fire for all tags.',
+          'optional': true,
+          'placeholder': '(v2\\..*)|(latest)'
         }
       ]
     });

--- a/static/js/services/external-notification-data.js
+++ b/static/js/services/external-notification-data.js
@@ -149,8 +149,9 @@ function(Config, Features, VulnerabilityService, DocumentationService) {
           'name': 'tag-regex',
           'type': 'regex',
           'title': 'matching tag(s)',
-          'help_text': 'An optional regular expression for matching the tag(s) referencing the ' +
-                       'vulnerable image. If left blank, the notification will fire for all tags.',
+          'help_text': 'An optional regular expression that must match the whole tag(s) ' +
+                       'referencing the vulnerable image. If left blank, the notification ' +
+                       'will fire for all tags.',
           'optional': true,
           'placeholder': '(v2\\..*)|(latest)'
         }

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -506,7 +506,7 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
 
   test(
     'creates vulnerability notification with tag-regex filter',
-    {tag: '@feature:SECURITY_SCANNER'},
+    {tag: ['@feature:SECURITY_SCANNER', '@PROJQUAY-12540']},
     async ({authenticatedPage, api}) => {
       // Create test organization with repository
       const org = await api.organization('vulnnotif');

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -504,6 +504,66 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
     },
   );
 
+  test(
+    'creates vulnerability notification with tag-regex filter',
+    {tag: '@feature:SECURITY_SCANNER'},
+    async ({authenticatedPage, api}) => {
+      // Create test organization with repository
+      const org = await api.organization('vulnnotif');
+      const repo = await api.repository(org.name, 'vulnrepo');
+
+      // Navigate to repository settings > Events and notifications tab
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=settings`,
+      );
+      await authenticatedPage
+        .getByTestId('settings-tab-eventsandnotifications')
+        .click();
+
+      // Create notification
+      await authenticatedPage
+        .getByRole('button', {name: 'Create notification'})
+        .click();
+
+      // Select the vulnerability found event
+      await authenticatedPage
+        .getByTestId('notification-event-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Package Vulnerability Found'})
+        .click();
+
+      // The tag-regex input should now be visible and optional
+      const tagRegexInput = authenticatedPage.getByTestId(
+        'vulnerability-tag-regex',
+      );
+      await expect(tagRegexInput).toBeVisible();
+      await tagRegexInput.fill('v2\\..*');
+
+      // Select webhook method
+      await authenticatedPage
+        .getByTestId('notification-method-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Webhook POST'})
+        .click();
+      await authenticatedPage
+        .getByTestId('webhook-url-field')
+        .fill('https://example.com/hook');
+
+      // Enter title and submit
+      await authenticatedPage
+        .getByTestId('notification-title')
+        .fill('Vuln Tag Filter');
+      await authenticatedPage.getByTestId('notification-submit-btn').click();
+
+      // Verify notification appears in table
+      await expect(
+        authenticatedPage.locator('tbody', {hasText: 'Vuln Tag Filter'}),
+      ).toBeVisible();
+    },
+  );
+
   test('recipient field: teams, users, and create team modal', async ({
     authenticatedPage,
     api,

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -564,6 +564,77 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
     },
   );
 
+  test(
+    'rejects vulnerability notification with an invalid tag-regex at creation',
+    {tag: ['@feature:SECURITY_SCANNER', '@PROJQUAY-12540']},
+    async ({authenticatedPage, api}) => {
+      // Create test organization with repository
+      const org = await api.organization('vulnnotifbad');
+      const repo = await api.repository(org.name, 'vulnrepo');
+
+      // Navigate to repository settings > Events and notifications tab
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=settings`,
+      );
+      await authenticatedPage
+        .getByTestId('settings-tab-eventsandnotifications')
+        .click();
+
+      // Open the create-notification form and select the vulnerability event
+      await authenticatedPage
+        .getByRole('button', {name: 'Create notification'})
+        .click();
+      await authenticatedPage
+        .getByTestId('notification-event-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Package Vulnerability Found'})
+        .click();
+
+      // Provide an uncompilable regular expression as the tag filter
+      const tagRegexInput = authenticatedPage.getByTestId(
+        'vulnerability-tag-regex',
+      );
+      await expect(tagRegexInput).toBeVisible();
+      await tagRegexInput.fill('[');
+
+      // Configure a valid webhook method + title so only the tag-regex is invalid
+      await authenticatedPage
+        .getByTestId('notification-method-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Webhook POST'})
+        .click();
+      await authenticatedPage
+        .getByTestId('webhook-url-field')
+        .fill('https://example.com/hook');
+      await authenticatedPage
+        .getByTestId('notification-title')
+        .fill('Bad Tag Filter');
+      await authenticatedPage.getByTestId('notification-submit-btn').click();
+
+      // The API rejects the pattern and the form surfaces the validation error
+      // instead of silently creating a broken notification.
+      await expect(
+        authenticatedPage.getByText('Invalid tag filter regular expression', {
+          exact: false,
+        }),
+      ).toBeVisible();
+
+      // No notification was created for the rejected pattern.
+      await expect(
+        authenticatedPage.locator('tbody', {hasText: 'Bad Tag Filter'}),
+      ).toHaveCount(0);
+
+      // Correcting the pattern lets the same submission succeed.
+      await tagRegexInput.fill('v2\\..*');
+      await authenticatedPage.getByTestId('notification-submit-btn').click();
+      await expect(
+        authenticatedPage.locator('tbody', {hasText: 'Bad Tag Filter'}),
+      ).toBeVisible();
+    },
+  );
+
   test('recipient field: teams, users, and create team modal', async ({
     authenticatedPage,
     api,

--- a/web/src/hooks/UseEvents.tsx
+++ b/web/src/hooks/UseEvents.tsx
@@ -13,6 +13,7 @@ import {useQuayConfig} from './UseQuayConfig';
 
 export interface NotificationEventConfig {
   days?: number;
+  'tag-regex'?: string;
 }
 
 export interface NotificationEvent {

--- a/web/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
@@ -33,6 +33,7 @@ import CreateQuayNotification from './NotificationsCreateNotificationQuay';
 import CreateSlackNotification from './NotificationsCreateNotificationSlack';
 import CreateWebhookNotification from './NotificationsCreateNotificationWebhook';
 import RepoEventExpiry from './RepoEventExpiry';
+import RepoEventVulnTagRegex from './RepoEventVulnTagRegex';
 import {CreateTeamModal} from 'src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
 
 export default function CreateNotification(props: CreateNotificationProps) {
@@ -109,6 +110,12 @@ export default function CreateNotification(props: CreateNotificationProps) {
         </FormGroup>
         <Conditional if={event?.type == NotificationEventType.imageExpiry}>
           <RepoEventExpiry
+            eventConfig={eventConfig}
+            setEventConfig={setEventConfig}
+          />
+        </Conditional>
+        <Conditional if={event?.type == NotificationEventType.vulnFound}>
+          <RepoEventVulnTagRegex
             eventConfig={eventConfig}
             setEventConfig={setEventConfig}
           />

--- a/web/src/routes/RepositoryDetails/Settings/RepoEventVulnTagRegex.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/RepoEventVulnTagRegex.tsx
@@ -25,9 +25,9 @@ export default function RepoEventVulnTagRegex(
       />
       <HelperText>
         <HelperTextItem>
-          An optional regular expression for matching the tag(s) referencing the
-          vulnerable image. If left blank, the notification will fire for all
-          tags.
+          An optional regular expression that must match the whole tag(s)
+          referencing the vulnerable image. If left blank, the notification will
+          fire for all tags.
         </HelperTextItem>
       </HelperText>
     </FormGroup>

--- a/web/src/routes/RepositoryDetails/Settings/RepoEventVulnTagRegex.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/RepoEventVulnTagRegex.tsx
@@ -1,0 +1,40 @@
+import {
+  FormGroup,
+  TextInput,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import {NotificationEventConfig} from 'src/hooks/UseEvents';
+
+export default function RepoEventVulnTagRegex(
+  props: RepoEventVulnTagRegexProps,
+) {
+  const onChange = (_event, value) => {
+    props.setEventConfig({...props.eventConfig, 'tag-regex': value});
+  };
+
+  return (
+    <FormGroup fieldId="vulnerability-tag-regex" label="Matching tag(s)">
+      <TextInput
+        value={props.eventConfig?.['tag-regex'] || ''}
+        onChange={onChange}
+        type="text"
+        id="vulnerability-tag-regex"
+        data-testid="vulnerability-tag-regex"
+        placeholder="(v2\..*)|(latest)"
+      />
+      <HelperText>
+        <HelperTextItem>
+          An optional regular expression for matching the tag(s) referencing the
+          vulnerable image. If left blank, the notification will fire for all
+          tags.
+        </HelperTextItem>
+      </HelperText>
+    </FormGroup>
+  );
+}
+
+interface RepoEventVulnTagRegexProps {
+  eventConfig: NotificationEventConfig;
+  setEventConfig: (val: NotificationEventConfig) => void;
+}


### PR DESCRIPTION
Adds a tag-regex filter for vulnerability notifications, so a notification only fires when the affected tag matches a configured regular expression. The backend logic lives in `notifications/notificationevent.py`, with unit tests and a Playwright e2e test covering the new filtering behavior.

Refs [PROJQUAY-12540](https://redhat.atlassian.net/browse/PROJQUAY-12540).

🤖 Generated with [Claude Code](https://claude.com/claude-code)