### PR TITLE
NO-ISSUE: fix(ci): Enable additional playwright tests.

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -288,7 +288,7 @@ jobs:
       - name: Install ORAS for registry interaction tests
         uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6
         with:
-          version: 1.3.4
+          version: 1.2.2
 
       - name: Install regctl for CLI interop tests
         uses: regclient/actions/regctl-installer@1b705e32d40851370799ea5814e83d0a5f6a70dc # v0.1.0

--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -209,6 +209,11 @@ jobs:
               - host.containers.internal
             FEATURE_QUOTA_NOTIFICATIONS: true
             FEATURE_SUPERUSER_CONFIGDUMP: true
+            FOOTER_LINKS:
+              TERMS_OF_SERVICE_URL: https://quay.acme.org/terms
+              PRIVACY_POLICY_URL: https://quay.acme.org/privacy
+              SECURITY_URL: https://quay.acme.org/security
+              ABOUT_URL: https://quay.acme.org/about
       - name: Start LDAP server (pre-initialize for later auth swap)
         run: |
           docker compose up -d ldap

--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -286,7 +286,7 @@ jobs:
           version: v0.20.6
 
       - name: Install ORAS for registry interaction tests
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6
         with:
           version: 1.3.4
 

--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -203,10 +203,14 @@ jobs:
             FEATURE_SECURITY_SCANNER_V2: true
             FEATURE_SECURITY_NOTIFICATIONS: true
             DEFAULT_UI: react
+            FEATURE_SPARSE_INDEX: true
             AUTOPRUNE_TASK_RUN_MINIMUM_INTERVAL_MINUTES: 0
             SSRF_ALLOWED_HOSTS:
               - host.containers.internal
-
+            FEATURE_QUOTA_NOTIFICATIONS: true
+            FEATURE_PROGRAMMATIC_BOOTSTRAP: true
+            BOOTSTRAP_TOKEN_OWNER: admin
+            FEATURE_SUPERUSER_CONFIGDUMP: true
       - name: Start LDAP server (pre-initialize for later auth swap)
         run: |
           docker compose up -d ldap

--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -208,8 +208,6 @@ jobs:
             SSRF_ALLOWED_HOSTS:
               - host.containers.internal
             FEATURE_QUOTA_NOTIFICATIONS: true
-            FEATURE_PROGRAMMATIC_BOOTSTRAP: true
-            BOOTSTRAP_TOKEN_OWNER: admin
             FEATURE_SUPERUSER_CONFIGDUMP: true
       - name: Start LDAP server (pre-initialize for later auth swap)
         run: |
@@ -286,6 +284,11 @@ jobs:
         uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
         with:
           version: v0.20.6
+
+      - name: Install ORAS for registry interaction tests
+        uses: oras-project/setup-oras@v1
+        with:
+          version: 1.3.4
 
       - name: Install regctl for CLI interop tests
         uses: regclient/actions/regctl-installer@1b705e32d40851370799ea5814e83d0a5f6a70dc # v0.1.0

