### PR TITLE
PROJQUAY-12490: feat(auth): add workload identity audit logging

### DIFF
--- a/auth/kubernetes_sa.py
+++ b/auth/kubernetes_sa.py
@@ -34,6 +34,10 @@ _SUBJECT_PATTERN = re.compile(r"^system:serviceaccount:([^:\s]+):([^:\s]+)$")
 class KubernetesSATokenValidationError(Exception):
     """Raised when a Kubernetes ServiceAccount credential cannot be trusted."""
 
+    def __init__(self, message: str, category: str = "trust"):
+        super().__init__(message)
+        self.category = category
+
 
 @dataclass(frozen=True)
 class ValidatedKubernetesSA:
@@ -116,35 +120,41 @@ class KubernetesSATokenValidator:
 
     def _parse_subject(self, subject: Any) -> tuple[str, str]:
         if not isinstance(subject, str):
-            raise KubernetesSATokenValidationError("Token is not a Kubernetes ServiceAccount token")
+            raise KubernetesSATokenValidationError(
+                "Token is not a Kubernetes ServiceAccount token", category="identity"
+            )
         match = _SUBJECT_PATTERN.match(subject)
         if not match:
-            raise KubernetesSATokenValidationError("Token is not a Kubernetes ServiceAccount token")
+            raise KubernetesSATokenValidationError(
+                "Token is not a Kubernetes ServiceAccount token", category="identity"
+            )
         return match.group(1), match.group(2)
 
     def _verify_bound_claims(self, claims: dict[str, Any], namespace: str, name: str) -> None:
         bound = claims.get("kubernetes.io")
         if not isinstance(bound, dict):
             raise KubernetesSATokenValidationError(
-                "Token is missing Kubernetes bound ServiceAccount claims"
+                "Token is missing Kubernetes bound ServiceAccount claims", category="identity"
             )
         if bound.get("namespace") != namespace:
-            raise KubernetesSATokenValidationError("Token namespace claim does not match subject")
+            raise KubernetesSATokenValidationError(
+                "Token namespace claim does not match subject", category="identity"
+            )
 
         service_account = bound.get("serviceaccount")
         if not isinstance(service_account, dict):
             raise KubernetesSATokenValidationError(
-                "Token is missing Kubernetes bound ServiceAccount claims"
+                "Token is missing Kubernetes bound ServiceAccount claims", category="identity"
             )
         if service_account.get("name") != name:
             raise KubernetesSATokenValidationError(
-                "Token ServiceAccount name claim does not match subject"
+                "Token ServiceAccount name claim does not match subject", category="identity"
             )
 
         uid = service_account.get("uid")
         if not isinstance(uid, str) or not uid:
             raise KubernetesSATokenValidationError(
-                "Token is missing a Kubernetes ServiceAccount UID claim"
+                "Token is missing a Kubernetes ServiceAccount UID claim", category="identity"
             )
 
     def _issuer_config(self, token_issuer: str) -> dict[str, Any]:

--- a/auth/test/test_kubernetes_sa.py
+++ b/auth/test/test_kubernetes_sa.py
@@ -253,12 +253,40 @@ def test_rejects_missing_iat_or_exp():
         validator.validate(token)
 
 
+def test_validation_failure_categories_separate_trust_from_identity():
+    private_key = _rsa_key()
+    validator, _ = _validator(private_key)
+
+    with pytest.raises(KubernetesSATokenValidationError) as trust_error:
+        validator.validate("not-a-jwt")
+    assert trust_error.value.category == "trust"
+
+    with pytest.raises(KubernetesSATokenValidationError) as identity_error:
+        validator.validate(_token(private_key, sub="ordinary-user"))
+    assert identity_error.value.category == "identity"
+
+    with pytest.raises(KubernetesSATokenValidationError) as bound_claim_error:
+        validator.validate(
+            _token(
+                private_key,
+                **{
+                    "kubernetes.io": {
+                        "namespace": NAMESPACE,
+                        "serviceaccount": {"name": "wrong-name", "uid": SA_UID},
+                    }
+                },
+            )
+        )
+    assert bound_claim_error.value.category == "identity"
+
+
 def test_rejects_malformed_token():
     private_key = _rsa_key()
     validator, _ = _validator(private_key)
 
-    with pytest.raises(KubernetesSATokenValidationError):
+    with pytest.raises(KubernetesSATokenValidationError) as exc_info:
         validator.validate("not-a-jwt")
