### PR TITLE
NO-ISSUE: feat(agents): add Prow/OpenShift CI debug-playwright skill

### DIFF
--- a/.agents/skills/debug-playwright-prow/SKILL.md
+++ b/.agents/skills/debug-playwright-prow/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: debug-playwright-prow
+description: >
+  Debug Playwright E2E test failures from Prow/OpenShift CI runs.
+  Downloads artifacts from GCS, categorizes failures (flaky/real/infra),
+  correlates with build logs and container logs, and offers fixes.
+argument-hint: PROW_URL
+allowed-tools:
+  - Bash(bash scripts/playwright-debug-prow.sh *)
+  - Bash(curl *)
+  - Read
+  - Grep
+  - Edit
+  - AskUserQuestion
+---
+
+# Debug Playwright CI Failures (Prow/OpenShift CI)
+
+Debug Playwright test failures for Prow job at `$ARGUMENTS`.
+
+## Step 1: Fetch and Categorize
+
+```bash
+bash scripts/playwright-debug-prow.sh $ARGUMENTS
+```
+
+Capture the full JSON output, then extract `artifacts_dir` for use in later commands:
+
+```bash
+PW_JSON=$(bash scripts/playwright-debug-prow.sh $ARGUMENTS)
+ARTIFACTS_DIR=$(echo "$PW_JSON" | jq -r '.artifacts_dir')
+```
+
+Key fields:
+- `artifacts_dir` — temp directory with downloaded artifacts
+- `failed` — tests that failed (real failures), includes `error_message`, `error_detail`, `last_step`, and `error_context`
+- `flaky` — tests that failed then passed on retry (detected from playwright output log)
+- `interrupted` — tests where a worker crashed
+- `stats` — overall run statistics
+- `html_report_url` — link to the HTML report on GCSWeb (if available)
+- `has_playwright_log` / `has_build_log` / `has_container_logs` — what extra data is available
+- `has_jaeger_traces` — always false for Prow (not yet collected; future enhancement)
+- `global_setup_failure` — if true, no tests ran at all (check `setup_errors` field)
+- `prow_url` — link to the Prow job view
+- `gcsweb_url` — link to browse all artifacts on GCSWeb
+
+If exit code is 2, the run is still in progress — tell the user to wait.
+
+## Step 2: Report Overview
+
+Summarize what happened conversationally:
+- Total tests, pass/fail/flaky counts
+- Link to the Prow job (`prow_url`)
+- Link to the HTML report on GCSWeb (`html_report_url`), if available
+- Link to browse all artifacts (`gcsweb_url`)
+- List flaky tests briefly (name + file) — note them but don't deep-dive unless asked
+- Note any interrupted tests (worker crashes)
+
+If `global_setup_failure` is true, report the setup errors and stop.
+
+If there are no real failures, report "all failures were flaky" with the list and stop.
+
+## Step 3: Diagnose Each Real Failure
+
+For each entry in `failed`, perform root cause analysis:
+
+### 3a: Read the test source
+
+Read the failing spec file at the reported line number. The file path from the JSON
+is relative to `web/playwright/e2e/` — resolve it against the quay/quay repo root
+(e.g., `auth/signin.spec.ts` -> `web/playwright/e2e/auth/signin.spec.ts`).
+
+Understand what the test does — what page it navigates to, what selectors it uses,
+what API calls it makes.
+
+Check `last_step` from the JSON — this tells you which Playwright action timed out
+(e.g., `locator.click("button.submit")`).
+
+### 3b: Correlate with build log
+
+If `has_build_log` is true, search for errors around the test failure:
+
+```bash
+grep -n "Traceback\|Error\|FATAL\|FAIL\|panic:" \
+  "$ARTIFACTS_DIR/build-log.txt" | head -30
+```
+
+Look for Python tracebacks, 500 responses, or infrastructure errors that coincide
+with the test failure.
+
+### 3c: Correlate with container logs
+
+If `has_container_logs` is true, search for backend errors:
+
+```bash
+grep -n "Traceback\|Internal Server Error\|FATAL" \
+  "$ARTIFACTS_DIR/container-logs/quay.log" | head -30
+```
+
+Container logs in Prow are collected via the `gather-extra` step rather than
+a dedicated artifact. They may contain quay pod logs, operator logs, or
+must-gather output.
+
+### 3d: Correlate with Playwright output log
+
+If `has_playwright_log` is true, search for additional context:
+
+```bash
+grep -B5 -A10 "FAILED_TEST_NAME" "$ARTIFACTS_DIR/playwright-output.log"
+```
+
+This log contains the raw Playwright test runner output including step-by-step
+actions, retry information, and full error traces.
+
+### 3e: Note on Jaeger traces
+
+Jaeger trace collection is **not yet configured** in the Prow CI pipeline.
+The `has_jaeger_traces` field will always be `false`. If trace correlation
+would help diagnose a timing or backend issue, note this as a limitation
+and suggest the user reproduce locally with Jaeger enabled.
+
+### 3f: Determine auth phase
+
+Check the test's `tags` for `auth:OIDC` or `auth:LDAP`. Tests without auth-specific
+tags run in the DB auth phase (the first phase).
+
+## Step 4: Classify and Explain
+
+For each failure, classify the root cause and explain conversationally:
+- **Selector change** — element not found but backend responded fine
+- **Backend error** — 500/traceback in container logs or build log errors
+- **Timing/race** — intermittent, slow responses, or missing `waitFor`
+- **Auth/config** — failure only in one auth phase, related to auth swap
+- **Test isolation** — leftover state from prior tests causing interference
+- **Infra** — browser crash, connection refused, worker timeout, pod scheduling
+
+For each one, state what the test was trying to do, what went wrong, what the
+build/container logs show, and what a fix would look like.
+
+## Step 5: Offer Fixes
+
+Ask: "Want me to apply fixes for any of these?"
+
+If yes, edit the spec files under `web/playwright/e2e/`. Show what you're changing
+and why. Only edit backend code if the user explicitly asks.
+
+Do NOT auto-commit — let the user review the changes.
+
+## Cleanup
+
+When diagnosis is complete, remove the temp artifacts directory:
+
+```bash
+rm -rf "$ARTIFACTS_DIR"
+```

