### PR TITLE
PROJQUAY-12489: feat(auth): mint workload token

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -19,7 +19,8 @@ from data.model.oauth import (
     delete_applications,
     get_bootstrap_app_name,
     get_bootstrap_managed_applications,
-    get_singleton_bootstrap_application_candidates,
+    get_bootstrap_tokens,
+    get_singleton_automatic_bootstrap_application_candidates,
     lock_bootstrap_token_operation,
 )
 from data.model.release import set_region_release
@@ -162,9 +163,14 @@ def _provision_bootstrap_token():
             lock_bootstrap_token_operation()
 
             bootstrap_application, stale_applications = (
-                get_singleton_bootstrap_application_candidates(owner)
+                get_singleton_automatic_bootstrap_application_candidates(owner)
             )
-            if bootstrap_application is not None:
+            bootstrap_tokens = (
+                get_bootstrap_tokens(bootstrap_application, authorized_user=owner)
+                if bootstrap_application is not None
+                else []
+            )
+            if bootstrap_tokens:
                 if stale_applications:
                     delete_applications(stale_applications)
                     logger.info(
@@ -181,7 +187,10 @@ def _provision_bootstrap_token():
                 logger.info("Bootstrap token already provisioned, skipping")
                 return
 
-            bootstrap_application = create_bootstrap_application(get_bootstrap_app_name(), owner)
+            if bootstrap_application is None:
+                bootstrap_application = create_bootstrap_application(
+                    get_bootstrap_app_name(), owner
+                )
             _, access_token = create_bootstrap_oauth_api_token(
                 bootstrap_application,
                 owner,

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -44,6 +44,7 @@ MAX_TOKEN_DISPLAY_NAME_LENGTH = 255
 BOOTSTRAP_APP_NAME = "__quay_bootstrap_app"
 BOOTSTRAP_APP_DESCRIPTION = "Auto-created by bootstrap token provisioning"
 BOOTSTRAP_TOKEN_DATA_KIND = "bootstrap"
+WORKLOAD_IDENTITY_TOKEN_DATA_KIND = "workload_identity"
 BOOTSTRAP_TOKEN_LOCK_ID = compute_advisory_lock_id("bootstrap_token", 0)
 
 
@@ -455,6 +456,63 @@ def _bootstrap_token_data_json(token: OAuthAccessToken) -> dict[str, Any]:
         return {}
 
 
+def create_workload_identity_oauth_token(
+    application: OAuthApplication,
+    user_obj: User,
+    scope: str,
+    issuer: str,
+    subject: str,
+    expiration_seconds: int = DEFAULT_TOKEN_EXPIRATION_SECONDS,
+) -> tuple[OAuthAccessToken, str]:
+    """Create a standard OAuth token with workload identity metadata."""
+    data = json.dumps(
+        {
+            "kind": WORKLOAD_IDENTITY_TOKEN_DATA_KIND,
+            "owner": user_obj.username,
+            "application_name": application.name,
+            "issuer": issuer,
+            "subject": subject,
+        }
+    )
+    return create_user_access_token_for_application(
+        user_obj,
+        application,
+        scope,
+        "Bearer",
+        expiration_seconds,
+        data=data,
+    )
+
+
+def workload_identity_token_data(token: OAuthAccessToken) -> dict[str, Any]:
+    """Return validated metadata for a workload identity OAuth token."""
+    data = _bootstrap_token_data_json(token)
+    return data if data.get("kind") == WORKLOAD_IDENTITY_TOKEN_DATA_KIND else {}
+
+
+def is_workload_identity_oauth_token(
+    token: OAuthAccessToken,
+    user_obj: User | None = None,
+    application: OAuthApplication | None = None,
+) -> bool:
+    data = workload_identity_token_data(token)
+    if not data:
+        return False
+    return (user_obj is None or data.get("owner") == user_obj.username) and (
+        application is None or data.get("application_name") == application.name
+    )
+
+
+def is_automatic_bootstrap_oauth_token(
+    token: OAuthAccessToken,
+    user_obj: User | None = None,
+    application: OAuthApplication | None = None,
+) -> bool:
+    return is_bootstrap_oauth_token(
+        token, user_obj, application
+    ) or is_workload_identity_oauth_token(token, user_obj, application)
+
+
 def is_bootstrap_oauth_token(
     token: OAuthAccessToken,
     user_obj: User | None = None,
@@ -639,6 +697,53 @@ def get_bootstrap_application_candidates(
         duplicate_applications.append(application)
 
     return canonical_application, duplicate_applications
+
+
+def get_automatic_bootstrap_application_candidates(
+    owner: User,
+) -> tuple[OAuthApplication | None, list[OAuthApplication]]:
+    applications = lookup_applications_by_name(owner, get_bootstrap_app_name())
+    by_id = {application.id: application for application in applications}
+    managed_ids = set()
+    if by_id:
+        tokens = OAuthAccessToken.select().where(
+            OAuthAccessToken.application << list(by_id),
+            OAuthAccessToken.authorized_user == owner,
+        )
+        for token in tokens:
+            application = by_id[token.application_id]
+            if is_automatic_bootstrap_oauth_token(token, owner, application):
+                managed_ids.add(application.id)
+    managed = [application for application in applications if application.id in managed_ids]
+    return (managed[0] if managed else None, managed[1:])
+
+
+def get_canonical_automatic_bootstrap_application(owner: User) -> OAuthApplication | None:
+    return get_automatic_bootstrap_application_candidates(owner)[0]
+
+
+def get_singleton_automatic_bootstrap_application_candidates(
+    owner: User,
+) -> tuple[OAuthApplication | None, list[OAuthApplication]]:
+    canonical = None
+    stale = []
+    for application in lookup_bootstrap_named_applications():
+        tokens = get_application_tokens(application)
+        if not any(
+            is_automatic_bootstrap_oauth_token(token, application=application) for token in tokens
+        ):
+            continue
+        owner_tokens = [
+            token
+            for token in tokens
+            if token.authorized_user_id == owner.id
+            and is_automatic_bootstrap_oauth_token(token, user_obj=owner, application=application)
+        ]
+        if canonical is None and application.organization_id == owner.id and owner_tokens:
+            canonical = application
+        else:
+            stale.append(application)
+    return canonical, stale
 
 
 def get_singleton_bootstrap_application_candidates(

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -15,19 +15,20 @@ from auth.workload_identity import (
     WorkloadIdentityAuthorizationError,
     authorize_workload_identity_scope,
 )
+from data import model
 from data.database import OAuthAccessToken
 from data.model import db_transaction
 from data.model.oauth import (
+    create_bootstrap_application,
     create_bootstrap_oauth_api_token,
+    create_workload_identity_oauth_token,
     delete_bootstrap_tokens,
+    get_canonical_automatic_bootstrap_application,
     lock_bootstrap_token_operation,
     validate_bootstrap_token,
 )
 from endpoints.api import ApiResource, nickname, resource, show_if
 from endpoints.decorators import anon_allowed
-
-# Compatibility alias for callers of the former endpoint-local helper.
-authorize_workload_scope = authorize_workload_identity_scope
 from endpoints.exception import (
     ApiErrorType,
     ApiException,
@@ -87,12 +88,35 @@ def _normalize_exchange_issuer(issuer):
     return (issuer or "").rstrip("/")
 
 
-def _exchange_expiration_seconds():
-    """Return the configured token lifetime bounded by the exchange maximum."""
+def _exchange_expiration_seconds(validated=None):
+    """Return the configured lifetime bounded by the verified JWT lifetime."""
+    if validated is None:
+        return min(
+            _exchange_config().get("BOOTSTRAP_TOKEN_MAX_TTL", 86400),
+            app.config.get("BOOTSTRAP_TOKEN_EXPIRATION", 3600),
+        )
+    try:
+        remaining = int(float(validated.claims["exp"]) - datetime.now(UTC).timestamp())
+    except (KeyError, TypeError, ValueError, OverflowError):
+        _exchange_error(
+            "invalid_token", "Kubernetes ServiceAccount token has invalid expiration", 401
+        )
+    if remaining <= 0:
+        _exchange_error("invalid_token", "Kubernetes ServiceAccount token has expired", 401)
     return min(
         _exchange_config().get("BOOTSTRAP_TOKEN_MAX_TTL", 86400),
         app.config.get("BOOTSTRAP_TOKEN_EXPIRATION", 3600),
+        remaining,
     )
+
+
+class WorkloadScopeAuthorizationError(WorkloadIdentityAuthorizationError):
+    """Backward-compatible alias for the endpoint authorization error."""
+
+
+def authorize_workload_scope(authorized_subjects, issuer, subject, requested_scope):
+    """Return the effective scope authorized for an exact issuer and subject."""
+    return authorize_workload_identity_scope(authorized_subjects, issuer, subject, requested_scope)
 
 
 def _raise_invalid_bootstrap_token() -> None:
@@ -118,6 +142,48 @@ def _is_local_bootstrap_renewal_request(req: Request) -> bool:
     )
 
 
+def _mint_authorized_exchange(validated, effective_scope):
+    owner = model.user.get_user(app.config.get("BOOTSTRAP_TOKEN_OWNER"))
+    if owner is None:
+        _exchange_error("server_error", "bootstrap token owner does not exist", 500)
+    expiration_seconds = _exchange_expiration_seconds(validated)
+    with db_transaction():
+        lock_bootstrap_token_operation()
+        application = get_canonical_automatic_bootstrap_application(owner)
+        if application is None:
+            application = create_bootstrap_application(model.oauth.get_bootstrap_app_name(), owner)
+        _, token = create_workload_identity_oauth_token(
+            application,
+            owner,
+            effective_scope,
+            validated.issuer,
+            validated.subject,
+            expiration_seconds=expiration_seconds,
+        )
+    return _exchange_response(
+        {
+            "access_token": token,
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "token_type": "Bearer",
+            "expires_in": expiration_seconds,
+            "scope": effective_scope,
+        }
+    )
+
+
+def _authorize_validated_exchange(validated, requested_scope):
+    try:
+        effective_scope = authorize_workload_identity_scope(
+            _exchange_config().get("AUTHORIZED_SUBJECTS", []),
+            validated.issuer,
+            validated.subject,
+            requested_scope,
+        )
+    except WorkloadIdentityAuthorizationError as exc:
+        _exchange_error("access_denied", str(exc), 403)
+    return _mint_authorized_exchange(validated, effective_scope)
+
+
 def _exchange_bootstrap_token():
     """Validate an exchange request and mint its bounded bootstrap token."""
     values = request.form
@@ -135,22 +201,7 @@ def _exchange_bootstrap_token():
         ).validate(raw)
     except KubernetesSATokenValidationError:
         _exchange_error("invalid_token", "Kubernetes ServiceAccount token failed validation", 401)
-    issuer = validated.issuer
-    subject = validated.subject
-    try:
-        effective_scope = authorize_workload_identity_scope(
-            _exchange_config().get("AUTHORIZED_SUBJECTS", []),
-            issuer,
-            subject,
-            values.get("scope", ""),
-        )
-    except WorkloadIdentityAuthorizationError as exc:
-        _exchange_error("access_denied", str(exc), 403)
-    _exchange_error(
-        "server_error",
-        "workload identity token issuance is not available",
-        503,
-    )
+    return _authorize_validated_exchange(validated, values.get("scope", ""))
 
 
 @resource("/v1/bootstrap/exchange")

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -4,11 +4,17 @@ import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import pytest
 from httmock import HTTMock, urlmatch
 
 from app import app as real_app
+from auth.kubernetes_sa import KubernetesSATokenValidator, ValidatedKubernetesSA
 from data import model
-from endpoints.api.bootstrap import _QUAY_BOOTSTRAP_RENEWAL_LOCATION_HEADER
+from endpoints.api.bootstrap import (
+    _QUAY_BOOTSTRAP_RENEWAL_LOCATION_HEADER,
+    BootstrapExchangeError,
+    _exchange_bootstrap_token,
+)
 from endpoints.test.shared import client_with_identity
 from test.fixtures import *
 from util.bootstrap_token import KubernetesTokenProvider
@@ -34,6 +40,31 @@ def _k8s_bootstrap_config(tmp_path, owner="devtable"):
         }
     )
     return config
+
+
+def _exchange_endpoint_config(tmp_path, owner="devtable"):
+    issuer = "https://kubernetes.default.svc"
+    subject = "system:serviceaccount:quay-operator:controller-manager"
+    config = _bootstrap_config(tmp_path, owner=owner)
+    config.update(
+        {
+            "FEATURE_KUBERNETES_SA_BOOTSTRAP": True,
+            "KUBERNETES_SA_BOOTSTRAP_CONFIG": {
+                "ISSUERS": [{"ISSUER": issuer}],
+                "AUTHORIZED_SUBJECTS": [
+                    {
+                        "ISSUER": issuer,
+                        "SUBJECT": subject,
+                        "SCOPES": "repo:read repo:write",
+                    }
+                ],
+                "BOOTSTRAP_TOKEN_MAX_TTL": 600,
+            },
+        }
+    )
+    return config, ValidatedKubernetesSA(
+        issuer, subject, {"exp": datetime.now(UTC).timestamp() + 3600}
+    )
 
 
 def _create_bootstrap_token(config):
@@ -103,6 +134,96 @@ def _k8s_secret_access_token(secret, key="token.json"):
 
 def _expired_time():
     return datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+
+
+def test_exchange_uses_shared_validator_cache_and_mints_bounded_token(
+    app, initialized_db, tmp_path
+):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "scope": "repo:read",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated) as validate,
+        app.test_request_context(method="POST", data=form),
+    ):
+        payload, status, headers = _exchange_bootstrap_token()
+
+    assert status == 200
+    assert payload["scope"] == "repo:read"
+    assert payload["expires_in"] == 600
+    assert headers["Cache-Control"] == "no-store"
+    validate.assert_called_once_with("service-account-jwt")
+
+
+def test_exchange_invalid_request_uses_matching_api_error_type(app, initialized_db, tmp_path):
+    config, _ = _exchange_endpoint_config(tmp_path)
+
+    with (
+        patch.dict(real_app.config, config),
+        app.test_request_context(method="POST", data={}),
+        pytest.raises(BootstrapExchangeError) as exc_info,
+    ):
+        _exchange_bootstrap_token()
+
+    assert exc_info.value.code == 400
+    assert exc_info.value.data["error"] == "invalid_request"
+    assert exc_info.value.data["error_type"] == "invalid_request"
+    assert exc_info.value.data["title"] == "invalid_request"
+
+
+def test_exchange_access_denied_uses_unauthorized_api_error_type(app, initialized_db, tmp_path):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    denied = ValidatedKubernetesSA(
+        validated.issuer,
+        "system:serviceaccount:untrusted:workload",
+        {},
+    )
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=denied),
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(BootstrapExchangeError) as exc_info,
+    ):
+        _exchange_bootstrap_token()
+
+    assert exc_info.value.code == 403
+    assert exc_info.value.data["error"] == "access_denied"
+    assert exc_info.value.data["error_type"] == "unauthorized"
+    assert exc_info.value.data["title"] == "unauthorized"
+
+
+def test_exchange_server_error_uses_matching_api_error_type(app, initialized_db, tmp_path):
+    config, validated = _exchange_endpoint_config(tmp_path, owner="missing-owner")
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(BootstrapExchangeError) as exc_info,
+    ):
+        _exchange_bootstrap_token()
+
+    assert exc_info.value.code == 500
+    assert exc_info.value.data["error"] == "server_error"
+    assert exc_info.value.data["error_type"] == "server_error"
+    assert exc_info.value.data["title"] == "server_error"
 
 
 def test_exchange_normalizes_issuer_trailing_slashes():


### PR DESCRIPTION
## Summary

Issues OAuth access tokens for authorized Kubernetes ServiceAccount workload identities, preserving the issuer and subject in token metadata for downstream authorization. This PR adds dedicated token creation and metadata helpers, updates the exchange flow to use them, and covers token lifecycle metadata with unit tests.