### PR TITLE
PROJQUAY-12487: feat(auth): authorize workload scope

### DIFF
--- a/auth/test/test_workload_identity.py
+++ b/auth/test/test_workload_identity.py
@@ -1,0 +1,46 @@
+import pytest
+
+from auth.workload_identity import (
+    WorkloadIdentityAuthorizationError,
+    authorize_workload_identity_scope,
+)
+
+ISSUER = "https://kubernetes.default.svc"
+SUBJECT = "system:serviceaccount:quay:controller"
+MAPPING = [{"ISSUER": ISSUER, "SUBJECT": SUBJECT, "SCOPES": "repo:write repo:read"}]
+
+
+@pytest.mark.parametrize(
+    "issuer, subject, requested, expected",
+    [
+        (ISSUER, SUBJECT, "repo:read", "repo:read"),
+        (ISSUER + "/", SUBJECT, "repo:read repo:read", "repo:read"),
+        (ISSUER, SUBJECT, "", "repo:read repo:write"),
+        (ISSUER, SUBJECT, "repo:write repo:read", "repo:read repo:write"),
+    ],
+)
+def test_authorize_workload_identity_scope(issuer, subject, requested, expected):
+    assert authorize_workload_identity_scope(MAPPING, issuer, subject, requested) == expected
+
+
+@pytest.mark.parametrize(
+    "issuer, subject, requested, mappings",
+    [
+        ("https://other", SUBJECT, "repo:read", MAPPING),
+        (ISSUER, SUBJECT + "-evil", "repo:read", MAPPING),
+        (ISSUER, SUBJECT, "repo:admin", MAPPING),
+        (ISSUER, SUBJECT, "   ", [{"ISSUER": ISSUER, "SUBJECT": SUBJECT, "SCOPES": ""}]),
+        (ISSUER, SUBJECT, "repo:read\tbad", MAPPING),
+        (ISSUER, SUBJECT, 'repo:read"bad', MAPPING),
+        (ISSUER, SUBJECT, "repo:read\\bad", MAPPING),
+        (
+            ISSUER,
+            SUBJECT,
+            "repo:read",
+            [{"ISSUER": ISSUER, "SUBJECT": SUBJECT, "SCOPES": "repo:read\tbad"}],
+        ),
+    ],
+)
+def test_authorization_rejects_invalid_mapping(issuer, subject, requested, mappings):
+    with pytest.raises(WorkloadIdentityAuthorizationError):
+        authorize_workload_identity_scope(mappings, issuer, subject, requested)

--- a/auth/workload_identity.py
+++ b/auth/workload_identity.py
@@ -1,0 +1,53 @@
+"""Authorization helpers for Kubernetes workload identity exchange."""
+
+import re
+
+_SCOPE_TOKEN = re.compile(r"^[\x21\x23-\x5b\x5d-\x7e]+$")
+
+
+class WorkloadIdentityAuthorizationError(Exception):
+    """Raised when a trusted workload identity is not authorized."""
+
+
+def _normalize_issuer(issuer: str | None) -> str:
+    return (issuer or "").rstrip("/")
+
+
+def _scope_tokens(value: str | None) -> set[str]:
+    """Parse an OAuth scope string and reject malformed scope-token input."""
+    if value is None or not value:
+        return set()
+    tokens = value.split(" ")
+    if any(
+        not token
+        or not _SCOPE_TOKEN.fullmatch(token)
+        or any(character in token for character in "\\\"'")
+        for token in tokens
+    ):
+        raise WorkloadIdentityAuthorizationError("scope contains invalid characters")
+    return set(tokens)
+
+
+def authorize_workload_identity_scope(
+    authorized_subjects: list[dict], issuer: str, subject: str, requested_scope: str
+) -> str:
+    """Return the canonical scope allowed for an exact issuer and subject."""
+    normalized = _normalize_issuer(issuer)
+    mapping = next(
+        (
+            item
+            for item in authorized_subjects
+            if _normalize_issuer(item.get("ISSUER")) == normalized
+            and item.get("SUBJECT") == subject
+        ),
+        None,
+    )
+    if mapping is None:
+        raise WorkloadIdentityAuthorizationError("Kubernetes ServiceAccount is not authorized")
+    allowed = _scope_tokens(mapping.get("SCOPES"))
+    requested = _scope_tokens(requested_scope) if requested_scope else allowed
+    if not allowed or not requested or not requested.issubset(allowed):
+        raise WorkloadIdentityAuthorizationError(
+            "requested scope is not authorized for the Kubernetes ServiceAccount"
+        )
+    return " ".join(sorted(requested))

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -11,6 +11,10 @@ from auth.kubernetes_sa import (
     KubernetesSATokenValidationError,
     KubernetesSATokenValidator,
 )
