### PR TITLE
PROJQUAY-13193: fix(mirror): skip unchanged tags during mirror sync

### DIFF
--- a/web/playwright/e2e/api/api-v1-mirror-incremental-sync.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-incremental-sync.spec.ts
@@ -2,7 +2,7 @@ import {test, expect} from '../../fixtures';
 
 test.describe(
   'Mirror incremental sync (PROJQUAY-13193)',
-  {tag: ['@api', '@feature:REPO_MIRROR']},
+  {tag: ['@api', '@feature:REPO_MIRROR', '@mirror-incremental-sync']},
   () => {
     test('second sync preserves tag digest and completes without error', async ({
       api,

--- a/web/playwright/e2e/api/api-v1-mirror-incremental-sync.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-incremental-sync.spec.ts
@@ -1,0 +1,89 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Mirror incremental sync (PROJQUAY-13193)',
+  {tag: ['@api', '@feature:REPO_MIRROR']},
+  () => {
+    test('second sync preserves tag digest and completes without error', async ({
+      api,
+    }) => {
+      // This test validates that the incremental sync optimization works
+      // correctly: a second sync of an unchanged tag should succeed and
+      // leave the manifest digest identical to the first sync.
+      test.setTimeout(300_000);
+
+      const org = await api.organization('incrsyncorg');
+      const repo = await api.repository(org.name, 'incrsyncrepo');
+      const robot = await api.robot(org.name, 'incrsyncbot');
+      await api.setMirrorState(org.name, repo.name);
+
+      const syncStartDate = new Date();
+      syncStartDate.setMinutes(syncStartDate.getMinutes() + 5);
+      await api.raw.createMirrorConfig(org.name, repo.name, {
+        external_reference: 'quay.io/quay/busybox',
+        sync_interval: 86400,
+        sync_start_date: syncStartDate.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['latest']},
+        robot_username: robot.fullName,
+        skopeo_timeout_interval: 300,
+        is_enabled: true,
+        verify_tls: true,
+      });
+
+      // --- First sync ---
+      await api.raw.triggerMirrorSync(org.name, repo.name);
+
+      await expect
+        .poll(
+          async () => {
+            const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
+            const status = cfg?.sync_status ?? 'UNKNOWN';
+            if (status === 'FAIL') {
+              throw new Error('First mirror sync failed');
+            }
+            return status;
+          },
+          {
+            timeout: 120_000,
+            intervals: [5_000, 10_000, 15_000],
+            message: 'First sync did not complete within 2 minutes',
+          },
+        )
+        .toBe('SUCCESS');
+
+      const tagsAfterFirst = await api.raw.getTags(org.name, repo.name);
+      const firstDigest = tagsAfterFirst.tags.find(
+        (t) => t.name === 'latest',
+      )?.manifest_digest;
+      expect(firstDigest).toBeTruthy();
+
+      // --- Second sync (should skip the unchanged tag) ---
+      await api.raw.triggerMirrorSync(org.name, repo.name);
+
+      await expect
+        .poll(
+          async () => {
+            const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
+            const status = cfg?.sync_status ?? 'UNKNOWN';
+            if (status === 'FAIL') {
+              throw new Error('Second mirror sync failed');
+            }
+            return status;
+          },
+          {
+            timeout: 120_000,
+            intervals: [5_000, 10_000, 15_000],
+            message: 'Second sync did not complete within 2 minutes',
+          },
+        )
+        .toBe('SUCCESS');
+
+      // Verify the tag digest is unchanged after the second sync
+      const tagsAfterSecond = await api.raw.getTags(org.name, repo.name);
+      const secondDigest = tagsAfterSecond.tags.find(
+        (t) => t.name === 'latest',
+      )?.manifest_digest;
+      expect(secondDigest).toBe(firstDigest);
+    });
+  },
+);

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -1811,7 +1811,11 @@ def perform_org_mirror_repo(skopeo: SkopeoMirror, org_mirror_repo: OrgMirrorRepo
         skopeo_timeout = config.skopeo_timeout
 
         # Build local tag->digest map for incremental sync
-        local_digests = _build_local_digest_map(claimed_repo.repository.id)
+        local_digests = (
+            _build_local_digest_map(claimed_repo.repository.id)
+            if claimed_repo.repository is not None
+            else {}
+        )
 
         for tag in tags:
             src_image = f"docker://{external_reference}:{tag}"

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -16,6 +16,7 @@ import features
 from app import app
 from data import database
 from data.database import (
+    Manifest,
     OrgMirrorConfig,
     OrgMirrorRepository,
     OrgMirrorRepoStatus,
@@ -24,13 +25,14 @@ from data.database import (
     RepoMirrorStatus,
     Repository,
     RepositoryState,
+    Tag,
 )
 from data.encryption import DecryptionFailureException
 from data.logs_model import logs_model
 from data.model import repository as repository_model
 from data.model.oci.tag import (
     delete_tag,
-    list_alive_tags,
+    filter_to_alive_tags,
     lookup_alive_tags_shallow,
     retarget_tag,
 )
@@ -463,6 +465,16 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                         namespace=namespace,
                         repository=repository_name,
                     ).set(remaining_tags)
+
+                    if check_repo_mirror_sync_status(mirror) == RepoMirrorStatus.CANCEL:
+                        logger.info(
+                            "Sync cancelled on repo %s/%s.",
+                            mirror.repository.namespace_user.username,
+                            mirror.repository.name,
+                        )
+                        overall_status = RepoMirrorStatus.CANCEL
+                        break
+
                     continue
 
             if use_arch_filter:
@@ -798,12 +810,20 @@ def delete_obsolete_tags(mirror, tags):
 
 def _build_local_digest_map(repository_id):
     """
-    Build a {tag_name: manifest_digest} map for all alive tags in the repository.
+    Build a {tag_name: manifest_digest} map for all alive, non-hidden tags.
+
+    Only selects Tag.name and Manifest.digest to avoid loading full manifest
+    bytes into memory, which matters for repos with many tags.
     Returns an empty dict on any failure so callers fall through to unconditional copy.
     """
     try:
-        tags = list_alive_tags(repository_id)
-        return {t.name: t.manifest.digest for t in tags if not t.hidden}
+        query = (
+            Tag.select(Tag.name, Manifest.digest)
+            .join(Manifest)
+            .where(Tag.repository == repository_id, Tag.hidden == False)
+        )
+        query = filter_to_alive_tags(query)
+        return {t.name: t.manifest.digest for t in query.iterator()}
     except Exception:
         logger.exception("Failed to build local digest map, skipping incremental sync")
         return {}
@@ -1817,6 +1837,19 @@ def perform_org_mirror_repo(skopeo: SkopeoMirror, org_mirror_repo: OrgMirrorRepo
                         tag,
                         remote_digest,
                     )
+
+                    if (
+                        check_org_mirror_repo_sync_status(claimed_repo)
+                        == OrgMirrorRepoStatus.CANCEL
+                    ):
+                        logger.info(
+                            "Org mirror sync cancelled on repo %s/%s.",
+                            org.username,
+                            claimed_repo.repository_name,
+                        )
+                        overall_status = OrgMirrorRepoStatus.CANCEL
+                        break
+
                     continue
 
             with database.CloseForLongOperation(app.config):

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -1,4 +1,5 @@
 import fnmatch
+import hashlib
 import json
 import logging
 import os
@@ -27,7 +28,7 @@ from data.database import (
 from data.encryption import DecryptionFailureException
 from data.logs_model import logs_model
 from data.model import repository as repository_model
-from data.model.oci.tag import delete_tag, lookup_alive_tags_shallow, retarget_tag
+from data.model.oci.tag import delete_tag, list_alive_tags, lookup_alive_tags_shallow, retarget_tag
 from data.model.org_mirror import (
     check_org_mirror_repo_sync_status,
     claim_org_mirror_config,
@@ -426,6 +427,9 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 architecture_filter,
             )
 
+        # Build local tag->digest map for incremental sync
+        local_digests = _build_local_digest_map(mirror.repository.id)
+
         for tag_index, tag in enumerate(tags):
             src_image = "docker://%s:%s" % (mirror.external_reference, tag)
             dest_image = "docker://%s/%s/%s:%s" % (
@@ -434,6 +438,27 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 mirror.repository.name,
                 tag,
             )
+
+            # Skip tags whose remote digest matches the local digest
+            if not use_arch_filter and tag in local_digests:
+                remote_digest = _remote_manifest_digest(
+                    skopeo,
+                    src_image,
+                    skopeo_timeout,
+                    username,
+                    password,
+                    mirror.external_registry_config.get("verify_tls", True),
+                    mirror.external_registry_config.get("proxy", {}),
+                    verbose_logs,
+                )
+                if remote_digest and remote_digest == local_digests[tag]:
+                    logger.info("Skipping unchanged tag '%s' (digest %s)", tag, remote_digest)
+                    remaining_tags = len(tags) - (tag_index + 1)
+                    repo_mirror_pending_tags.labels(
+                        namespace=namespace,
+                        repository=repository_name,
+                    ).set(remaining_tags)
+                    continue
 
             if use_arch_filter:
                 # Use architecture-filtered copy
@@ -764,6 +789,54 @@ def delete_obsolete_tags(mirror, tags):
         delete_tag(mirror.repository, tag.name)
 
     return obsolete_tags
+
+
+def _build_local_digest_map(repository_id):
+    """
+    Build a {tag_name: manifest_digest} map for all alive tags in the repository.
+    Returns an empty dict on any failure so callers fall through to unconditional copy.
+    """
+    try:
+        tags = list_alive_tags(repository_id)
+        return {t.name: t.manifest.digest for t in tags if not t.hidden}
+    except Exception:
+        logger.exception("Failed to build local digest map, skipping incremental sync")
+        return {}
+
+
+def _remote_manifest_digest(
+    skopeo, image, timeout, username, password, verify_tls, proxy, verbose_logs
+):
+    """
+    Fetch the remote manifest digest by hashing the raw manifest bytes.
+
+    Uses inspect_raw (skopeo inspect --raw) which returns the manifest list
+    for multi-arch images or the manifest for single-arch images.  Computing
+    sha256 over the raw bytes produces the same digest that Quay stores on
+    the Tag, unlike plain ``skopeo inspect`` which resolves through the
+    manifest list to a platform-specific config digest.
+
+    Returns the "sha256:<hex>" digest string on success, None on failure.
+    """
+    try:
+        with database.CloseForLongOperation(app.config):
+            result = skopeo.inspect_raw(
+                image,
+                timeout,
+                username=username,
+                password=password,
+                verify_tls=verify_tls,
+                proxy=proxy,
+                verbose_logs=verbose_logs,
+            )
+        if result.success and result.stdout:
+            manifest_bytes = result.stdout
+            if isinstance(manifest_bytes, str):
+                manifest_bytes = manifest_bytes.encode("utf-8")
+            return "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+    except Exception:
+        logger.debug("Failed to inspect remote digest for %s", image, exc_info=True)
+    return None
 
 
 def _get_v2_bearer_token(server, scheme, namespace, repo_name, username, password, verify_tls):
@@ -1712,11 +1785,34 @@ def perform_org_mirror_repo(skopeo: SkopeoMirror, org_mirror_repo: OrgMirrorRepo
         )
         skopeo_timeout = config.skopeo_timeout
 
+        # Build local tag->digest map for incremental sync
+        local_digests = _build_local_digest_map(claimed_repo.repository.id)
+
         for tag in tags:
             src_image = f"docker://{external_reference}:{tag}"
             dest_image = (
                 f"docker://{dest_server}/{org.username}/{claimed_repo.repository_name}:{tag}"
             )
+
+            # Skip tags whose remote digest matches the local digest
+            if tag in local_digests:
+                remote_digest = _remote_manifest_digest(
+                    skopeo,
+                    src_image,
+                    skopeo_timeout,
+                    username,
+                    password,
+                    config.external_registry_config.get("verify_tls", True),
+                    config.external_registry_config.get("proxy", {}),
+                    verbose_logs,
+                )
+                if remote_digest and remote_digest == local_digests[tag]:
+                    logger.info(
+                        "Org mirror: skipping unchanged tag '%s' (digest %s)",
+                        tag,
+                        remote_digest,
+                    )
+                    continue
 
             with database.CloseForLongOperation(app.config):
                 result = skopeo.copy(

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -28,7 +28,12 @@ from data.database import (
 from data.encryption import DecryptionFailureException
 from data.logs_model import logs_model
 from data.model import repository as repository_model
-from data.model.oci.tag import delete_tag, list_alive_tags, lookup_alive_tags_shallow, retarget_tag
+from data.model.oci.tag import (
+    delete_tag,
+    list_alive_tags,
+    lookup_alive_tags_shallow,
+    retarget_tag,
+)
 from data.model.org_mirror import (
     check_org_mirror_repo_sync_status,
     claim_org_mirror_config,

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -2444,9 +2444,7 @@ def test_build_local_digest_map_empty_repo(initialized_db):
 
 def test_build_local_digest_map_returns_empty_on_error(initialized_db):
     """_build_local_digest_map returns {} on exception so callers fall through to full copy."""
-    with mock.patch(
-        "workers.repomirrorworker.list_alive_tags", side_effect=Exception("db error")
-    ):
+    with mock.patch("workers.repomirrorworker.list_alive_tags", side_effect=Exception("db error")):
         digest_map = _build_local_digest_map(999999)
 
     assert digest_map == {}

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -2444,7 +2444,9 @@ def test_build_local_digest_map_empty_repo(initialized_db):
 
 def test_build_local_digest_map_returns_empty_on_error(initialized_db):
     """_build_local_digest_map returns {} on exception so callers fall through to full copy."""
-    with mock.patch("workers.repomirrorworker.list_alive_tags", side_effect=Exception("db error")):
+    with mock.patch(
+        "workers.repomirrorworker.filter_to_alive_tags", side_effect=Exception("db error")
+    ):
         digest_map = _build_local_digest_map(999999)
 
     assert digest_map == {}

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -22,7 +22,9 @@ from test.fixtures import *
 from util.repomirror.skopeomirror import SkopeoMirror, SkopeoResults
 from workers.repomirrorworker import (
     PreemptedException,
+    _build_local_digest_map,
     _get_v2_bearer_token,
+    _remote_manifest_digest,
     copy_filtered_architectures,
     delete_obsolete_tags,
     perform_mirror,
@@ -2410,3 +2412,343 @@ def test_workers_active_gauge_reset_on_terminate(initialized_db, app):
 
         worker.terminate(graceful=True)
         gauge.set.assert_called_with(0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for incremental sync helpers (PROJQUAY-13193)
+# ---------------------------------------------------------------------------
+
+
+def test_build_local_digest_map_returns_tag_digest_pairs(initialized_db):
+    """_build_local_digest_map returns a {name: digest} dict for alive tags."""
+    mirror, repo = create_mirror_repo_robot(["latest"], repo_name="digest_map")
+    _create_tag(repo, "v1")
+    _create_tag(repo, "v2")
+
+    digest_map = _build_local_digest_map(repo.id)
+
+    assert "v1" in digest_map
+    assert "v2" in digest_map
+    assert digest_map["v1"].startswith("sha256:")
+    assert digest_map["v2"].startswith("sha256:")
+
+
+def test_build_local_digest_map_empty_repo(initialized_db):
+    """_build_local_digest_map returns an empty dict for a repo with no tags."""
+    mirror, repo = create_mirror_repo_robot(["latest"], repo_name="empty_map")
+
+    digest_map = _build_local_digest_map(repo.id)
+
+    assert digest_map == {}
+
+
+def test_build_local_digest_map_returns_empty_on_error(initialized_db):
+    """_build_local_digest_map returns {} on exception so callers fall through to full copy."""
+    with mock.patch(
+        "workers.repomirrorworker.list_alive_tags", side_effect=Exception("db error")
+    ):
+        digest_map = _build_local_digest_map(999999)
+
+    assert digest_map == {}
+
+
+def test_remote_manifest_digest_returns_sha256(initialized_db, app):
+    """_remote_manifest_digest hashes raw manifest bytes and returns sha256:hex."""
+    import hashlib
+
+    raw_manifest = b'{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.index.v1+json"}'
+    expected_digest = "sha256:" + hashlib.sha256(raw_manifest).hexdigest()
+
+    skopeo = mock.MagicMock()
+    skopeo.inspect_raw.return_value = SkopeoResults(True, [], raw_manifest, "")
+
+    result = _remote_manifest_digest(
+        skopeo, "docker://example.com/repo:latest", 300, None, None, True, {}, False
+    )
+
+    assert result == expected_digest
+    skopeo.inspect_raw.assert_called_once()
+
+
+def test_remote_manifest_digest_returns_none_on_failure(initialized_db, app):
+    """_remote_manifest_digest returns None when skopeo inspect_raw fails."""
+    skopeo = mock.MagicMock()
+    skopeo.inspect_raw.return_value = SkopeoResults(False, [], "", "connection refused")
+
+    result = _remote_manifest_digest(
+        skopeo, "docker://example.com/repo:latest", 300, None, None, True, {}, False
+    )
+
+    assert result is None
+
+
+def test_remote_manifest_digest_returns_none_on_exception(initialized_db, app):
+    """_remote_manifest_digest returns None on exception so callers fall through."""
+    skopeo = mock.MagicMock()
+    skopeo.inspect_raw.side_effect = Exception("network error")
+
+    result = _remote_manifest_digest(
+        skopeo, "docker://example.com/repo:latest", 300, None, None, True, {}, False
+    )
+
+    assert result is None
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_perform_mirror_skips_unchanged_tag(run_skopeo_mock, initialized_db, app):
+    """When remote digest matches local digest, skopeo copy is not called for that tag."""
+    import hashlib
+
+    mirror, repo = create_mirror_repo_robot(
+        ["latest"], repo_name="skip_unchanged", external_registry_config={"verify_tls": False}
+    )
+    _create_tag(repo, "latest")
+
+    # Get the local manifest digest so we can make the remote return matching raw bytes
+    local_map = _build_local_digest_map(repo.id)
+    local_digest = local_map["latest"]
+
+    # Build raw manifest bytes that hash to the same digest as the local tag
+    # We need to find the actual manifest bytes from the DB
+    from data.database import Manifest as ManifestDB
+
+    manifest_row = (
+        ManifestDB.select()
+        .where(ManifestDB.repository == repo.id, ManifestDB.digest == local_digest)
+        .get()
+    )
+    raw_manifest_bytes = manifest_row.manifest_bytes.encode("utf-8")
+
+    # Verify our raw bytes produce the expected digest
+    computed = "sha256:" + hashlib.sha256(raw_manifest_bytes).hexdigest()
+    assert computed == local_digest
+
+    skopeo_calls = [
+        # 1) list-tags
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "list-tags",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository",
+            ],
+            "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
+        },
+        # 2) inspect --raw for digest comparison — returns matching manifest
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "inspect",
+                "--raw",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository:latest",
+            ],
+            "results": SkopeoResults(True, [], raw_manifest_bytes, ""),
+        },
+        # NO copy call — tag should be skipped
+    ]
+
+    def skopeo_test(args, proxy, timeout=300):
+        try:
+            skopeo_call = skopeo_calls.pop(0)
+            _assert_skopeo_args(args, skopeo_call["args"])
+            return skopeo_call["results"]
+        except Exception as e:
+            skopeo_calls.append(skopeo_call)
+            raise e
+
+    run_skopeo_mock.side_effect = skopeo_test
+
+    worker = RepoMirrorWorker()
+    worker._process_mirrors()
+
+    # All expected calls consumed, no copy was issued
+    assert [] == skopeo_calls
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_perform_mirror_syncs_changed_tag(run_skopeo_mock, initialized_db, app):
+    """When remote digest differs from local, skopeo copy IS called."""
+    from data.model.user import retrieve_robot_token
+
+    mirror, repo = create_mirror_repo_robot(
+        ["latest"], repo_name="sync_changed", external_registry_config={"verify_tls": False}
+    )
+    _create_tag(repo, "latest")
+
+    # Return different raw manifest bytes so digest won't match
+    different_manifest = b'{"schemaVersion": 2, "config": {"digest": "sha256:different"}}'
+
+    skopeo_calls = [
+        # 1) list-tags
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "list-tags",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository",
+            ],
+            "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
+        },
+        # 2) inspect --raw — returns DIFFERENT manifest
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "inspect",
+                "--raw",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository:latest",
+            ],
+            "results": SkopeoResults(True, [], different_manifest, ""),
+        },
+        # 3) copy IS called because digest differs
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "copy",
+                "--all",
+                "--remove-signatures",
+                "--src-tls-verify=False",
+                "--dest-tls-verify=True",
+                "docker://registry.example.com/namespace/repository:latest",
+                "docker://localhost:5000/mirror/sync_changed:latest",
+            ],
+            "results": SkopeoResults(True, [], "stdout", "stderr"),
+        },
+    ]
+
+    def skopeo_test(args, proxy, timeout=300):
+        try:
+            skopeo_call = skopeo_calls.pop(0)
+            _assert_skopeo_args(args, skopeo_call["args"])
+            return skopeo_call["results"]
+        except Exception as e:
+            skopeo_calls.append(skopeo_call)
+            raise e
+
+    run_skopeo_mock.side_effect = skopeo_test
+
+    worker = RepoMirrorWorker()
+    worker._process_mirrors()
+
+    # All calls consumed including the copy
+    assert [] == skopeo_calls
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_perform_mirror_syncs_new_tag(run_skopeo_mock, initialized_db, app):
+    """New tags not present locally are always synced (no inspect_raw call)."""
+    mirror, repo = create_mirror_repo_robot(
+        ["latest"], repo_name="sync_new", external_registry_config={"verify_tls": False}
+    )
+    # Do NOT create a local "latest" tag — repo is empty
+
+    skopeo_calls = [
+        # 1) list-tags
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "list-tags",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository",
+            ],
+            "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
+        },
+        # 2) copy directly — no inspect_raw because tag is new
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "copy",
+                "--all",
+                "--remove-signatures",
+                "--src-tls-verify=False",
+                "--dest-tls-verify=True",
+                "docker://registry.example.com/namespace/repository:latest",
+                "docker://localhost:5000/mirror/sync_new:latest",
+            ],
+            "results": SkopeoResults(True, [], "stdout", "stderr"),
+        },
+    ]
+
+    def skopeo_test(args, proxy, timeout=300):
+        try:
+            skopeo_call = skopeo_calls.pop(0)
+            _assert_skopeo_args(args, skopeo_call["args"])
+            return skopeo_call["results"]
+        except Exception as e:
+            skopeo_calls.append(skopeo_call)
+            raise e
+
+    run_skopeo_mock.side_effect = skopeo_test
+
+    worker = RepoMirrorWorker()
+    worker._process_mirrors()
+
+    assert [] == skopeo_calls
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_perform_mirror_fallthrough_on_inspect_failure(run_skopeo_mock, initialized_db, app):
+    """When inspect_raw fails, the tag is still synced via copy (safe fallthrough)."""
+    mirror, repo = create_mirror_repo_robot(
+        ["latest"], repo_name="fallthrough", external_registry_config={"verify_tls": False}
+    )
+    _create_tag(repo, "latest")
+
+    skopeo_calls = [
+        # 1) list-tags
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "list-tags",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository",
+            ],
+            "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
+        },
+        # 2) inspect --raw FAILS
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "inspect",
+                "--raw",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository:latest",
+            ],
+            "results": SkopeoResults(False, [], "", "connection refused"),
+        },
+        # 3) copy IS called as fallthrough
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "copy",
+                "--all",
+                "--remove-signatures",
+                "--src-tls-verify=False",
+                "--dest-tls-verify=True",
+                "docker://registry.example.com/namespace/repository:latest",
+                "docker://localhost:5000/mirror/fallthrough:latest",
+            ],
+            "results": SkopeoResults(True, [], "stdout", "stderr"),
+        },
+    ]
+
+    def skopeo_test(args, proxy, timeout=300):
+        try:
+            skopeo_call = skopeo_calls.pop(0)
+            _assert_skopeo_args(args, skopeo_call["args"])
+            return skopeo_call["results"]
+        except Exception as e:
+            skopeo_calls.append(skopeo_call)
+            raise e
+
+    run_skopeo_mock.side_effect = skopeo_test
+
+    worker = RepoMirrorWorker()
+    worker._process_mirrors()
+
+    assert [] == skopeo_calls

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -458,6 +458,8 @@ def test_rollback(
     _create_tag(repo, "updated")
     _create_tag(repo, "deleted")
 
+    different_manifest = b'{"schemaVersion": 2, "config": {"digest": "sha256:different"}}'
+
     skopeo_calls = [
         {
             "args": [
@@ -485,6 +487,16 @@ def test_rollback(
                 "docker://localhost:5000/mirror/repo:created",
             ],
             "results": SkopeoResults(True, [], "Success", ""),
+        },
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "inspect",
+                "--raw",
+                "--tls-verify=True",
+                "docker://registry.example.com/namespace/repository:updated",
+            ],
+            "results": SkopeoResults(True, [], different_manifest, ""),
         },
         {
             "args": [


### PR DESCRIPTION
## Summary
- Skip re-syncing tags whose remote manifest digest matches the local tag digest during mirror sync
- Use `skopeo inspect --raw` + `sha256` to compute the remote digest (works for both single-arch and multi-arch images)
- All failure modes (DB errors, inspect failures) fall through to the original unconditional copy path so the optimization never prevents a sync
- Apply the same optimization to both repo-level and org-level mirror sync

## Test plan
- [x] `test_build_local_digest_map_returns_tag_digest_pairs` — helper returns correct `{name: digest}` map
- [x] `test_build_local_digest_map_empty_repo` — empty repo returns `{}`
- [x] `test_build_local_digest_map_returns_empty_on_error` — DB exception returns `{}` (safe fallthrough)
- [x] `test_remote_manifest_digest_returns_sha256` — `inspect_raw` + sha256 produces correct digest
- [x] `test_remote_manifest_digest_returns_none_on_failure` — failed inspect returns `None`
- [x] `test_remote_manifest_digest_returns_none_on_exception` — exception returns `None` (safe fallthrough)
- [x] `test_perform_mirror_skips_unchanged_tag` — matching digest → no `skopeo copy` call
- [x] `test_perform_mirror_syncs_changed_tag` — different digest → `skopeo copy` IS called
- [x] `test_perform_mirror_syncs_new_tag` — new tag → copy directly, no inspect
- [x] `test_perform_mirror_fallthrough_on_inspect_failure` — failed inspect → copy still happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)