--- a/.agents/skills/debug-playwright-prow/scripts/playwright-debug-prow.sh
+++ b/.agents/skills/debug-playwright-prow/scripts/playwright-debug-prow.sh
@@ -1,0 +1,1 @@
+../../../../scripts/playwright-debug-prow.sh

--- a/scripts/playwright-debug-prow.sh
+++ b/scripts/playwright-debug-prow.sh
@@ -1,0 +1,453 @@
+#!/bin/bash
+# playwright-debug-prow.sh -- Download and analyze Playwright CI artifacts from Prow/OpenShift CI.
+#
+# Usage:
+#   bash scripts/playwright-debug-prow.sh <PROW_URL>
+#
+# Prow URL formats accepted:
+#   https://prow.ci.openshift.org/view/gs/<bucket>/<path>/<build_id>
+#   https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/<bucket>/<path>/<build_id>/
+#
+# Exit codes:
+#   0 — analyzed successfully
+#   1 — error (no artifacts, bad input, download failure)
+#   2 — run still in progress
+
+set -euo pipefail
+
+INPUT="${1:?Usage: playwright-debug-prow.sh <PROW_URL>}"
+
+# --- URL Parsing ---
+# Normalize the URL and extract GCS bucket, job path, and build ID.
+#
+# Prow view URL:
+#   https://prow.ci.openshift.org/view/gs/BUCKET/logs/JOB_NAME/BUILD_ID
+# GCSWeb URL:
+#   https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/BUCKET/logs/JOB_NAME/BUILD_ID/
+
+GCS_BUCKET=""
+GCS_JOB_PATH=""
+BUILD_ID=""
+JOB_NAME=""
+
+if [[ "$INPUT" =~ ^https://prow\.ci\.openshift\.org/view/gs/([^/]+)/(.+)/([0-9]+)/?$ ]]; then
+  GCS_BUCKET="${BASH_REMATCH[1]}"
+  GCS_JOB_PATH="${BASH_REMATCH[2]}"
+  BUILD_ID="${BASH_REMATCH[3]}"
+elif [[ "$INPUT" =~ ^https://gcsweb-ci[^/]*/gcs/([^/]+)/(.+)/([0-9]+)/?$ ]]; then
+  GCS_BUCKET="${BASH_REMATCH[1]}"
+  GCS_JOB_PATH="${BASH_REMATCH[2]}"
+  BUILD_ID="${BASH_REMATCH[3]}"
+else
+  echo "ERROR: Unrecognized Prow URL format." >&2
+  echo "Expected:" >&2
+  echo "  https://prow.ci.openshift.org/view/gs/<bucket>/logs/<job_name>/<build_id>" >&2
+  echo "  https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/<bucket>/logs/<job_name>/<build_id>/" >&2
+  exit 1
+fi
+
+# Extract the job name (last path component before build ID)
+JOB_NAME=$(basename "$GCS_JOB_PATH")
+
+GCS_BASE="https://storage.googleapis.com/${GCS_BUCKET}/${GCS_JOB_PATH}/${BUILD_ID}"
+GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/${GCS_BUCKET}/${GCS_JOB_PATH}/${BUILD_ID}"
+PROW_URL="https://prow.ci.openshift.org/view/gs/${GCS_BUCKET}/${GCS_JOB_PATH}/${BUILD_ID}"
+
+echo "Job: $JOB_NAME" >&2
+echo "Build ID: $BUILD_ID" >&2
+echo "GCS base: $GCS_BASE" >&2
+
+# --- Check Job Status ---
+# Download prowjob.json to check if the job has completed.
+PROWJOB_JSON=$(curl -sfL "${GCS_BASE}/prowjob.json" 2>/dev/null) || {
+  echo "ERROR: Could not fetch prowjob.json — job may not exist or GCS is unreachable" >&2
+  exit 1
+}
+
+JOB_STATUS=$(echo "$PROWJOB_JSON" | jq -r '.status.state // "unknown"')
+JOB_START=$(echo "$PROWJOB_JSON" | jq -r '.status.startTime // ""')
+JOB_COMPLETION=$(echo "$PROWJOB_JSON" | jq -r '.status.completionTime // ""')
+
+if [ "$JOB_STATUS" != "success" ] && [ "$JOB_STATUS" != "failure" ] && [ "$JOB_STATUS" != "aborted" ] && [ "$JOB_STATUS" != "error" ]; then
+  echo "Job is still $JOB_STATUS (not completed yet)" >&2
+  jq -n --arg build_id "$BUILD_ID" --arg prow_url "$PROW_URL" --arg status "$JOB_STATUS" \
+    '{build_id: $build_id, prow_url: $prow_url, status: $status, error: "job not completed"}'
+  exit 2
+fi
+
+echo "Job status: $JOB_STATUS" >&2
+
+# --- Discover Artifacts ---
+# The e2e step name for Quay Playwright tests is "quay-test-e2e".
+# Artifacts live under: artifacts/<workflow>/<step>/artifacts/
+# We try common step names.
+STEP_NAME="quay-test-e2e"
+
+# Discover the workflow name by listing artifact directories.
+# The workflow name is the first directory under artifacts/.
+# We'll try to download the JUnit XML to confirm the path.
+WORK_DIR=$(mktemp -d)
+echo "Downloading artifacts to $WORK_DIR ..." >&2
+
+# Try to find the correct artifact path by probing for junit_playwright.xml
+JUNIT_FOUND=false
+ARTIFACT_BASE=""
+
+# Build a list of candidate artifact base paths to probe.
+# The structure is: artifacts/{workflow_name}/{step_name}/artifacts/
+# We try the step name directly under common workflow patterns.
+# First, try fetching the started.json to get more context
+STARTED_JSON=$(curl -sfL "${GCS_BASE}/started.json" 2>/dev/null || echo "{}")
+
+# Probe for JUnit XML at the expected artifact paths
+# Pattern: artifacts/{workflow}/{step}/artifacts/junit_playwright.xml
+for step in "$STEP_NAME" "e2e" "e2e-test" "quay-e2e"; do
+  PROBE_URL="${GCS_BASE}/artifacts/${step}/artifacts/junit_playwright.xml"
+  if curl -sfL --head "$PROBE_URL" >/dev/null 2>&1; then
+    ARTIFACT_BASE="${GCS_BASE}/artifacts/${step}/artifacts"
+    STEP_NAME="$step"
+    JUNIT_FOUND=true
+    echo "  Found artifacts at: artifacts/${step}/artifacts/" >&2
+    break
+  fi
+
+  # Also try with a workflow name prefix (artifacts/workflow/step/artifacts/)
+  # Common pattern: the job name contains the workflow info
+  # Try without the workflow prefix as some jobs put artifacts directly
+  PROBE_URL="${GCS_BASE}/artifacts/${step}/junit_playwright.xml"
+  if curl -sfL --head "$PROBE_URL" >/dev/null 2>&1; then
+    ARTIFACT_BASE="${GCS_BASE}/artifacts/${step}"
+    STEP_NAME="$step"
+    JUNIT_FOUND=true
+    echo "  Found artifacts at: artifacts/${step}/ (flat layout)" >&2
+    break
+  fi
+done
+
+# If not found with simple names, try a broader search using the GCS XML API
+if [ "$JUNIT_FOUND" != "true" ]; then
+  echo "  Probing GCS for junit_playwright.xml location..." >&2
+  # Use the GCS XML API to list objects with a prefix filter
+  GCS_LIST_URL="https://storage.googleapis.com/${GCS_BUCKET}?prefix=${GCS_JOB_PATH}/${BUILD_ID}/artifacts/&delimiter=/"
+  ARTIFACT_DIRS=$(curl -sfL "$GCS_LIST_URL" 2>/dev/null | grep -oP '(?<=<Prefix>)[^<]+' || true)
+
+  for dir in $ARTIFACT_DIRS; do
+    # dir looks like: logs/JOB_NAME/BUILD_ID/artifacts/WORKFLOW_NAME/
+    WORKFLOW_DIR=$(basename "$dir")
+    PROBE_URL="https://storage.googleapis.com/${GCS_BUCKET}/${dir}${STEP_NAME}/artifacts/junit_playwright.xml"
+    if curl -sfL --head "$PROBE_URL" >/dev/null 2>&1; then
+      ARTIFACT_BASE="https://storage.googleapis.com/${GCS_BUCKET}/${dir}${STEP_NAME}/artifacts"
+      JUNIT_FOUND=true
+      echo "  Found artifacts at: ${dir}${STEP_NAME}/artifacts/" >&2
+      break
+    fi
+  done
+fi
+
+if [ "$JUNIT_FOUND" != "true" ]; then
+  echo "ERROR: Could not locate junit_playwright.xml in artifacts" >&2
+  echo "  Tried step names: $STEP_NAME, e2e, e2e-test, quay-e2e" >&2
+  echo "  Check the job artifacts at: ${GCSWEB_BASE}/artifacts/" >&2
+  exit 1
+fi
+
+# --- Download Artifacts ---
+HAS_JUNIT=false
+HAS_PLAYWRIGHT_LOG=false
+HAS_BUILD_LOG=false
+HAS_HTML_REPORT=false
+HAS_CONTAINER_LOGS=false
+
+# Download JUnit XML
+curl -sfL "${ARTIFACT_BASE}/junit_playwright.xml" -o "$WORK_DIR/junit_playwright.xml" 2>/dev/null && {
+  HAS_JUNIT=true
+  echo "  Downloaded: junit_playwright.xml" >&2
+} || echo "  Warning: failed to download junit_playwright.xml" >&2
+
+# Download Playwright output log
+curl -sfL "${ARTIFACT_BASE}/playwright-output.log" -o "$WORK_DIR/playwright-output.log" 2>/dev/null && {
+  HAS_PLAYWRIGHT_LOG=true
+  echo "  Downloaded: playwright-output.log" >&2
+} || echo "  Not available: playwright-output.log" >&2
+
+# Download build log (one level up from artifacts/)
+BUILD_LOG_URL="${ARTIFACT_BASE%/artifacts}/build-log.txt"
+curl -sfL "$BUILD_LOG_URL" -o "$WORK_DIR/build-log.txt" 2>/dev/null && {
+  HAS_BUILD_LOG=true
+  echo "  Downloaded: build-log.txt" >&2
+} || echo "  Not available: build-log.txt" >&2
+
+# Check for HTML report
+HTML_REPORT_URL="${ARTIFACT_BASE}/index.html"
+if curl -sfL --head "$HTML_REPORT_URL" >/dev/null 2>&1; then
+  HAS_HTML_REPORT=true
+  echo "  Available: HTML report (index.html)" >&2
+fi
+
+# Check for container logs in gather-extra artifacts
+# Pattern: artifacts/{workflow}/gather-extra/artifacts/...
+GATHER_EXTRA_BASE="${ARTIFACT_BASE%/${STEP_NAME}/artifacts}/gather-extra/artifacts"
+if curl -sfL --head "${GATHER_EXTRA_BASE}/" >/dev/null 2>&1; then
+  # Try to download quay pod logs if they exist
+  mkdir -p "$WORK_DIR/container-logs"
+  # Probe for common quay pod log locations
+  for log_name in "quay-quay.log" "quay.log" "pods/quay.log"; do
+    if curl -sfL "${GATHER_EXTRA_BASE}/${log_name}" -o "$WORK_DIR/container-logs/quay.log" 2>/dev/null; then
+      HAS_CONTAINER_LOGS=true
+      echo "  Downloaded: container logs (${log_name})" >&2
+      break
+    fi
+  done
+  if [ "$HAS_CONTAINER_LOGS" != "true" ]; then
+    echo "  Note: gather-extra exists but no quay pod logs found" >&2
+  fi
+fi
+
+# --- Parse JUnit XML ---
+if [ "$HAS_JUNIT" != "true" ]; then
+  echo "ERROR: JUnit XML is required for analysis" >&2
+  exit 1
+fi
+
+# Use Python to parse JUnit XML — more reliable than xmlstarlet and usually available
+PARSE_RESULT=$(python3 -c '
+import xml.etree.ElementTree as ET
+import json
+import sys
+
+try:
+    tree = ET.parse(sys.argv[1])
+except ET.ParseError as e:
+    print(json.dumps({"parse_error": str(e)}))
+    sys.exit(0)
+
+root = tree.getroot()
+
+stats = {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "flaky": 0,
+    "duration": 0.0
+}
+
+failed = []
+flaky = []
+interrupted = []
+
+# Handle both <testsuites> and <testsuite> as root
+suites = root.findall(".//testsuite") if root.tag == "testsuites" else [root]
+
+for suite in suites:
+    suite_name = suite.get("name", "")
+    stats["total"] += int(suite.get("tests", "0"))
+    stats["failed"] += int(suite.get("failures", "0"))
+    stats["skipped"] += int(suite.get("skipped", "0"))
+    try:
+        stats["duration"] += float(suite.get("time", "0"))
+    except ValueError:
+        pass
+
+    for tc in suite.findall("testcase"):
+        tc_name = tc.get("name", "")
+        tc_classname = tc.get("classname", "")
+        tc_file = tc.get("file", tc_classname)
+        tc_time = tc.get("time", "0")
+
+        failure = tc.find("failure")
+        error = tc.find("error")
+        skipped = tc.find("skipped")
+
+        if failure is not None:
+            error_msg = failure.get("message", "")
+            error_text = (failure.text or "")[:2000]
+            failed.append({
+                "title": tc_name,
+                "file": tc_file,
+                "suite": suite_name,
+                "duration": tc_time,
+                "error_message": error_msg[:500],
+                "error_detail": error_text,
+            })
+        elif error is not None:
+            error_msg = error.get("message", "")
+            error_text = (error.text or "")[:2000]
+            # Interrupted tests usually have "interrupted" in the message
+            if "interrupt" in error_msg.lower():
+                interrupted.append({
+                    "title": tc_name,
+                    "file": tc_file,
+                    "suite": suite_name,
+                })
+            else:
+                failed.append({
+                    "title": tc_name,
+                    "file": tc_file,
+                    "suite": suite_name,
+                    "duration": tc_time,
+                    "error_message": error_msg[:500],
+                    "error_detail": error_text,
+                })
+
+stats["passed"] = stats["total"] - stats["failed"] - stats["skipped"]
+
+print(json.dumps({
+    "stats": stats,
+    "failed": failed,
+    "flaky": flaky,
+    "interrupted": interrupted,
+}, indent=2))
+' "$WORK_DIR/junit_playwright.xml" 2>/dev/null) || {
+  echo "ERROR: Failed to parse JUnit XML" >&2
+  exit 1
+}
+
+# Check for parse error
+PARSE_ERROR=$(echo "$PARSE_RESULT" | jq -r '.parse_error // empty')
+if [ -n "$PARSE_ERROR" ]; then
+  echo "ERROR: JUnit XML parse error: $PARSE_ERROR" >&2
+  exit 1
+fi
+
+STATS=$(echo "$PARSE_RESULT" | jq '.stats')
+FAILED=$(echo "$PARSE_RESULT" | jq '.failed')
+FLAKY=$(echo "$PARSE_RESULT" | jq '.flaky')
+INTERRUPTED=$(echo "$PARSE_RESULT" | jq '.interrupted')
+
+FAILED_COUNT=$(echo "$FAILED" | jq 'length')
+
+# --- Detect Flaky Tests from Playwright Output Log ---
+# The playwright output log may contain retry information that the JUnit XML lacks.
+# If we have the log, look for "retry #N" patterns to identify flaky tests.
+if [ "$HAS_PLAYWRIGHT_LOG" = "true" ]; then
+  FLAKY_FROM_LOG=$(python3 -c '
+import json, re, sys
+
+flaky = []
+seen = set()
+retry_pattern = re.compile(r"\[retry #(\d+)\]")
+
+with open(sys.argv[1]) as f:
+    for line in f:
+        m = retry_pattern.search(line)
+        if m and "passed" in line.lower():
+            # Extract test name from lines like: "[retry #1] ... test-name ... passed"
+            parts = line.strip()
+            if parts not in seen:
+                seen.add(parts)
+                flaky.append({"title": parts, "retries": int(m.group(1))})
+
+print(json.dumps(flaky))
+' "$WORK_DIR/playwright-output.log" 2>/dev/null || echo "[]")
+
+  FLAKY_COUNT=$(echo "$FLAKY_FROM_LOG" | jq 'length')
+  if [ "$FLAKY_COUNT" -gt 0 ]; then
+    FLAKY="$FLAKY_FROM_LOG"
+    echo "  Detected $FLAKY_COUNT flaky test(s) from playwright output log" >&2
+  fi
+fi
+
+# --- Enrich Failed Tests with Context from Playwright Log ---
+# Search the playwright output log for additional context on each failure.
+if [ "$HAS_PLAYWRIGHT_LOG" = "true" ] && [ "$FAILED_COUNT" -gt 0 ]; then
+  FAILED=$(python3 -c '
+import json, sys
+
+failed = json.loads(sys.argv[1])
+log_file = sys.argv[2]
+
+with open(log_file) as f:
+    log_lines = f.readlines()
+
+log_text = "".join(log_lines)
+
+for test in failed:
+    title = test.get("title", "")
+    # Find the last Playwright action before the error (similar to last_step in GHA)
+    context_lines = []
+    in_test = False
+    for i, line in enumerate(log_lines):
+        if title in line:
+            in_test = True
+            context_lines = []
+        elif in_test:
+            stripped = line.strip()
+            if stripped.startswith("locator.") or stripped.startswith("page.") or stripped.startswith("expect("):
+                test["last_step"] = stripped[:200]
+            if "Error:" in line or "Timeout" in line:
+                context_lines.append(stripped[:300])
+                # Grab a few lines after the error
+                for j in range(i+1, min(i+4, len(log_lines))):
+                    context_lines.append(log_lines[j].strip()[:300])
+                break
+
+    if context_lines:
+        test["error_context"] = "\n".join(context_lines)
+
+print(json.dumps(failed))
+' "$FAILED" "$WORK_DIR/playwright-output.log" 2>/dev/null) || true
+fi
+
+# --- Check for Global Setup Failure ---
+GLOBAL_SETUP_FAILURE=false
+SETUP_ERRORS="[]"
+TOTAL_TESTS=$(echo "$STATS" | jq '.total')
+
+if [ "$TOTAL_TESTS" -eq 0 ]; then
+  GLOBAL_SETUP_FAILURE=true
+  # Try to extract setup errors from build log
+  if [ "$HAS_BUILD_LOG" = "true" ]; then
+    SETUP_ERRORS=$(grep -i "error\|fatal\|failed" "$WORK_DIR/build-log.txt" | tail -20 | \
+      python3 -c 'import json,sys; print(json.dumps([l.strip()[:500] for l in sys.stdin.readlines()]))' 2>/dev/null || echo "[]")
+  fi
+fi
+
+# --- Build Report URLs ---
+HTML_REPORT_GCSWEB=""
+if [ "$HAS_HTML_REPORT" = "true" ]; then
+  # Convert GCS URL to GCSWeb URL for browsable access
+  ARTIFACT_PATH="${ARTIFACT_BASE#https://storage.googleapis.com/}"
+  HTML_REPORT_GCSWEB="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/${ARTIFACT_PATH}/index.html"
+fi
+
+# --- Output ---
+jq -n \
+  --arg build_id "$BUILD_ID" \
+  --arg job_name "$JOB_NAME" \
+  --arg prow_url "$PROW_URL" \
+  --arg gcsweb_url "$GCSWEB_BASE" \
+  --arg job_status "$JOB_STATUS" \
+  --arg artifacts_dir "$WORK_DIR" \
+  --arg artifact_base_url "$ARTIFACT_BASE" \
+  --arg html_report_url "$HTML_REPORT_GCSWEB" \
+  --argjson has_playwright_log "$HAS_PLAYWRIGHT_LOG" \
+  --argjson has_build_log "$HAS_BUILD_LOG" \
+  --argjson has_container_logs "$HAS_CONTAINER_LOGS" \
+  --argjson has_jaeger_traces false \
+  --argjson global_setup_failure "$GLOBAL_SETUP_FAILURE" \
+  --argjson stats "$STATS" \
+  --argjson failed "$FAILED" \
+  --argjson flaky "$FLAKY" \
+  --argjson interrupted "$INTERRUPTED" \
+  --argjson setup_errors "$SETUP_ERRORS" \
+  '{
+    build_id: $build_id,
+    job_name: $job_name,
+    prow_url: $prow_url,
+    gcsweb_url: $gcsweb_url,
+    job_status: $job_status,
+    artifacts_dir: $artifacts_dir,
+    artifact_base_url: $artifact_base_url,
+    html_report_url: $html_report_url,
+    has_playwright_log: $has_playwright_log,
+    has_build_log: $has_build_log,
+    has_container_logs: $has_container_logs,
+    has_jaeger_traces: $has_jaeger_traces,
+    global_setup_failure: $global_setup_failure,
+    stats: $stats,
+    failed: $failed,
+    flaky: $flaky,
+    interrupted: $interrupted,
+    setup_errors: $setup_errors
+  }'


### PR DESCRIPTION
Add a Prow-adapted version of the debug-playwright skill that downloads and analyzes Playwright E2E test artifacts from OpenShift CI/Prow runs instead of GitHub Actions.

Key changes from the GHA version:
- Accepts Prow URLs (prow.ci.openshift.org/view/gs/... or gcsweb-ci)
- Downloads artifacts from GCS via curl (no gh CLI dependency)
- Parses JUnit XML with Python for test result categorization
- Discovers artifact paths by probing GCS for junit_playwright.xml
- Links to HTML reports on GCSWeb instead of surge.sh
- Looks for container logs in gather-extra artifacts
- Notes Jaeger traces as a future enhancement (not yet in Prow pipeline)