### PR TITLE
[redhat-3.15] PROJQUAY-12892: fix(cve): CVE-2026-59879: Bump immutable to 5.1.9

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12203,9 +12203,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -126,7 +126,7 @@
     "@patternfly/react-table": "^5.1.0",
     "node-forge": "^1.4.0",
     "minimatch": "3.1.5",
-    "immutable": "^5.1.5",
+    "immutable": "^5.1.8",
     "decode-uri-component": "^0.5.0",
     "svgo": "4.0.1",
     "brace-expansion": "^1.1.18",


### PR DESCRIPTION
## Summary

Security fix for CVE-2026-59879 affecting immutable

## CVE Details

CVE: CVE-2026-59879
Severity: HIGH (CVSSv4: 8.7)
Impact: Denial of Service due to mishandling of large index values in List operations
Component: immutable
Old Version: 5.1.5
New Version: 5.1.9

## Changes

Fixed immutable to 5.1.9 in web/package.json
Updated immutable from  5.1.5 in 5.1.9 in web/package-lock.json


## References

https://www.cve.org/CVERecord?id=CVE-2026-59879
https://www.npmjs.com/package/immutable

## Resolves

[PROJQUAY-12892](https://redhat.atlassian.net/browse/PROJQUAY-12892)