### PR TITLE
NO-ISSUE: fix(auth): downgrade basic auth parsing exception log level

### DIFF
--- a/auth/basic.py
+++ b/auth/basic.py
@@ -55,7 +55,7 @@ def _parse_basic_auth_header(auth):
     try:
         credentials = [part.decode("utf-8") for part in b64decode(normalized[1]).split(b":", 1)]
     except (TypeError, UnicodeDecodeError, ValueError):
-        logger.exception("Exception when parsing basic auth header: %s", auth)
+        logger.debug("Exception when parsing basic auth header: %s", auth)
         return None, "Could not parse basic auth header"
 
     if len(credentials) != 2:


### PR DESCRIPTION
## Summary

- Downgrade `logger.exception` to `logger.debug` in `auth/basic.py` for basic auth header parsing failures
- Malformed `Authorization` headers from clients trigger `TypeError`, `UnicodeDecodeError`, or `ValueError` exceptions during base64 decoding — these are routine client errors, not server-side bugs
- `logger.exception` logs at ERROR level with a full traceback, which Sentry captures as reportable events, adding significant noise with no actionable value
- `logger.debug` preserves the diagnostic information for debug-level log consumers while keeping it out of Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)