+from auth.workload_identity import (
+    WorkloadIdentityAuthorizationError,
+    authorize_workload_identity_scope,
+)
 from data.database import OAuthAccessToken
 from data.model import db_transaction
 from data.model.oauth import (
@@ -21,6 +25,9 @@ from data.model.oauth import (
 )
 from endpoints.api import ApiResource, nickname, resource, show_if
 from endpoints.decorators import anon_allowed
+
+# Compatibility alias for callers of the former endpoint-local helper.
+authorize_workload_scope = authorize_workload_identity_scope
 from endpoints.exception import (
     ApiErrorType,
     ApiException,
@@ -42,6 +49,8 @@ class BootstrapTokenCleanupError(Exception):
 
 
 class BootstrapExchangeError(ApiException):
+    """Represent an OAuth token-exchange error as a Quay API problem."""
+
     _ERROR_TYPES = {
         "invalid_request": ApiErrorType.invalid_request,
         "invalid_token": ApiErrorType.invalid_token,
@@ -110,6 +119,7 @@ def _is_local_bootstrap_renewal_request(req: Request) -> bool:
 
 
 def _exchange_bootstrap_token():
+    """Validate an exchange request and mint its bounded bootstrap token."""
     values = request.form
     required = ("grant_type", "subject_token", "subject_token_type")
     if (
@@ -118,13 +128,29 @@ def _exchange_bootstrap_token():
         or values.get("subject_token_type") != "urn:ietf:params:oauth:token-type:jwt"
     ):
         _exchange_error("invalid_request", "invalid token exchange request", 400)
+    raw = values["subject_token"]
     try:
         validated = KubernetesSATokenValidator(
             _exchange_config(), app.config["HTTPCLIENT"], model_cache
-        ).validate(values["subject_token"])
+        ).validate(raw)
     except KubernetesSATokenValidationError:
         _exchange_error("invalid_token", "Kubernetes ServiceAccount token failed validation", 401)
-    _exchange_error("server_error", "workload identity authorization is not available", 503)
+    issuer = validated.issuer
+    subject = validated.subject
+    try:
+        effective_scope = authorize_workload_identity_scope(
+            _exchange_config().get("AUTHORIZED_SUBJECTS", []),
+            issuer,
+            subject,
+            values.get("scope", ""),
+        )
+    except WorkloadIdentityAuthorizationError as exc:
+        _exchange_error("access_denied", str(exc), 403)
+    _exchange_error(
+        "server_error",
+        "workload identity token issuance is not available",
+        503,
+    )
 
 
 @resource("/v1/bootstrap/exchange")
@@ -133,6 +159,7 @@ class BootstrapTokenExchange(ApiResource):
     @anon_allowed
     @nickname("exchangeBootstrapToken")
     def post(self):
+        """Exchange a Kubernetes ServiceAccount JWT for a scoped token."""
         return _exchange_bootstrap_token()
 
 

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -116,6 +116,28 @@ def test_exchange_normalizes_issuer_trailing_slashes():
     )
 
 
+def test_authorize_workload_scope_normalizes_issuer_and_scope():
+    from endpoints.api.bootstrap import authorize_workload_scope
+
+    authorized_subjects = [
+        {
+            "ISSUER": "https://cluster.example.com",
+            "SUBJECT": "system:serviceaccount:quay:operator",
+            "SCOPES": "org:admin repo:read",
+        }
+    ]
+
+    assert (
+        authorize_workload_scope(
+            authorized_subjects,
+            "https://cluster.example.com/",
+            "system:serviceaccount:quay:operator",
+            "repo:read",
+        )
+        == "repo:read"
+    )
+
+
 def test_exchange_expiration_is_bounded_by_maximum():
     from endpoints.api.bootstrap import _exchange_expiration_seconds
 

--- a/web/playwright/e2e/api/bootstrap-exchange.spec.ts
+++ b/web/playwright/e2e/api/bootstrap-exchange.spec.ts
@@ -42,7 +42,12 @@ async function expectInvalidToken(response: {
 test.describe(
   'Kubernetes ServiceAccount workload identity exchange API',
   {
-    tag: ['@api', '@feature:KUBERNETES_SA_BOOTSTRAP', '@PROJQUAY-12484'],
+    tag: [
+      '@api',
+      '@feature:KUBERNETES_SA_BOOTSTRAP',
+      '@PROJQUAY-12484',
+      '@PROJQUAY-12487',
+    ],
   },
   () => {
     test('rejects a malformed subject token', async ({playwright}) => {
@@ -123,17 +128,22 @@ test.describe(
       playwright,
     }) => {
       const subjectToken = process.env.WORKLOAD_IDENTITY_SUBJECT_TOKEN;
-      test.skip(!subjectToken, 'WORKLOAD_IDENTITY_SUBJECT_TOKEN is not set');
+      const configuredScope = process.env.WORKLOAD_IDENTITY_SCOPE;
+      test.skip(
+        !subjectToken || !configuredScope,
+        'WORKLOAD_IDENTITY_SUBJECT_TOKEN and WORKLOAD_IDENTITY_SCOPE are required',
+      );
 
+      const requestedScope = `${configuredScope} ${configuredScope}`;
+      const expectedScope = [...new Set(requestedScope.split(/\s+/))]
+        .sort()
+        .join(' ');
       const request = await playwright.request.newContext({
         ignoreHTTPSErrors: true,
       });
       try {
         const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
-          form: exchangeForm(
-            subjectToken!,
-            process.env.WORKLOAD_IDENTITY_SCOPE,
-          ),
+          form: exchangeForm(subjectToken!, requestedScope),
         });
         expect(response.status()).toBe(200);
         const body = (await response.json()) as {
@@ -145,13 +155,43 @@ test.describe(
         expect(body.access_token).toEqual(expect.any(String));
         expect(body.token_type).toBe('Bearer');
         expect(body.expires_in).toEqual(expect.any(Number));
-        expect(body.scope).toEqual(expect.any(String));
+        expect(body.scope).toBe(expectedScope);
 
         const managementResponse = await request.get(
           `${API_URL}${process.env.WORKLOAD_IDENTITY_MANAGEMENT_PATH ?? '/api/v1/user/'}`,
           {headers: {Authorization: `Bearer ${body.access_token}`}},
         );
         expect(managementResponse.status()).toBe(200);
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('rejects a request containing an unauthorized scope', async ({
+      playwright,
+    }) => {
+      const subjectToken = process.env.WORKLOAD_IDENTITY_SUBJECT_TOKEN;
+      const configuredScope = process.env.WORKLOAD_IDENTITY_SCOPE;
+      test.skip(
+        !subjectToken || !configuredScope,
+        'WORKLOAD_IDENTITY_SUBJECT_TOKEN and WORKLOAD_IDENTITY_SCOPE are required',
+      );
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const response = await request.post(`${API_URL}${EXCHANGE_PATH}`, {
+          form: exchangeForm(subjectToken!, `${configuredScope} unknown:scope`),
+        });
+        expect(response.status()).toBe(403);
+        const body = (await response.json()) as {
+          access_token?: string;
+          error_type?: string;
+          error?: string;
+        };
+        expect(body.access_token).toBeUndefined();
+        expect(body.error_type ?? body.error).toBe('unauthorized');
       } finally {
         await request.dispose();
       }


### PR DESCRIPTION
 Authorizes workload-identity token scopes by matching the validated Kubernetes ServiceAccount against the
 administrator-configured `AUTHORIZED_SUBJECTS` allow-list.

   Only an exact issuer and subject match is accepted. Requested scopes must be a subset of the scopes configured for that
 ServiceAccount; identities without an explicit entry, excessive scopes, malformed scopes, and wildcard-like subjects are
 rejected.

   When no scope is requested, the token receives all scopes configured for the matched ServiceAccount. The resulting
 effective scope is then used consistently for token issuance and in the response.

   ## Changes

   - Extract workload scope authorization into a dedicated helper.
   - Require exact issuer and ServiceAccount subject matches.
   - Reject unauthorized or malformed scope requests.
   - Default omitted scopes to the matched subject’s complete allow-list.
   - Return the normalized, effective scope for downstream token issuance.
   - Add unit coverage for exact matching, scope enforcement, omitted scopes, duplicate scopes, and invalid requests.

   ## Testing

   - `TEST=true PYTHONPATH="." pytest endpoints/api/test/test_bootstrap.py -v`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>