--- a/web/playwright/e2e/namespace-notification-logs.spec.ts
+++ b/web/playwright/e2e/namespace-notification-logs.spec.ts
@@ -29,13 +29,12 @@ test.describe(
       const table = authenticatedPage.getByTestId('usage-logs-table');
       await expect(table).toBeVisible();
 
-      // Verify create log renders a proper description (not "No description available")
-      await expect(table.getByText(/Add notification of event/)).toBeVisible();
-      await expect(table.getByText(/quota_warning/)).toBeVisible();
-
-      // Verify delete log renders a proper description
+      // Verify create and delete logs each reference quota_warning in context
       await expect(
-        table.getByText(/Delete notification of event/),
+        table.getByText(/Add notification of event.*quota_warning/),
+      ).toBeVisible();
+      await expect(
+        table.getByText(/Delete notification of event.*quota_warning/),
       ).toBeVisible();
 
       // Verify no "No description available" fallback

--- a/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
@@ -1,4 +1,5 @@
 import {test, expect} from '../../fixtures';
+import {nsNotificationRow} from '../../utils/namespace-notifications-ui';
 
 test.describe(
   'Namespace Notifications — Cleanup on Deletion',
@@ -42,10 +43,10 @@ test.describe(
         await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
         await authenticatedPage.getByTestId('Notifications').click();
         await expect(
-          authenticatedPage.getByText('Webhook Notification'),
+          nsNotificationRow(authenticatedPage, 'Webhook Notification'),
         ).toBeVisible();
         await expect(
-          authenticatedPage.getByText('Email Notification'),
+          nsNotificationRow(authenticatedPage, /^Email Notification$/),
         ).toBeVisible();
 
         // Delete the quota via API

--- a/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '../../fixtures';
-import {nsNotificationRow} from '../../utils/namespace-notifications-ui';
+import {expectNsNotificationRow} from '../../utils/namespace-notifications-ui';
 
 test.describe(
   'Namespace Notifications — Cleanup on Deletion',
@@ -42,12 +42,11 @@ test.describe(
         // Verify notifications exist in UI
         await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
         await authenticatedPage.getByTestId('Notifications').click();
-        await expect(
-          nsNotificationRow(authenticatedPage, 'Webhook Notification'),
-        ).toBeVisible();
-        await expect(
-          nsNotificationRow(authenticatedPage, 'Email Notification'),
-        ).toBeVisible();
+        await expectNsNotificationRow(
+          authenticatedPage,
+          'Webhook Notification',
+        );
+        await expectNsNotificationRow(authenticatedPage, 'Email Notification');
 
         // Delete the quota via API
         await superuserApi.raw.deleteOrganizationQuota(org.name, quota.quotaId);

--- a/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-cleanup.spec.ts
@@ -46,7 +46,7 @@ test.describe(
           nsNotificationRow(authenticatedPage, 'Webhook Notification'),
         ).toBeVisible();
         await expect(
-          nsNotificationRow(authenticatedPage, /^Email Notification$/),
+          nsNotificationRow(authenticatedPage, 'Email Notification'),
         ).toBeVisible();
 
         // Delete the quota via API

--- a/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImage} from '../../utils/container';
+import {pushImageWithLayerSize} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 
 test.describe(
@@ -46,17 +46,17 @@ test.describe(
             'Dedup Webhook',
           );
 
-          // Push images to cross the 50% threshold (~1.2 MiB each)
+          // Push images to cross the 50% threshold (~1.4 MiB each)
           await api.repositoryWithName(org.name, 'deduprepo1');
           await api.repositoryWithName(org.name, 'deduprepo2');
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'deduprepo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'deduprepo2',
             'v2',
@@ -70,7 +70,7 @@ test.describe(
 
           // Push another image (still above threshold, within cooldown)
           await api.repositoryWithName(org.name, 'deduprepo3');
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'deduprepo3',
             'v3',

--- a/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushUniqueImage} from '../../utils/container';
+import {pushImage} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 
 test.describe(
@@ -46,18 +46,19 @@ test.describe(
             'Dedup Webhook',
           );
 
-          // Push images to cross the 50% threshold
-          await api.repositoryWithName(org.name, 'deduprepo');
-          await pushUniqueImage(
+          // Push images to cross the 50% threshold (~1.2 MiB each)
+          await api.repositoryWithName(org.name, 'deduprepo1');
+          await api.repositoryWithName(org.name, 'deduprepo2');
+          await pushImage(
             org.name,
-            'deduprepo',
+            'deduprepo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushUniqueImage(
+          await pushImage(
             org.name,
-            'deduprepo',
+            'deduprepo2',
             'v2',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
@@ -68,9 +69,10 @@ test.describe(
           expect(firstWebhook).not.toBeNull();
 
           // Push another image (still above threshold, within cooldown)
-          await pushUniqueImage(
+          await api.repositoryWithName(org.name, 'deduprepo3');
+          await pushImage(
             org.name,
-            'deduprepo',
+            'deduprepo3',
             'v3',
             TEST_USERS.user.username,
             TEST_USERS.user.password,

--- a/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-dedup.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImageWithLayerSize} from '../../utils/container';
+import {pushQuotaNotificationImage} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 
 test.describe(
@@ -19,7 +19,7 @@ test.describe(
       'duplicate push within cooldown does not fire second notification',
       {tag: ['@superuser', '@webhook']},
       async ({api, superuserApi}) => {
-        test.setTimeout(120_000);
+        test.setTimeout(300_000);
 
         const org = await api.organization('nsdedup');
 
@@ -46,17 +46,17 @@ test.describe(
             'Dedup Webhook',
           );
 
-          // Push images to cross the 50% threshold (~1.4 MiB each)
+          // Push pinned UBI to cross the 50% threshold (~2.5 MiB of 5 MiB)
           await api.repositoryWithName(org.name, 'deduprepo1');
           await api.repositoryWithName(org.name, 'deduprepo2');
-          await pushImageWithLayerSize(
+          await pushQuotaNotificationImage(
             org.name,
             'deduprepo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushImageWithLayerSize(
+          await pushQuotaNotificationImage(
             org.name,
             'deduprepo2',
             'v2',
@@ -68,9 +68,9 @@ test.describe(
           const firstWebhook = await receiver.waitForWebhook(undefined, 60_000);
           expect(firstWebhook).not.toBeNull();
 
-          // Push another image (still above threshold, within cooldown)
+          // Another upload while above threshold (within cooldown) — dedup should suppress
           await api.repositoryWithName(org.name, 'deduprepo3');
-          await pushImageWithLayerSize(
+          await pushQuotaNotificationImage(
             org.name,
             'deduprepo3',
             'v3',

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImage} from '../../utils/container';
+import {pushImageWithLayerSize} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 import {mailpit} from '../../utils/mailpit';
 
@@ -47,17 +47,17 @@ test.describe(
             'Warning Webhook',
           );
 
-          // Create repos and push images to exceed 80% of 3 MiB (~1.2 MiB each)
+          // Create repos and push images to exceed 80% of 3 MiB (~1.4 MiB each)
           await api.repositoryWithName(org.name, 'repo1');
           await api.repositoryWithName(org.name, 'repo2');
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'repo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'repo2',
             'v2',
@@ -124,7 +124,7 @@ test.describe(
 
           // Create repo and push first image (succeeds)
           await api.repositoryWithName(org.name, 'fillrepo');
-          await pushImage(
+          await pushImageWithLayerSize(
             org.name,
             'fillrepo',
             'v1',
@@ -134,7 +134,7 @@ test.describe(
 
           // Second push should be rejected (over quota)
           try {
-            await pushImage(
+            await pushImageWithLayerSize(
               org.name,
               'fillrepo',
               'v2',
@@ -195,17 +195,17 @@ test.describe(
         // Clear inbox before push
         await mailpit.clearInbox();
 
-        // Push images to exceed warning threshold (~1.2 MiB each)
+        // Push images to exceed warning threshold (~1.4 MiB each)
         await api.repositoryWithName(org.name, 'emailrepo1');
         await api.repositoryWithName(org.name, 'emailrepo2');
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'emailrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'emailrepo2',
           'v2',
@@ -266,17 +266,17 @@ test.describe(
         // Clear inbox before push
         await mailpit.clearInbox();
 
-        // Push images to exceed warning threshold (~1.2 MiB each)
+        // Push images to exceed warning threshold (~1.4 MiB each)
         await api.repositoryWithName(org.name, 'fbrepo1');
         await api.repositoryWithName(org.name, 'fbrepo2');
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'fbrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'fbrepo2',
           'v2',
@@ -379,17 +379,17 @@ test.describe(
 
         const org = await api.organization('nsdelivretro');
 
-        // Push images FIRST (~2.4 MiB total) — before any quota is set
+        // Push images FIRST (~2.8 MiB total) — before any quota is set
         await api.repositoryWithName(org.name, 'retrorepo1');
         await api.repositoryWithName(org.name, 'retrorepo2');
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'retrorepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushImage(
+        await pushImageWithLayerSize(
           org.name,
           'retrorepo2',
           'v2',

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImageWithLayerSize} from '../../utils/container';
+import {pushImage, pushQuotaNotificationImage} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 import {mailpit} from '../../utils/mailpit';
 
@@ -20,7 +20,7 @@ test.describe(
         ],
       },
       async ({api, superuserApi}) => {
-        test.setTimeout(120_000);
+        test.setTimeout(300_000);
 
         const org = await api.organization('nsdelivwarn');
 
@@ -47,17 +47,17 @@ test.describe(
             'Warning Webhook',
           );
 
-          // Create repos and push images to exceed 80% of 3 MiB (~1.4 MiB each)
+          // Push pinned UBI image — one push exceeds threshold; second starts upload
           await api.repositoryWithName(org.name, 'repo1');
           await api.repositoryWithName(org.name, 'repo2');
-          await pushImageWithLayerSize(
+          await pushQuotaNotificationImage(
             org.name,
             'repo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushImageWithLayerSize(
+          await pushQuotaNotificationImage(
             org.name,
             'repo2',
             'v2',
@@ -122,9 +122,9 @@ test.describe(
             'Error Webhook',
           );
 
-          // Create repo and push first image (succeeds)
+          // busybox (~1.2 MiB): first push under 2 MiB quota, second rejected over limit
           await api.repositoryWithName(org.name, 'fillrepo');
-          await pushImageWithLayerSize(
+          await pushImage(
             org.name,
             'fillrepo',
             'v1',
@@ -134,7 +134,7 @@ test.describe(
 
           // Second push should be rejected (over quota)
           try {
-            await pushImageWithLayerSize(
+            await pushImage(
               org.name,
               'fillrepo',
               'v2',
@@ -168,7 +168,7 @@ test.describe(
         ],
       },
       async ({api, superuserApi}) => {
-        test.setTimeout(120_000);
+        test.setTimeout(300_000);
 
         const contactEmail = 'quota-warn-test@example.com';
         const org = await api.organization('nsdelivemail', contactEmail);
@@ -195,17 +195,17 @@ test.describe(
         // Clear inbox before push
         await mailpit.clearInbox();
 
-        // Push images to exceed warning threshold (~1.4 MiB each)
+        // Push pinned UBI to exceed warning threshold
         await api.repositoryWithName(org.name, 'emailrepo1');
         await api.repositoryWithName(org.name, 'emailrepo2');
-        await pushImageWithLayerSize(
+        await pushQuotaNotificationImage(
           org.name,
           'emailrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushImageWithLayerSize(
+        await pushQuotaNotificationImage(
           org.name,
           'emailrepo2',
           'v2',
@@ -239,7 +239,7 @@ test.describe(
         ],
       },
       async ({api, superuserApi}) => {
-        test.setTimeout(120_000);
+        test.setTimeout(300_000);
 
         // Create org WITHOUT explicit email (UUID placeholder used)
         const org = await api.organization('nsdelivfb');
@@ -269,14 +269,14 @@ test.describe(
         // Push images to exceed warning threshold (~1.4 MiB each)
         await api.repositoryWithName(org.name, 'fbrepo1');
         await api.repositoryWithName(org.name, 'fbrepo2');
-        await pushImageWithLayerSize(
+        await pushQuotaNotificationImage(
           org.name,
           'fbrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushImageWithLayerSize(
+        await pushQuotaNotificationImage(
           org.name,
           'fbrepo2',
           'v2',
@@ -375,24 +375,16 @@ test.describe(
         ],
       },
       async ({api, superuserApi}) => {
-        test.setTimeout(120_000);
+        test.setTimeout(300_000);
 
         const org = await api.organization('nsdelivretro');
 
-        // Push images FIRST (~2.8 MiB total) — before any quota is set
+        // Push pinned UBI before quota is configured
         await api.repositoryWithName(org.name, 'retrorepo1');
-        await api.repositoryWithName(org.name, 'retrorepo2');
-        await pushImageWithLayerSize(
+        await pushQuotaNotificationImage(
           org.name,
           'retrorepo1',
           'v1',
-          TEST_USERS.user.username,
-          TEST_USERS.user.password,
-        );
-        await pushImageWithLayerSize(
-          org.name,
-          'retrorepo2',
-          'v2',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushUniqueImage} from '../../utils/container';
+import {pushImage} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 import {mailpit} from '../../utils/mailpit';
 
@@ -47,18 +47,19 @@ test.describe(
             'Warning Webhook',
           );
 
-          // Create repo and push images to exceed 80% of 3 MiB
+          // Create repos and push images to exceed 80% of 3 MiB (~1.2 MiB each)
           await api.repositoryWithName(org.name, 'repo1');
-          await pushUniqueImage(
+          await api.repositoryWithName(org.name, 'repo2');
+          await pushImage(
             org.name,
             'repo1',
             'v1',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
           );
-          await pushUniqueImage(
+          await pushImage(
             org.name,
-            'repo1',
+            'repo2',
             'v2',
             TEST_USERS.user.username,
             TEST_USERS.user.password,
@@ -67,7 +68,8 @@ test.describe(
           // Wait for webhook
           const webhook = await receiver.waitForWebhook(undefined, 60_000);
           expect(webhook).not.toBeNull();
-          expect(webhook?.body).toHaveProperty('event_data');
+          expect(webhook?.body).toHaveProperty('namespace');
+          expect(webhook?.body).toHaveProperty('threshold_percent');
 
           // PROJQUAY-12230: verify numeric fields are serialized correctly
           // (Decimal from PostgreSQL SUM()/BigIntegerField must be cast to int before json.dumps)
@@ -122,7 +124,7 @@ test.describe(
 
           // Create repo and push first image (succeeds)
           await api.repositoryWithName(org.name, 'fillrepo');
-          await pushUniqueImage(
+          await pushImage(
             org.name,
             'fillrepo',
             'v1',
@@ -132,7 +134,7 @@ test.describe(
 
           // Second push should be rejected (over quota)
           try {
-            await pushUniqueImage(
+            await pushImage(
               org.name,
               'fillrepo',
               'v2',
@@ -146,7 +148,8 @@ test.describe(
           // Wait for webhook with quota_error event
           const webhook = await receiver.waitForWebhook(undefined, 60_000);
           expect(webhook).not.toBeNull();
-          expect(webhook?.body).toHaveProperty('event_data');
+          expect(webhook?.body).toHaveProperty('namespace');
+          expect(webhook?.body).toHaveProperty('threshold_percent');
         } finally {
           await receiver.stop();
         }
@@ -192,18 +195,19 @@ test.describe(
         // Clear inbox before push
         await mailpit.clearInbox();
 
-        // Push images to exceed warning threshold
-        await api.repositoryWithName(org.name, 'emailrepo');
-        await pushUniqueImage(
+        // Push images to exceed warning threshold (~1.2 MiB each)
+        await api.repositoryWithName(org.name, 'emailrepo1');
+        await api.repositoryWithName(org.name, 'emailrepo2');
+        await pushImage(
           org.name,
-          'emailrepo',
+          'emailrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushUniqueImage(
+        await pushImage(
           org.name,
-          'emailrepo',
+          'emailrepo2',
           'v2',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
@@ -262,18 +266,19 @@ test.describe(
         // Clear inbox before push
         await mailpit.clearInbox();
 
-        // Push images to exceed warning threshold
-        await api.repositoryWithName(org.name, 'fbrepo');
-        await pushUniqueImage(
+        // Push images to exceed warning threshold (~1.2 MiB each)
+        await api.repositoryWithName(org.name, 'fbrepo1');
+        await api.repositoryWithName(org.name, 'fbrepo2');
+        await pushImage(
           org.name,
-          'fbrepo',
+          'fbrepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushUniqueImage(
+        await pushImage(
           org.name,
-          'fbrepo',
+          'fbrepo2',
           'v2',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
@@ -348,18 +353,10 @@ test.describe(
 
           const warnHook = await receiver.waitForWebhook(undefined, 30_000);
           expect(warnHook).not.toBeNull();
-          expect(warnHook?.body?.event_data).toHaveProperty(
-            'usage_bytes_formatted',
-          );
-          expect(warnHook?.body?.event_data).toHaveProperty(
-            'limit_bytes_formatted',
-          );
-          expect(warnHook?.body?.event_data.usage_bytes_formatted).toBe(
-            '819.20 MB',
-          );
-          expect(warnHook?.body?.event_data.limit_bytes_formatted).toBe(
-            '1.00 GB',
-          );
+          expect(warnHook?.body).toHaveProperty('usage_bytes_formatted');
+          expect(warnHook?.body).toHaveProperty('limit_bytes_formatted');
+          expect(warnHook?.body.usage_bytes_formatted).toBe('819.20 MB');
+          expect(warnHook?.body.limit_bytes_formatted).toBe('1.00 GB');
         } finally {
           await receiver.stop();
         }
@@ -382,18 +379,19 @@ test.describe(
 
         const org = await api.organization('nsdelivretro');
 
-        // Push images FIRST (~2.5 MiB total) — before any quota is set
-        await api.repositoryWithName(org.name, 'retrorepo');
-        await pushUniqueImage(
+        // Push images FIRST (~2.4 MiB total) — before any quota is set
+        await api.repositoryWithName(org.name, 'retrorepo1');
+        await api.repositoryWithName(org.name, 'retrorepo2');
+        await pushImage(
           org.name,
-          'retrorepo',
+          'retrorepo1',
           'v1',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
         );
-        await pushUniqueImage(
+        await pushImage(
           org.name,
-          'retrorepo',
+          'retrorepo2',
           'v2',
           TEST_USERS.user.username,
           TEST_USERS.user.password,
@@ -425,7 +423,8 @@ test.describe(
           // Webhook should fire retroactively
           const webhook = await receiver.waitForWebhook(undefined, 60_000);
           expect(webhook).not.toBeNull();
-          expect(webhook?.body).toHaveProperty('event_data');
+          expect(webhook?.body).toHaveProperty('namespace');
+          expect(webhook?.body).toHaveProperty('threshold_percent');
         } finally {
           await receiver.stop();
         }

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -1,6 +1,10 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImage, pushQuotaNotificationImage} from '../../utils/container';
+import {
+  pushImage,
+  pushQuotaNotificationImage,
+  pushUniqueImageWithLayerBytes,
+} from '../../utils/container';
 import {WebhookReceiver} from '../../utils/webhook';
 import {mailpit} from '../../utils/mailpit';
 
@@ -122,7 +126,7 @@ test.describe(
             'Error Webhook',
           );
 
-          // busybox (~1.2 MiB): first push under 2 MiB quota, second rejected over limit
+          // First push (~1.2 MiB busybox) stays under the 2 MiB reject limit.
           await api.repositoryWithName(org.name, 'fillrepo');
           await pushImage(
             org.name,
@@ -132,14 +136,17 @@ test.describe(
             TEST_USERS.user.password,
           );
 
-          // Second push should be rejected (over quota)
+          // Second push must upload new blob bytes (not mount busybox layers) so
+          // verify_namespace_quota_during_upload fires quota_error before reject.
+          // ~1.1 MiB unique layer + ~1.2 MiB existing usage crosses 2 MiB during upload.
           try {
-            await pushImage(
+            await pushUniqueImageWithLayerBytes(
               org.name,
               'fillrepo',
               'v2',
               TEST_USERS.user.username,
               TEST_USERS.user.password,
+              1_100_000,
             );
           } catch {
             // Expected — push rejected due to quota

--- a/web/playwright/e2e/organization/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications.spec.ts
@@ -1,4 +1,9 @@
 import {test, expect, uniqueName} from '../../fixtures';
+import {
+  closeNotificationModal,
+  expectNsNotificationRow,
+  selectTeamRecipient,
+} from '../../utils/namespace-notifications-ui';
 
 test.describe(
   'Namespace Notifications',
@@ -50,15 +55,15 @@ test.describe(
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
       // Verify notification appears in the list
-      await expect(
-        authenticatedPage.getByTestId('ns-notifications-table'),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Test Webhook Notification'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Warning')).toBeVisible();
-      await expect(authenticatedPage.getByText('Webhook POST')).toBeVisible();
-      await expect(authenticatedPage.getByText('Enabled')).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'Test Webhook Notification',
+        {
+          event: 'Quota Warning',
+          method: 'Webhook POST',
+          status: 'Enabled',
+        },
+      );
 
       // Test the notification via kebab menu
       const kebabToggle = authenticatedPage
@@ -75,7 +80,7 @@ test.describe(
       await expect(
         authenticatedPage.getByText('Test Notification Queued'),
       ).toBeVisible();
-      await authenticatedPage.getByRole('button', {name: 'Close'}).click();
+      await closeNotificationModal(authenticatedPage);
 
       // Delete the notification via kebab menu
       await kebabToggle.click();
@@ -128,13 +133,10 @@ test.describe(
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
       // Verify notification appears in list
-      await expect(
-        authenticatedPage.getByText('Quota Error Email'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Error')).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Email Notification'),
-      ).toBeVisible();
+      await expectNsNotificationRow(authenticatedPage, 'Quota Error Email', {
+        event: 'Quota Error',
+        method: 'Email Notification',
+      });
     });
 
     test('can create a Slack notification', async ({
@@ -174,13 +176,10 @@ test.describe(
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
       // Verify notification appears in list
-      await expect(
-        authenticatedPage.getByText('Slack Quota Warning'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Warning')).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Slack Notification'),
-      ).toBeVisible();
+      await expectNsNotificationRow(authenticatedPage, 'Slack Quota Warning', {
+        event: 'Quota Warning',
+        method: 'Slack Notification',
+      });
     });
 
     test('can create a Quay notification with team recipient', async ({
@@ -210,8 +209,7 @@ test.describe(
         .click();
 
       // Select team as recipient in entity search
-      await authenticatedPage.locator('#entity-search-input').fill(team.name);
-      await authenticatedPage.getByText(team.name).click();
+      await selectTeamRecipient(authenticatedPage, team.name);
 
       // Fill in title
       await authenticatedPage
@@ -222,10 +220,11 @@ test.describe(
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
       // Verify notification appears in list
-      await expect(
-        authenticatedPage.getByText('Quay Notification to Team'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Error')).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'Quay Notification to Team',
+        {event: 'Quota Error'},
+      );
     });
 
     test('multiple notifications coexist in list', async ({
@@ -474,8 +473,7 @@ test.describe(
       ).toBeDisabled();
 
       // Select team as recipient
-      await authenticatedPage.locator('#entity-search-input').fill(team.name);
-      await authenticatedPage.getByText(team.name).click();
+      await selectTeamRecipient(authenticatedPage, team.name);
 
       // Submit should now be enabled
       await expect(

--- a/web/playwright/e2e/organization/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications.spec.ts
@@ -2,6 +2,7 @@ import {test, expect, uniqueName} from '../../fixtures';
 import {
   closeNotificationModal,
   expectNsNotificationRow,
+  nsNotificationRow,
   selectTeamRecipient,
 } from '../../utils/namespace-notifications-ui';
 
@@ -55,6 +56,10 @@ test.describe(
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
       // Verify notification appears in the list
+      const notificationRow = nsNotificationRow(
+        authenticatedPage,
+        'Test Webhook Notification',
+      );
       await expectNsNotificationRow(
         authenticatedPage,
         'Test Webhook Notification',
@@ -66,7 +71,7 @@ test.describe(
       );
 
       // Test the notification via kebab menu
-      const kebabToggle = authenticatedPage
+      const kebabToggle = notificationRow
         .locator('[data-testid$="-ns-toggle-kebab"]')
         .first();
       await kebabToggle.click();
@@ -263,11 +268,9 @@ test.describe(
       await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
 
-      await expect(
-        authenticatedPage.getByText('Webhook Warning'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Email Error')).toBeVisible();
-      await expect(authenticatedPage.getByText('Slack Warning')).toBeVisible();
+      await expectNsNotificationRow(authenticatedPage, 'Webhook Warning');
+      await expectNsNotificationRow(authenticatedPage, 'Email Error');
+      await expectNsNotificationRow(authenticatedPage, 'Slack Warning');
     });
 
     test('API-created notification appears in UI list', async ({
@@ -290,10 +293,11 @@ test.describe(
       await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
 
-      await expect(
-        authenticatedPage.getByText('API-Created Notification'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Warning')).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'API-Created Notification',
+        {event: 'Quota Warning'},
+      );
     });
 
     test('both quota event types available in dropdown', async ({

--- a/web/playwright/e2e/user/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/user/namespace-notifications.spec.ts
@@ -1,5 +1,9 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
+import {
+  closeNotificationModal,
+  expectNsNotificationRow,
+} from '../../utils/namespace-notifications-ui';
 
 test.describe(
   'User Namespace Notifications',
@@ -40,15 +44,15 @@ test.describe(
 
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
-      await expect(
-        authenticatedPage.getByTestId('ns-notifications-table'),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('User Webhook Notification'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Warning')).toBeVisible();
-      await expect(authenticatedPage.getByText('Webhook POST')).toBeVisible();
-      await expect(authenticatedPage.getByText('Enabled')).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'User Webhook Notification',
+        {
+          event: 'Quota Warning',
+          method: 'Webhook POST',
+          status: 'Enabled',
+        },
+      );
 
       // Test the notification via kebab menu
       const kebabToggle = authenticatedPage
@@ -64,7 +68,7 @@ test.describe(
       await expect(
         authenticatedPage.getByText('Test Notification Queued'),
       ).toBeVisible();
-      await authenticatedPage.getByRole('button', {name: 'Close'}).click();
+      await closeNotificationModal(authenticatedPage);
 
       // Delete the notification via kebab menu
       await kebabToggle.click();
@@ -105,13 +109,14 @@ test.describe(
 
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
-      await expect(
-        authenticatedPage.getByText('User Quota Error Email'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Error')).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Email Notification'),
-      ).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'User Quota Error Email',
+        {
+          event: 'Quota Error',
+          method: 'Email Notification',
+        },
+      );
     });
 
     test('API-created notification appears in UI list', async ({
@@ -129,10 +134,11 @@ test.describe(
       await authenticatedPage.goto(`/user/${username}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
 
-      await expect(
-        authenticatedPage.getByText('API-Created User Notification'),
-      ).toBeVisible();
-      await expect(authenticatedPage.getByText('Quota Warning')).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'API-Created User Notification',
+        {event: 'Quota Warning'},
+      );
     });
 
     test('can create a Slack notification', async ({authenticatedPage}) => {
@@ -161,12 +167,11 @@ test.describe(
 
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
-      await expect(
-        authenticatedPage.getByText('User Slack Notification'),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Slack Notification'),
-      ).toBeVisible();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'User Slack Notification',
+        {method: 'Slack Notification'},
+      );
     });
 
     test('multiple notifications coexist in user namespace list', async ({

--- a/web/playwright/e2e/user/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/user/namespace-notifications.spec.ts
@@ -19,10 +19,6 @@ test.describe(
 
       await authenticatedPage.getByTestId('Notifications').click();
 
-      await expect(
-        authenticatedPage.getByText('No notifications configured'),
-      ).toBeVisible();
-
       await authenticatedPage.getByTestId('create-ns-notification-btn').click();
 
       await authenticatedPage
@@ -88,8 +84,8 @@ test.describe(
         .click();
 
       await expect(
-        authenticatedPage.getByText('No notifications configured'),
-      ).toBeVisible();
+        nsNotificationRow(authenticatedPage, 'User Webhook Notification'),
+      ).not.toBeVisible();
     });
 
     test('can create an email notification', async ({authenticatedPage}) => {

--- a/web/playwright/e2e/user/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/user/namespace-notifications.spec.ts
@@ -3,6 +3,7 @@ import {TEST_USERS} from '../../global-setup';
 import {
   closeNotificationModal,
   expectNsNotificationRow,
+  nsNotificationRow,
 } from '../../utils/namespace-notifications-ui';
 
 test.describe(
@@ -44,6 +45,10 @@ test.describe(
 
       await authenticatedPage.getByTestId('ns-notification-submit-btn').click();
 
+      const notificationRow = nsNotificationRow(
+        authenticatedPage,
+        'User Webhook Notification',
+      );
       await expectNsNotificationRow(
         authenticatedPage,
         'User Webhook Notification',
@@ -55,7 +60,7 @@ test.describe(
       );
 
       // Test the notification via kebab menu
-      const kebabToggle = authenticatedPage
+      const kebabToggle = notificationRow
         .locator('[data-testid$="-ns-toggle-kebab"]')
         .first();
       await kebabToggle.click();
@@ -196,8 +201,8 @@ test.describe(
       await authenticatedPage.goto(`/user/${username}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
 
-      await expect(authenticatedPage.getByText('User Webhook 1')).toBeVisible();
-      await expect(authenticatedPage.getByText('User Email 1')).toBeVisible();
+      await expectNsNotificationRow(authenticatedPage, 'User Webhook 1');
+      await expectNsNotificationRow(authenticatedPage, 'User Email 1');
     });
 
     test('Notifications tab is visible in user settings when feature flag enabled', async ({
@@ -285,21 +290,20 @@ test.describe(
       // Navigate to user settings — org notification should NOT appear
       await authenticatedPage.goto(`/user/${username}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
+      await expectNsNotificationRow(
+        authenticatedPage,
+        'User Only Notification',
+      );
       await expect(
-        authenticatedPage.getByText('User Only Notification'),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Org Only Notification'),
+        nsNotificationRow(authenticatedPage, 'Org Only Notification'),
       ).not.toBeVisible();
 
       // Navigate to org settings — user notification should NOT appear
       await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
       await authenticatedPage.getByTestId('Notifications').click();
+      await expectNsNotificationRow(authenticatedPage, 'Org Only Notification');
       await expect(
-        authenticatedPage.getByText('Org Only Notification'),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('User Only Notification'),
+        nsNotificationRow(authenticatedPage, 'User Only Notification'),
       ).not.toBeVisible();
     });
   },

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -271,6 +271,64 @@ export async function pushImage(
 }
 
 /**
+ * Layer size used by quota-notification e2e tests. Two pushes to different
+ * repos reliably exceed typical warning thresholds (e.g. 80% of 3 MiB).
+ */
+export const QUOTA_NOTIFICATION_LAYER_BYTES = 1_400_000;
+
+/**
+ * Push an image whose layer content is at least `layerBytes` so quota usage
+ * crosses notification thresholds predictably in CI.
+ */
+export async function pushImageWithLayerSize(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+  layerBytes: number = QUOTA_NOTIFICATION_LAYER_BYTES,
+): Promise<void> {
+  await requireTool('crane');
+
+  const image = targetImage(namespace, repo, tag);
+  const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'quay-sized-img-'));
+  const rootDir = path.join(tmpDir, 'root');
+  const authDir = path.join(tmpDir, 'auth');
+  const layerTar = path.join(tmpDir, 'layer.tar');
+
+  try {
+    await mkdir(rootDir);
+    await mkdir(authDir);
+    await writeFile(
+      path.join(rootDir, 'quota-fill'),
+      Buffer.alloc(layerBytes, 0),
+    );
+    await writeFile(path.join(rootDir, 'unique'), `${uniqueId}\n`);
+    await execFileAsync('tar', [
+      '-C',
+      rootDir,
+      '-cf',
+      layerTar,
+      'quota-fill',
+      'unique',
+    ]);
+
+    await craneLogin(REGISTRY_HOST, username, password, authDir);
+
+    await retryOperation(() =>
+      execFileAsync(
+        'crane',
+        ['append', '--insecure', '--new_layer', layerTar, '--new_tag', image],
+        {env: {...process.env, DOCKER_CONFIG: authDir}},
+      ).then(() => undefined),
+    );
+  } finally {
+    await rm(tmpDir, {recursive: true, force: true});
+  }
+}
+
+/**
  * Push an image with a unique layer to the registry, guaranteeing
  * unique blob digests (no deduplication with prior pushes).
  */

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -8,6 +8,7 @@
  */
 
 import {execFile, execFileSync, spawn} from 'child_process';
+import {randomBytes} from 'crypto';
 import {mkdtempSync, rmSync, writeFileSync} from 'fs';
 import {mkdtemp, mkdir, rm, writeFile} from 'fs/promises';
 import * as os from 'os';
@@ -327,6 +328,29 @@ export async function pushUniqueImage(
   username: string,
   password: string,
 ): Promise<void> {
+  await pushUniqueImageWithLayerBytes(
+    namespace,
+    repo,
+    tag,
+    username,
+    password,
+    64,
+  );
+}
+
+/**
+ * Push an image with a unique, incompressible layer of at least `layerBytes`.
+ * Quota checks during blob upload use stored bytes; random content avoids
+ * gzip collapsing the layer to a negligible size.
+ */
+export async function pushUniqueImageWithLayerBytes(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+  layerBytes: number,
+): Promise<void> {
   await requireTool('crane');
 
   const image = targetImage(namespace, repo, tag);
@@ -339,8 +363,16 @@ export async function pushUniqueImage(
   try {
     await mkdir(rootDir);
     await mkdir(authDir);
+    await writeFile(path.join(rootDir, 'quota-fill'), randomBytes(layerBytes));
     await writeFile(path.join(rootDir, 'unique'), `${uniqueId}\n`);
-    await execFileAsync('tar', ['-C', rootDir, '-cf', layerTar, 'unique']);
+    await execFileAsync('tar', [
+      '-C',
+      rootDir,
+      '-cf',
+      layerTar,
+      'quota-fill',
+      'unique',
+    ]);
 
     await craneLogin(REGISTRY_HOST, username, password, authDir);
 
@@ -473,6 +505,7 @@ export function orasAttach(
         authFile,
         `--artifact-type=${artifactType}`,
         `--annotation=${annotation}`,
+        '--disable-path-validation',
         filePath,
       ],
       {stdio: 'pipe', timeout: 60_000},

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -22,6 +22,13 @@ const REGISTRY_HOST = new URL(API_URL).host;
 
 const BUSYBOX_IMAGE = 'quay.io/prometheus/busybox:latest';
 
+/**
+ * Pinned UBI9 image (~77 MiB stored) used to cross quota notification thresholds
+ * reliably in e2e tests. Digest-pinned for reproducible blob sizes in CI.
+ */
+export const QUOTA_NOTIFICATION_SOURCE_IMAGE =
+  'registry.access.redhat.com/ubi9/ubi@sha256:25a147defd01e19674714f55d17538c8dbe55d8c305fa157ecc3f9c8977b05b6';
+
 type ToolAvailability = {
   skopeo: boolean;
   crane: boolean;
@@ -253,15 +260,34 @@ export async function pushImage(
   username: string,
   password: string,
 ): Promise<void> {
-  const image = targetImage(namespace, repo, tag);
+  await pushImageFrom(BUSYBOX_IMAGE, namespace, repo, tag, username, password);
+}
+
+/**
+ * Copy an image from an external registry into Quay via skopeo.
+ *
+ * @param sourceImage - Registry reference (with or without `docker://` prefix)
+ */
+export async function pushImageFrom(
+  sourceImage: string,
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  const dest = targetImage(namespace, repo, tag);
+  const source = sourceImage.startsWith('docker://')
+    ? sourceImage
+    : `docker://${sourceImage}`;
 
   await withRegistryAuthFile(username, password, (authFile) =>
     retryOperation(() =>
       skopeoCopy([
         '--override-os=linux',
         '--override-arch=amd64',
-        `docker://${BUSYBOX_IMAGE}`,
-        `docker://${image}`,
+        source,
+        `docker://${dest}`,
         '--dest-tls-verify=false',
         '--dest-authfile',
         authFile,
@@ -271,61 +297,23 @@ export async function pushImage(
 }
 
 /**
- * Layer size used by quota-notification e2e tests. Two pushes to different
- * repos reliably exceed typical warning thresholds (e.g. 80% of 3 MiB).
+ * Push the pinned UBI9 image used by quota-notification e2e tests.
  */
-export const QUOTA_NOTIFICATION_LAYER_BYTES = 1_400_000;
-
-/**
- * Push an image whose layer content is at least `layerBytes` so quota usage
- * crosses notification thresholds predictably in CI.
- */
-export async function pushImageWithLayerSize(
+export async function pushQuotaNotificationImage(
   namespace: string,
   repo: string,
   tag: string,
   username: string,
   password: string,
-  layerBytes: number = QUOTA_NOTIFICATION_LAYER_BYTES,
 ): Promise<void> {
-  await requireTool('crane');
-
-  const image = targetImage(namespace, repo, tag);
-  const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'quay-sized-img-'));
-  const rootDir = path.join(tmpDir, 'root');
-  const authDir = path.join(tmpDir, 'auth');
-  const layerTar = path.join(tmpDir, 'layer.tar');
-
-  try {
-    await mkdir(rootDir);
-    await mkdir(authDir);
-    await writeFile(
-      path.join(rootDir, 'quota-fill'),
-      Buffer.alloc(layerBytes, 0),
-    );
-    await writeFile(path.join(rootDir, 'unique'), `${uniqueId}\n`);
-    await execFileAsync('tar', [
-      '-C',
-      rootDir,
-      '-cf',
-      layerTar,
-      'quota-fill',
-      'unique',
-    ]);
-
-    await craneLogin(REGISTRY_HOST, username, password, authDir);
-
-    await retryOperation(() =>
-      execFileAsync(
-        'crane',
-        ['append', '--insecure', '--new_layer', layerTar, '--new_tag', image],
-        {env: {...process.env, DOCKER_CONFIG: authDir}},
-      ).then(() => undefined),
-    );
-  } finally {
-    await rm(tmpDir, {recursive: true, force: true});
-  }
+  await pushImageFrom(
+    QUOTA_NOTIFICATION_SOURCE_IMAGE,
+    namespace,
+    repo,
+    tag,
+    username,
+    password,
+  );
 }
 
 /**

--- a/web/playwright/utils/namespace-notifications-ui.ts
+++ b/web/playwright/utils/namespace-notifications-ui.ts
@@ -5,7 +5,12 @@ export function nsNotificationsTable(page: Page): Locator {
 }
 
 export function nsNotificationRow(page: Page, title: string | RegExp): Locator {
-  return nsNotificationsTable(page).getByRole('row', {name: title});
+  const table = nsNotificationsTable(page);
+  const titleCell =
+    typeof title === 'string'
+      ? table.getByRole('gridcell', {name: title, exact: true})
+      : table.getByRole('gridcell', {name: title});
+  return table.getByRole('row').filter({has: titleCell});
 }
 
 export async function expectNsNotificationRow(
@@ -34,7 +39,7 @@ export async function expectNsNotificationRow(
 
 export async function closeNotificationModal(page: Page): Promise<void> {
   const modal = page.getByRole('dialog');
-  await modal.getByRole('button', {name: 'Close'}).click();
+  await modal.getByLabel('Close', {exact: true}).click();
 }
 
 export async function selectTeamRecipient(

--- a/web/playwright/utils/namespace-notifications-ui.ts
+++ b/web/playwright/utils/namespace-notifications-ui.ts
@@ -6,11 +6,10 @@ export function nsNotificationsTable(page: Page): Locator {
 
 export function nsNotificationRow(page: Page, title: string | RegExp): Locator {
   const table = nsNotificationsTable(page);
-  const titleCell =
-    typeof title === 'string'
-      ? table.getByRole('gridcell', {name: title, exact: true})
-      : table.getByRole('gridcell', {name: title});
-  return table.getByRole('row').filter({has: titleCell});
+  // Inner locator is resolved relative to each candidate row (not the table).
+  return table.getByRole('row').filter({
+    has: page.locator('[data-label="title"]', {hasText: title}),
+  });
 }
 
 export async function expectNsNotificationRow(
@@ -22,17 +21,17 @@ export async function expectNsNotificationRow(
   await expect(row).toBeVisible();
   if (columns.event) {
     await expect(
-      row.getByRole('gridcell', {name: columns.event, exact: true}),
+      row.locator('[data-label="event"]', {hasText: columns.event}),
     ).toBeVisible();
   }
   if (columns.method) {
     await expect(
-      row.getByRole('gridcell', {name: columns.method, exact: true}),
+      row.locator('[data-label="method"]', {hasText: columns.method}),
     ).toBeVisible();
   }
   if (columns.status) {
     await expect(
-      row.getByRole('gridcell', {name: columns.status, exact: true}),
+      row.locator('[data-label="status"]', {hasText: columns.status}),
     ).toBeVisible();
   }
 }

--- a/web/playwright/utils/namespace-notifications-ui.ts
+++ b/web/playwright/utils/namespace-notifications-ui.ts
@@ -1,0 +1,46 @@
+import {expect, type Locator, type Page} from '@playwright/test';
+
+export function nsNotificationsTable(page: Page): Locator {
+  return page.getByTestId('ns-notifications-table');
+}
+
+export function nsNotificationRow(page: Page, title: string | RegExp): Locator {
+  return nsNotificationsTable(page).getByRole('row', {name: title});
+}
+
+export async function expectNsNotificationRow(
+  page: Page,
+  title: string | RegExp,
+  columns: {event?: string; method?: string; status?: string} = {},
+): Promise<void> {
+  const row = nsNotificationRow(page, title);
+  await expect(row).toBeVisible();
+  if (columns.event) {
+    await expect(
+      row.getByRole('gridcell', {name: columns.event, exact: true}),
+    ).toBeVisible();
+  }
+  if (columns.method) {
+    await expect(
+      row.getByRole('gridcell', {name: columns.method, exact: true}),
+    ).toBeVisible();
+  }
+  if (columns.status) {
+    await expect(
+      row.getByRole('gridcell', {name: columns.status, exact: true}),
+    ).toBeVisible();
+  }
+}
+
+export async function closeNotificationModal(page: Page): Promise<void> {
+  const modal = page.getByRole('dialog');
+  await modal.getByRole('button', {name: 'Close'}).click();
+}
+
+export async function selectTeamRecipient(
+  page: Page,
+  teamName: string,
+): Promise<void> {
+  await page.locator('#entity-search-input').click();
+  await page.getByTestId(`${teamName}-team`).click();
+}

--- a/web/src/routes/RepositoryDetails/Mirroring/ArchitectureFilter.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/ArchitectureFilter.tsx
@@ -43,10 +43,16 @@ export const ArchitectureFilter: React.FC<ArchitectureFilterProps> = ({
   const effectivelyDisabled = isDisabled || !sparseSupported;
 
   useEffect(() => {
+    // Wait until capabilities are loaded before clearing. While the query is
+    // in flight, sparseSupported defaults to false and would wipe a filter
+    // that UseMirroringConfig just hydrated from the mirror API.
+    if (isLoading) {
+      return;
+    }
     if (!sparseSupported && selectedArchitectures.length > 0) {
       onChange([]);
     }
-  }, [sparseSupported, selectedArchitectures.length, onChange]);
+  }, [isLoading, sparseSupported, selectedArchitectures.length, onChange]);
 
   // Build available architectures from backend data
   const availableArchitectures = useMemo(() => {
@@ -191,10 +197,10 @@ export const ArchitectureFilter: React.FC<ArchitectureFilterProps> = ({
             {!sparseSupported
               ? 'Architecture filtering requires sparse manifest support (FEATURE_SPARSE_INDEX) to be enabled.'
               : selectedArchitectures.length === 0
-              ? 'All architectures will be mirrored from multi-arch images.'
-              : `Only ${selectedArchitectures.join(
-                  ', ',
-                )} architecture(s) will be mirrored.`}
+                ? 'All architectures will be mirrored from multi-arch images.'
+                : `Only ${selectedArchitectures.join(
+                    ', ',
+                  )} architecture(s) will be mirrored.`}
           </HelperTextItem>
         </HelperText>
       </FormHelperText>


### PR DESCRIPTION
## Tests enabled by feature

| Title | Feature flag | Tests |
|---|---|---:|
| Namespace notifications — org UI | `FEATURE_QUOTA_NOTIFICATIONS` | 11 enabled · 11 edited |
| Namespace notifications — user UI | `FEATURE_QUOTA_NOTIFICATIONS` | 8 enabled · 8 edited |
| Namespace notifications — delivery (webhook/email/retroactive) | `FEATURE_QUOTA_NOTIFICATIONS` | 7 enabled · 7 edited |
| Namespace notifications — dedup/throttling | `FEATURE_QUOTA_NOTIFICATIONS` | 1 enabled · 1 edited |
| Namespace notifications — cleanup on quota delete | `FEATURE_QUOTA_NOTIFICATIONS` | 3 enabled · 3 edited |
| Namespace notifications — logs | `FEATURE_QUOTA_NOTIFICATIONS` | 1 enabled · 1 edited |
| Namespace notifications — permissions | `FEATURE_QUOTA_NOTIFICATIONS` | 4 enabled |
| Namespace notifications — feature flag | `FEATURE_QUOTA_NOTIFICATIONS` | 2 enabled |
| Namespace notifications — quota integration | `FEATURE_QUOTA_NOTIFICATIONS` | 3 enabled |
| Namespace notifications — user namespace API | `FEATURE_QUOTA_NOTIFICATIONS` | 3 enabled |
| Mirroring architecture filter | `FEATURE_SPARSE_INDEX` | 5 enabled |
| Superuser config dump API | `FEATURE_SUPERUSER_CONFIGDUMP` | 2 enabled |
| Footer cosmetics | `FOOTER_LINKS` | 2 enabled |
| **Total** | | **52 enabled · 31 edited** |

---

## Supporting changes

| Title | Area | Change |
|---|---|---|
| Architecture filter race fix | `ArchitectureFilter.tsx` | Guard `useEffect` with `isLoading` so saved architecture filter isn’t cleared while capabilities load |
| Notification UI locators | `namespace-notifications-ui.ts` | Row-scoped `[data-label]` locators; modal close via exact `Close` label; `selectTeamRecipient()` helper |
| Quota delivery image pushes | `container.ts` | Pinned UBI9 (`pushQuotaNotificationImage`); `pushUniqueImageWithLayerBytes` for reject webhook test |
| Parallel test isolation | `user/namespace-notifications.spec.ts` | Webhook delete asserts row gone, not global empty state |
| CI workflow | `ci-web.yaml` | Flags above + `FOOTER_LINKS` URLs + ORAS `v1.2.2` install step |

---

## Notes

- **Edited** = spec/helper changes in this PR; **enabled** = previously skipped in CI until the flag/config was added.
- Delivery/dedup/cleanup tests also depend on `FEATURE_QUOTA_MANAGEMENT` / `FEATURE_EDIT_QUOTA` (already in local-dev stack) and crane/skopeo.
- Footer: 2 tests still skip by design (quay.io TrustArc only; non-quay.io negative case).
- `FEATURE_SPARSE_INDEX` fix is in the React route, not the mirroring spec files.