### PR TITLE
NO-ISSUE: fix(ci): mark stale Playwright comment when retest skips artifact

### DIFF
--- a/.github/workflows/playwright-report-deploy.yaml
+++ b/.github/workflows/playwright-report-deploy.yaml
@@ -126,3 +126,62 @@ jobs:
               body: commentBody
             });
           }
+
+    # When the Playwright job did not run in this CI pass (e.g. the job was
+    # skipped on a /retest) the report artifact will be absent but the
+    # pr-info artifact may still exist. Without this step a stale failure
+    # comment posted by an earlier run would remain unrectified on the PR.
+    # See https://github.com/quay/quay/issues/7034.
+    - name: Mark existing Playwright comment as stale when artifact is missing
+      if: steps.download-report.outputs.found_artifact != 'true' && steps.download-pr-info.outputs.found_artifact == 'true'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        RUN_URL: ${{ github.event.workflow_run.html_url }}
+        RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      with:
+        script: |
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
+          const runUrl = process.env.RUN_URL;
+          const conclusion = process.env.RUN_CONCLUSION;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+          });
+
+          const botComment = comments.find(comment =>
+            comment.user.type === 'Bot' &&
+            comment.body.includes('Playwright Test Report')
+          );
+
+          // No prior Playwright comment, nothing to update.
+          if (!botComment) {
+            core.info('No existing Playwright comment to mark stale.');
+            return;
+          }
+
+          // Skip if the existing comment has already been marked stale by a
+          // previous run, so we do not re-edit it on every subsequent retest.
+          if (botComment.body.includes('Playwright tests were not re-run')) {
+            core.info('Existing Playwright comment is already marked as stale.');
+            return;
+          }
+
+          const staleBody = `## Playwright Test Report
+
+          ⚠️ **Tests not re-run in most recent CI pass**
+
+          The result above is from a prior run. The Playwright job was skipped or produced no artifact in the latest [workflow run](${runUrl}) (conclusion: \`${conclusion}\`), so the deployed report could not be refreshed.
+
+          If this PR still needs Playwright validation, trigger a full re-run (rather than \`/retest\` alone) so the E2E job executes and uploads a fresh report.
+
+          _This notice was added automatically because the \`playwright-report\` artifact was not found._`;
+
+          await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: botComment.id,
+            body: staleBody,
+          });


### PR DESCRIPTION
## Summary

When a `/retest` is invoked on a PR whose Playwright job was previously skipped (e.g. on a Go/Python-only PR or after a partial retest), the `playwright-report` artifact is absent and the `playwright-report-deploy.yaml` workflow silently no-ops. Any earlier Playwright failure comment posted on the PR remains unrectified, so reviewers cannot distinguish a stale failure from a current one. This was reported and reproduced in [#7034](https://github.com/quay/quay/issues/7034) using PR [#7015](https://github.com/quay/quay/pull/7015) as the example.

## What changed

In `.github/workflows/playwright-report-deploy.yaml`, add one new step that runs when:

- `download-report.outputs.found_artifact != 'true'` (the report artifact is missing), and
- `download-pr-info.outputs.found_artifact == 'true'` (we still know the PR number), and
- an existing bot-authored comment on the PR contains the literal `Playwright Test Report`.

When those conditions hold, the step rewrites the existing comment to clearly mark it as a prior-run result, includes the latest workflow run URL, and notes that a full re-run is required to refresh the report. The step is idempotent: a comment already flagged as stale is left alone on subsequent runs.

No existing step is modified. The deployment, comment-update-with-success, and CI gating semantics are unchanged.

## Validation

- YAML parses cleanly; the job now has 7 steps (was 6).
- The new step's `if:` predicate ensures it only runs on the narrow stale-comment path; the happy path (artifact present, deploy succeeds) is untouched.
- Idempotency check (`body.includes('Playwright tests were not re-run')`) prevents the comment from being rewritten on every subsequent retest.
- The new step uses the same pinned `actions/github-script` SHA as the existing comment step.

Manual repro: on a PR that already has a Playwright failure comment, run a CI pass where the Playwright job does not produce an artifact (e.g. via `/retest` after a code-only change). After the workflow completes, the existing comment should display the stale-notice body instead of the old failure status.

Closes #7034