### PR TITLE
[redhat-3.10] PROJQUAY-12894: fix(cve): CVE-2026-59879: Bump immutable to 5.1.9

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12966,9 +12966,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -36063,9 +36063,9 @@
       "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
     },
     "immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "devOptional": true
     },
     "import-fresh": {
@@ -43260,7 +43260,7 @@
       "devOptional": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^5.1.5",
+        "immutable": "^5.1.8",
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -119,7 +119,7 @@
     "node-forge": "1.4.0",
     "axios": "^1.19.0",
     "minimatch": "^3.1.5",
-    "immutable": "^5.1.5",
+    "immutable": "^5.1.8",
     "decode-uri-component": "^0.5.0",
     "svgo": "4.0.1",
     "brace-expansion": "^1.1.18",


### PR DESCRIPTION
## Summary

Security fix for CVE-2026-59879 affecting immutable

## CVE Details

CVE: CVE-2026-59879
Severity: HIGH (CVSSv4: 8.7)
Impact: Denial of Service due to mishandling of large index values in List operations
Component: immutable
Old Version: 5.1.5
New Version: 5.1.9

## Changes

Fixed immutable to 5.1.9 in web/package.json
Updated immutable from  5.1.5 in 5.1.9 in web/package-lock.json


## References

https://www.cve.org/CVERecord?id=CVE-2026-59879
https://www.npmjs.com/package/immutable

## Resolves

[PROJQUAY-12894](https://redhat.atlassian.net/browse/PROJQUAY-12894)