+    assert exc_info.value.category == "trust"
 
 
 def test_rejects_token_missing_kid():

--- a/data/migrations/test/test_workload_identity_audit_log_kinds.py
+++ b/data/migrations/test/test_workload_identity_audit_log_kinds.py
@@ -1,0 +1,43 @@
+from importlib import import_module
+from types import SimpleNamespace
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from data.migrations.tester import NoopTester
+
+migration = import_module(
+    "data.migrations.versions.8fd6edfc06db_add_workload_identity_audit_log_kinds"
+)
+
+
+def _operations(connection):
+    context = MigrationContext.configure(connection, opts={"render_as_batch": True})
+    return Operations(context)
+
+
+def test_workload_identity_audit_log_kinds_migration_upgrade_and_downgrade():
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    logentrykind = sa.Table(
+        "logentrykind",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False, unique=True),
+    )
+
+    with engine.begin() as connection:
+        metadata.create_all(connection)
+        tables = SimpleNamespace(logentrykind=logentrykind)
+        migration.upgrade(_operations(connection), tables, NoopTester())
+
+        expected = {
+            "workload_identity_token_exchange",
+            "workload_identity_token_exchange_failed",
+        }
+        assert set(connection.execute(sa.select(logentrykind.c.name)).scalars()) == expected
+
+        migration.downgrade(_operations(connection), tables, NoopTester())
+
+        assert set(connection.execute(sa.select(logentrykind.c.name)).scalars()) == set()

