### PR TITLE
PROJQUAY-13201: fix(omr): do not rewrite a tag that already points at the manifest

### DIFF
--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -34,6 +34,35 @@ func (q *Queries) ExpireActiveTag(ctx context.Context, arg ExpireActiveTagParams
 	return q.db.ExecContext(ctx, expireActiveTag, arg.LifetimeEndMs, arg.RepositoryID, arg.Name)
 }
 
+const getActiveTag = `-- name: GetActiveTag :one
+SELECT id, manifest_id, lifetime_start_ms
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY lifetime_start_ms DESC
+LIMIT 1
+`
+
+type GetActiveTagParams struct {
+	RepositoryID int64  `json:"repository_id"`
+	Name         string `json:"name"`
+}
+
+type GetActiveTagRow struct {
+	ID              int64         `json:"id"`
+	ManifestID      sql.NullInt64 `json:"manifest_id"`
+	LifetimeStartMs int64         `json:"lifetime_start_ms"`
+}
+
+// Returns the live (lifetime_end_ms IS NULL) tag row for a name. Callers use
+// it to skip the expire-and-insert cycle when the tag already points at the
+// manifest being written, so a repeated PUT does not leave an expired row.
+func (q *Queries) GetActiveTag(ctx context.Context, arg GetActiveTagParams) (GetActiveTagRow, error) {
+	row := q.db.QueryRowContext(ctx, getActiveTag, arg.RepositoryID, arg.Name)
+	var i GetActiveTagRow
+	err := row.Scan(&i.ID, &i.ManifestID, &i.LifetimeStartMs)
+	return i, err
+}
+
 const getActiveTagDigest = `-- name: GetActiveTagDigest :one
 SELECT m.digest
 FROM tag t

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -421,10 +421,31 @@ func (s *SQLiteStore) PutTag(ctx context.Context, repoID int64, t oci.TagRecord)
 	return id, nil
 }
 
-// putTag expires any active tag with the same name, then inserts a new one.
-// This avoids the NULL != NULL issue on the
-// (repository_id, name, lifetime_end_ms) unique index.
+// putTag points tag at manifestID. When the active tag already targets that
+// manifest the call is a no-op and the existing row id is returned: the
+// distribution manifest handler stores a tagged manifest through PutManifest
+// and then calls the tag service for the same tag, and without this check the
+// second write expired the row the first one had just created, leaving one
+// expired tag row per push (PROJQUAY-13201).
+//
+// Otherwise it expires the active tag and inserts a new row. Expiring first
+// avoids the NULL != NULL issue on the (repository_id, name, lifetime_end_ms)
+// unique index, and the probe-and-advance loop in expireActiveTag keeps
+// concurrent retargets from colliding on lifetime_end_ms.
 func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, manifestID int64, tag string) (int64, error) {
+	active, err := q.GetActiveTag(ctx, daldb.GetActiveTagParams{
+		RepositoryID: repoID,
+		Name:         tag,
+	})
+	switch {
+	case err == nil:
+		if active.ManifestID.Valid && active.ManifestID.Int64 == manifestID {
+			return active.ID, nil
+		}
+	case !errors.Is(err, sql.ErrNoRows):
+		return 0, fmt.Errorf("get active tag %q: %w", tag, err)
+	}
+
 	transitionMs, err := expireActiveTag(ctx, q, repoID, tag, time.Now().UnixMilli())
 	if err != nil {
 		return 0, fmt.Errorf("expire tag %q: %w", tag, err)

--- a/internal/dal/metastore/metastore_sqlite_test.go
+++ b/internal/dal/metastore/metastore_sqlite_test.go
@@ -353,6 +353,67 @@ func TestPutTag(t *testing.T) {
 	}
 }
 
+// TestPutManifest_TaggedPushThenPutTagSameManifest_NoExpiredRow covers the
+// distribution handler sequence for one tagged push: PutManifest with the tag,
+// then the tag service's PutTag for the same tag and digest. The second write
+// must not expire and re-create the row (PROJQUAY-13201).
+func TestPutManifest_TaggedPushThenPutTagSameManifest_NoExpiredRow(t *testing.T) {
+	store := setupStore(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dgst := digest.FromString("manifest-v1")
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":1}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	firstID := activeTagID(t, store.(*metastore.SQLiteStore), repoID, "latest")
+
+	secondID, err := store.PutTag(ctx, repoID, oci.TagRecord{Name: "latest", Digest: dgst})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondID != firstID {
+		t.Errorf("PutTag for the current manifest returned id %d, want the existing row %d", secondID, firstID)
+	}
+	assertTagRowCounts(t, store.(*metastore.SQLiteStore), repoID, "latest", 1, 0)
+
+	// A repeated PutManifest with the same tag and digest (a client re-push)
+	// must also leave the history untouched.
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":1}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertTagRowCounts(t, store.(*metastore.SQLiteStore), repoID, "latest", 1, 0)
+
+	// Retargeting the tag to a different manifest still records history.
+	dgst2 := digest.FromString("manifest-v2")
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst2,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":2}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertTagRowCounts(t, store.(*metastore.SQLiteStore), repoID, "latest", 1, 1)
+	if got := activeTagID(t, store.(*metastore.SQLiteStore), repoID, "latest"); got == firstID {
+		t.Errorf("retarget kept tag row %d active, want a new row", got)
+	}
+}
+
 func TestDeleteTag(t *testing.T) {
 	store := setupStore(t)
 	ctx := t.Context()
@@ -805,5 +866,36 @@ func assertProtectionTagCount(t *testing.T, s *metastore.SQLiteStore, manifestID
 	}
 	if count != 1 {
 		t.Errorf("non-expiring tags for manifest %d: got %d, want 1", manifestID, count)
+	}
+}
+
+// activeTagID returns the id of the single live tag row with the given name.
+func activeTagID(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string) int64 {
+	t.Helper()
+	var id int64
+	err := s.DB().QueryRowContext(context.Background(),
+		`SELECT id FROM tag WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL`,
+		repoID, tag).Scan(&id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// assertTagRowCounts checks how many live and expired rows a tag name has.
+func assertTagRowCounts(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string, wantLive, wantExpired int) {
+	t.Helper()
+	var live, expired int
+	err := s.DB().QueryRowContext(context.Background(),
+		`SELECT
+		    COALESCE(SUM(CASE WHEN lifetime_end_ms IS NULL THEN 1 ELSE 0 END), 0),
+		    COALESCE(SUM(CASE WHEN lifetime_end_ms IS NOT NULL THEN 1 ELSE 0 END), 0)
+		 FROM tag WHERE repository_id = ? AND name = ?`,
+		repoID, tag).Scan(&live, &expired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live != wantLive || expired != wantExpired {
+		t.Errorf("tag %q rows: got live=%d expired=%d, want live=%d expired=%d", tag, live, expired, wantLive, wantExpired)
 	}
 }

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -53,3 +53,13 @@ SELECT m.digest
 FROM tag t
 JOIN manifest m ON t.manifest_id = m.id
 WHERE t.repository_id = ? AND t.name = ? AND t.lifetime_end_ms IS NULL;
+
+-- name: GetActiveTag :one
+-- Returns the live (lifetime_end_ms IS NULL) tag row for a name. Callers use
+-- it to skip the expire-and-insert cycle when the tag already points at the
+-- manifest being written, so a repeated PUT does not leave an expired row.
+SELECT id, manifest_id, lifetime_start_ms
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY lifetime_start_ms DESC
+LIMIT 1;

--- a/internal/e2e/mirrorregistry/internal/e2etest/harness.go
+++ b/internal/e2e/mirrorregistry/internal/e2etest/harness.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -169,6 +170,31 @@ func (h *Harness) ExpireUploadProtection(ctx context.Context) error {
 		return fmt.Errorf("expire E2E uploaded blobs: %w", err)
 	}
 	return nil
+}
+
+// TagRows reports how many live and expired rows the tag history table holds
+// for one tag name in a repository ("namespace/name").
+func (h *Harness) TagRows(ctx context.Context, repository, tag string) (live, expired int, err error) {
+	if h == nil || h.gcDB == nil {
+		return 0, 0, fmt.Errorf("count tag rows with uninitialized E2E harness")
+	}
+	namespace, name, ok := strings.Cut(repository, "/")
+	if !ok {
+		return 0, 0, fmt.Errorf("repository %q must be namespace/name", repository)
+	}
+	err = h.gcDB.QueryRowContext(ctx, `
+		SELECT
+		    COALESCE(SUM(CASE WHEN t.lifetime_end_ms IS NULL THEN 1 ELSE 0 END), 0),
+		    COALESCE(SUM(CASE WHEN t.lifetime_end_ms IS NOT NULL THEN 1 ELSE 0 END), 0)
+		FROM tag t
+		JOIN repository r ON r.id = t.repository_id
+		JOIN "user" u ON u.id = r.namespace_user_id
+		WHERE u.username = ? AND r.name = ? AND t.name = ?`,
+		namespace, name, tag).Scan(&live, &expired)
+	if err != nil {
+		return 0, 0, fmt.Errorf("count E2E tag rows: %w", err)
+	}
+	return live, expired, nil
 }
 
 // BaseURL returns the HTTP URL of the in-process registry.

--- a/internal/e2e/mirrorregistry/registry_protocol_test.go
+++ b/internal/e2e/mirrorregistry/registry_protocol_test.go
@@ -207,3 +207,41 @@ func TestRegistryMonolithicBlobUpload(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, content, got)
 }
+
+// TestRegistryTaggedPushLeavesSingleTagRow verifies that one tagged manifest
+// PUT (manifest store write followed by the distribution tag-service write)
+// records exactly one live tag row and no expired history, and that a re-push
+// of the same content stays idempotent, while retargeting the tag to a new
+// manifest still records one expired row (PROJQUAY-13201).
+func TestRegistryTaggedPushLeavesSingleTagRow(t *testing.T) {
+	h := e2etest.New(t)
+	ctx := t.Context()
+	const repository = "admin/single-tag-row"
+
+	first := pushImage(t, h, repository, "latest", []byte(`{"arch":"amd64"}`), []byte("layer-one"))
+	live, expired, err := h.TagRows(ctx, repository, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, 1, live, "live tag rows after first push")
+	assert.Equal(t, 0, expired, "expired tag rows after first push")
+
+	// Re-push the identical tagged manifest.
+	response, err := h.Registry().PutManifest(ctx, repository, "latest", first.manifest, v1.MediaTypeImageManifest)
+	require.NoError(t, err)
+	assert.Equal(t, first.digest, response.Digest)
+	live, expired, err = h.TagRows(ctx, repository, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, 1, live, "live tag rows after re-push")
+	assert.Equal(t, 0, expired, "expired tag rows after re-push")
+
+	// Retarget the tag to a different manifest.
+	second := pushImage(t, h, repository, "latest", []byte(`{"arch":"arm64"}`), []byte("layer-two"))
+	require.NotEqual(t, first.digest, second.digest)
+	live, expired, err = h.TagRows(ctx, repository, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, 1, live, "live tag rows after retarget")
+	assert.Equal(t, 1, expired, "expired tag rows after retarget")
+
+	manifest, err := h.Registry().GetManifest(ctx, repository, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, second.manifest, manifest.Body)
+}


### PR DESCRIPTION
## Summary

- `putTag` now looks up the active tag first and returns its id unchanged when it already points at the manifest being written; only a real retarget expires the old row and inserts a new one
- Adds the `GetActiveTag` sqlc query
- Adds a metastore unit test for the PutManifest-then-PutTag sequence the distribution handler performs, a harness helper that counts live/expired tag rows, and an e2e test covering push, identical re-push, and retarget

## Context

Every tagged manifest PUT left two rows in `tag`: one expired 1–14 ms after creation and one live. The distribution manifest handler stores the manifest with its tag (`PutManifest` → `putTag`) and then calls the tag service (`PutTag` → `putTag`) for the same tag and digest. Since the expire-then-insert change in [PROJQUAY-12711](https://redhat.atlassian.net/browse/PROJQUAY-12711), the second call expired the row the first one had just written. A 1,000-tag push on the OMR performance VM left 7,563 tag rows for 3,173 live tags, and every phantom row is extra work for the expired-tag GC phase 14 days later. Quay's Python path writes the tag once through `create_manifest_and_retarget_tag` and only expires the previous tag when it points at a different manifest.

The [PROJQUAY-12711](https://redhat.atlassian.net/browse/PROJQUAY-12711) collision handling is untouched: a retarget still goes through `expireActiveTag`.

## Test plan

- [x] `go test ./internal/dal/metastore/ -count=1` (new `TestPutManifest_TaggedPushThenPutTagSameManifest_NoExpiredRow`)
- [x] `go test ./internal/e2e/mirrorregistry/ -count=1` (new `TestRegistryTaggedPushLeavesSingleTagRow`; existing `TestRegistryConcurrentSameTagPushes` still passes)
- [x] `go test ./internal/... -count=1`, `golangci-lint run ./internal/dal/... ./internal/e2e/...`
- [x] Manual, on the 2-vCPU OMR VM: before the fix one `skopeo copy` push produced `[('v1', expired), ('v1', live)]`; with the fixed binary one push produces a single live row, an identical re-push leaves it unchanged, and a retarget to a different image yields exactly one expired plus one live row; pulls unaffected, no 5xx