--- a/data/migrations/versions/8fd6edfc06db_add_workload_identity_audit_log_kinds.py
+++ b/data/migrations/versions/8fd6edfc06db_add_workload_identity_audit_log_kinds.py
@@ -1,0 +1,34 @@
+"""add workload identity audit log kinds
+
+Revision ID: 8fd6edfc06db
+Revises: 9fa37f66a9b6
+Create Date: 2026-09-09 19:21:38.130579
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8fd6edfc06db"
+down_revision = "9fa37f66a9b6"
+
+
+def upgrade(op, tables, tester):
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "workload_identity_token_exchange"},
+            {"name": "workload_identity_token_exchange_failed"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.c.name.in_(
+                [
+                    "workload_identity_token_exchange",
+                    "workload_identity_token_exchange_failed",
+                ]
+            )
+        )
+    )

--- a/data/model/test/test_oauth.py
+++ b/data/model/test/test_oauth.py
@@ -58,7 +58,12 @@ def test_oauth_access_token_last_accessed_indexed_by_application():
 
 
 def test_oauth_api_token_log_kinds_seeded(initialized_db):
-    expected_log_kinds = {"create_oauth_api_token", "revoke_oauth_api_token"}
+    expected_log_kinds = {
+        "create_oauth_api_token",
+        "revoke_oauth_api_token",
+        "workload_identity_token_exchange",
+        "workload_identity_token_exchange_failed",
+    }
     found_log_kinds = {
         kind.name for kind in LogEntryKind.select().where(LogEntryKind.name << expected_log_kinds)
     }

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -27,7 +27,7 @@ from data.model.oauth import (
     lock_bootstrap_token_operation,
     validate_bootstrap_token,
 )
-from endpoints.api import ApiResource, nickname, resource, show_if
+from endpoints.api import ApiResource, log_action, nickname, resource, show_if
 from endpoints.decorators import anon_allowed
 from endpoints.exception import (
     ApiErrorType,
@@ -142,6 +142,35 @@ def _is_local_bootstrap_renewal_request(req: Request) -> bool:
     )
 
 
+def _log_workload_identity_exchange(
+    *,
+    owner,
+    outcome,
+    requested_scope,
+    effective_scope=None,
+    issuer=None,
+    subject=None,
+    token_record=None,
+    failure_category=None,
+    failure_reason=None,
+):
+    metadata = {"outcome": outcome, "requested_scope": requested_scope}
+    if issuer is not None and subject is not None:
+        metadata.update({"issuer": issuer, "subject": subject})
+    if effective_scope is not None:
+        metadata["effective_scope"] = effective_scope
+    if token_record is not None:
+        metadata["oauth_token_uuid"] = token_record.uuid
+    if outcome == "failure":
+        metadata.update({"failure_category": failure_category, "failure_reason": failure_reason})
+    kind = (
+        "workload_identity_token_exchange"
+        if outcome == "success"
+        else "workload_identity_token_exchange_failed"
+    )
+    log_action(kind, owner.username if owner is not None else None, metadata=metadata)
+
+
 def _mint_authorized_exchange(validated, effective_scope):
     owner = model.user.get_user(app.config.get("BOOTSTRAP_TOKEN_OWNER"))
     if owner is None:
@@ -152,7 +181,7 @@ def _mint_authorized_exchange(validated, effective_scope):
         application = get_canonical_automatic_bootstrap_application(owner)
         if application is None:
             application = create_bootstrap_application(model.oauth.get_bootstrap_app_name(), owner)
-        _, token = create_workload_identity_oauth_token(
+        token_record, token = create_workload_identity_oauth_token(
             application,
             owner,
             effective_scope,
@@ -160,6 +189,15 @@ def _mint_authorized_exchange(validated, effective_scope):
             validated.subject,
             expiration_seconds=expiration_seconds,
         )
+    _log_workload_identity_exchange(
+        owner=owner,
+        outcome="success",
+        requested_scope=effective_scope,
+        effective_scope=effective_scope,
+        issuer=validated.issuer,
+        subject=validated.subject,
+        token_record=token_record,
+    )
     return _exchange_response(
         {
             "access_token": token,

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -2,13 +2,17 @@ import base64
 import json
 import os
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from httmock import HTTMock, urlmatch
 
 from app import app as real_app
-from auth.kubernetes_sa import KubernetesSATokenValidator, ValidatedKubernetesSA
+from auth.kubernetes_sa import (
+    KubernetesSATokenValidationError,
+    KubernetesSATokenValidator,
+    ValidatedKubernetesSA,
+)
 from data import model
 from endpoints.api.bootstrap import (
     _QUAY_BOOTSTRAP_RENEWAL_LOCATION_HEADER,
@@ -161,11 +165,48 @@ def test_exchange_uses_shared_validator_cache_and_mints_bounded_token(
     validate.assert_called_once_with("service-account-jwt")
 
 
+def test_exchange_audit_success_contains_safe_correlation_metadata(app, initialized_db, tmp_path):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "scope": "repo:write repo:read repo:read",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        patch("endpoints.api.bootstrap.log_action") as audit,
+        app.test_request_context(method="POST", data=form),
+    ):
+        payload, _, _ = _exchange_bootstrap_token()
+
+    kind, account_name = audit.call_args.args[:2]
+    metadata = audit.call_args.kwargs["metadata"]
+    token_record = model.oauth.validate_access_token(payload["access_token"])
+    application = token_record.application
+    assert kind == "workload_identity_token_exchange"
+    assert account_name == "devtable"
+    assert metadata == {
+        "outcome": "success",
+        "requested_scope": "repo:read repo:write",
+        "effective_scope": "repo:read repo:write",
+        "issuer": validated.issuer,
+        "subject": validated.subject,
+        "oauth_token_uuid": token_record.uuid,
+        "client_id": application.client_id,
+    }
+    assert "service-account-jwt" not in repr(metadata)
+    assert all(secret_key not in metadata for secret_key in ("subject_token", "jti", "kid"))
+
+
 def test_exchange_invalid_request_uses_matching_api_error_type(app, initialized_db, tmp_path):
     config, _ = _exchange_endpoint_config(tmp_path)
 
     with (
         patch.dict(real_app.config, config),
+        patch("endpoints.api.bootstrap.log_action") as audit,
         app.test_request_context(method="POST", data={}),
         pytest.raises(BootstrapExchangeError) as exc_info,
     ):
@@ -175,6 +216,16 @@ def test_exchange_invalid_request_uses_matching_api_error_type(app, initialized_
     assert exc_info.value.data["error"] == "invalid_request"
     assert exc_info.value.data["error_type"] == "invalid_request"
     assert exc_info.value.data["title"] == "invalid_request"
+    kind, account_name = audit.call_args.args[:2]
+    metadata = audit.call_args.kwargs["metadata"]
+    assert kind == "workload_identity_token_exchange_failed"
+    assert account_name == "devtable"
+    assert metadata == {
+        "outcome": "failure",
+        "requested_scope": "",
+        "failure_category": "request",
+        "failure_reason": "invalid_request",
+    }
 
 
 def test_exchange_access_denied_uses_unauthorized_api_error_type(app, initialized_db, tmp_path):
@@ -193,6 +244,7 @@ def test_exchange_access_denied_uses_unauthorized_api_error_type(app, initialize
     with (
         patch.dict(real_app.config, config),
         patch.object(KubernetesSATokenValidator, "validate", return_value=denied),
+        patch("endpoints.api.bootstrap.log_action") as audit,
         app.test_request_context(method="POST", data=form),
         pytest.raises(BootstrapExchangeError) as exc_info,
     ):
@@ -202,6 +254,15 @@ def test_exchange_access_denied_uses_unauthorized_api_error_type(app, initialize
     assert exc_info.value.data["error"] == "access_denied"
     assert exc_info.value.data["error_type"] == "unauthorized"
     assert exc_info.value.data["title"] == "unauthorized"
+    kind, account_name = audit.call_args.args[:2]
+    metadata = audit.call_args.kwargs["metadata"]
+    assert kind == "workload_identity_token_exchange_failed"
+    assert account_name == "devtable"
+    assert metadata["failure_category"] == "authorization"
+    assert metadata["failure_reason"] == "subject_not_authorized"
+    assert metadata["issuer"] == denied.issuer
+    assert metadata["subject"] == denied.subject
+    assert "service-account-jwt" not in repr(metadata)
 
 
 def test_exchange_server_error_uses_matching_api_error_type(app, initialized_db, tmp_path):
@@ -215,6 +276,7 @@ def test_exchange_server_error_uses_matching_api_error_type(app, initialized_db,
     with (
         patch.dict(real_app.config, config),
         patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        patch("endpoints.api.bootstrap.log_action") as audit,
         app.test_request_context(method="POST", data=form),
         pytest.raises(BootstrapExchangeError) as exc_info,
     ):
@@ -224,6 +286,137 @@ def test_exchange_server_error_uses_matching_api_error_type(app, initialized_db,
     assert exc_info.value.data["error"] == "server_error"
     assert exc_info.value.data["error_type"] == "server_error"
     assert exc_info.value.data["title"] == "server_error"
+    kind, account_name = audit.call_args.args[:2]
+    metadata = audit.call_args.kwargs["metadata"]
+    assert kind == "workload_identity_token_exchange_failed"
+    assert account_name is None
+    assert metadata["failure_category"] == "issuance"
+    assert metadata["failure_reason"] == "token_owner_missing"
+    assert metadata["issuer"] == validated.issuer
+    assert metadata["subject"] == validated.subject
+
+
+@pytest.mark.parametrize(
+    ("category", "failure_category", "failure_reason"),
+    [
+        ("trust", "trust", "token_validation_failed"),
+        ("identity", "identity", "service_account_identity_invalid"),
+    ],
+)
+def test_exchange_validation_failures_use_stable_audit_taxonomy(
+    app, initialized_db, tmp_path, category, failure_category, failure_reason
+):
+    config, _ = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(
+            KubernetesSATokenValidator,
+            "validate",
+            side_effect=KubernetesSATokenValidationError("presented jwt", category=category),
+        ),
+        patch("endpoints.api.bootstrap.log_action") as audit,
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(BootstrapExchangeError),
+    ):
+        _exchange_bootstrap_token()
+
+    metadata = audit.call_args.kwargs["metadata"]
+    assert metadata["failure_category"] == failure_category
+    assert metadata["failure_reason"] == failure_reason
+    assert "presented jwt" not in repr(metadata)
+    assert "service-account-jwt" not in repr(metadata)
+
+
+def test_exchange_scope_denial_has_distinct_audit_reason(app, initialized_db, tmp_path):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "scope": "repo:delete repo:read repo:read",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        patch("endpoints.api.bootstrap.log_action") as audit,
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(BootstrapExchangeError),
+    ):
+        _exchange_bootstrap_token()
+
+    metadata = audit.call_args.kwargs["metadata"]
+    assert metadata["failure_category"] == "authorization"
+    assert metadata["failure_reason"] == "scope_not_authorized"
+    assert metadata["requested_scope"] == "repo:delete repo:read"
+    assert metadata["issuer"] == validated.issuer
+    assert metadata["subject"] == validated.subject
+
+
+def test_exchange_application_creation_failure_is_audited_and_reraised(
+    app, initialized_db, tmp_path
+):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    }
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        patch.object(
+            model.oauth,
+            "get_canonical_bootstrap_application",
+            side_effect=RuntimeError("application-secret"),
+        ),
+        patch("endpoints.api.bootstrap.log_action") as audit,
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(RuntimeError, match="application-secret"),
+    ):
+        _exchange_bootstrap_token()
+
+    metadata = audit.call_args.kwargs["metadata"]
+    assert metadata["failure_category"] == "issuance"
+    assert metadata["failure_reason"] == "application_creation_failed"
+    assert "application-secret" not in repr(metadata)
+
+
+def test_exchange_token_creation_failure_is_audited_and_reraised(app, initialized_db, tmp_path):
+    config, validated = _exchange_endpoint_config(tmp_path)
+    form = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": "service-account-jwt",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    }
+    application = Mock(client_id="client-id")
+
+    with (
+        patch.dict(real_app.config, config),
+        patch.object(KubernetesSATokenValidator, "validate", return_value=validated),
+        patch.object(model.oauth, "get_canonical_bootstrap_application", return_value=application),
+        patch(
+            "endpoints.api.bootstrap.create_workload_identity_oauth_token",
+            side_effect=RuntimeError("token-secret"),
+        ),
+        patch("endpoints.api.bootstrap.log_action") as audit,
+        app.test_request_context(method="POST", data=form),
+        pytest.raises(RuntimeError, match="token-secret"),
+    ):
+        _exchange_bootstrap_token()
+
+    metadata = audit.call_args.kwargs["metadata"]
+    assert metadata["failure_category"] == "issuance"
+    assert metadata["failure_reason"] == "token_creation_failed"
+    assert "token-secret" not in repr(metadata)
+    assert "service-account-jwt" not in repr(metadata)
 
 
 def test_exchange_normalizes_issuer_trailing_slashes():
@@ -256,6 +449,15 @@ def test_authorize_workload_scope_normalizes_issuer_and_scope():
             "repo:read",
         )
         == "repo:read"
+    )
+    assert (
+        authorize_workload_scope(
+            authorized_subjects,
+            "https://cluster.example.com/",
+            "system:serviceaccount:quay:operator",
+            "",
+        )
+        == "org:admin repo:read"
     )
 
 

--- a/initdb.py
+++ b/initdb.py
@@ -625,6 +625,8 @@ def initialize_database():
 
     LogEntryKind.create(name="create_oauth_api_token")
     LogEntryKind.create(name="revoke_oauth_api_token")
+    LogEntryKind.create(name="workload_identity_token_exchange")
+    LogEntryKind.create(name="workload_identity_token_exchange_failed")
 
     ImageStorageLocation.create(name="local_eu")
     ImageStorageLocation.create(name="local_us")


### PR DESCRIPTION
## Summary

Adds Quay audit records for successful and failed Kubernetes ServiceAccount workload identity token exchanges.

Audit events are associated with the configured bootstrap token owner when available and capture:

- the validated Kubernetes issuer and ServiceAccount subject;
- requested and effective OAuth scopes;
- stable request, trust, identity, authorization, and issuance outcomes;
- the issued OAuth token UUID and client ID for correlation.

The presented ServiceAccount JWT, token secret, JWT identifiers, arbitrary claims, and exception messages are never recorded.

## Changes

- add success and failure workload identity audit event kinds;
- categorize Kubernetes token validation failures as trust or identity failures;
- distinguish unauthorized subjects from unauthorized scopes;
- audit application and OAuth token issuance failures;
- add an Alembic migration and test-database seed data for the new event kinds;
- add validator, endpoint, model, and migration coverage.

## Testing

Passed:

```bash
TEST=true PYTHONPATH=. pytest \
  auth/test/test_kubernetes_sa.py \
  endpoints/api/test/test_bootstrap.py \
  data/model/test/test_oauth.py \
  data/migrations/test/test_workload_identity_audit_log_kinds.py \
  -q
```

Result: `130 passed`.

Passed:

```bash
python -m black --check \
  auth/kubernetes_sa.py \
  auth/test/test_kubernetes_sa.py \
  endpoints/api/bootstrap.py \
  endpoints/api/test/test_bootstrap.py \
  data/model/test/test_oauth.py \
  initdb.py \
  data/migrations/versions/8fd6edfc06db_add_workload_identity_audit_log_kinds.py \
  data/migrations/test/test_workload_identity_audit_log_kinds.py

git diff --check
```

Playwright was not run: exercising successful exchange auditing requires a trusted Kubernetes OIDC issuer, while the behavior is covered at the endpoint and migration layers above.
