### PR TITLE
PROJQUAY-13202: fix(omr): purge API-deleted repositories in the GC cycle

### DIFF
--- a/internal/dal/daldb/gc.sql.go
+++ b/internal/dal/daldb/gc.sql.go
@@ -43,6 +43,64 @@ func (q *Queries) CountManifestBlobRefs(ctx context.Context, blobID int64) (int6
 	return count, err
 }
 
+const countManifestsByRepository = `-- name: CountManifestsByRepository :one
+SELECT COUNT(*) FROM manifest WHERE repository_id = ?
+`
+
+func (q *Queries) CountManifestsByRepository(ctx context.Context, repositoryID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countManifestsByRepository, repositoryID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countTagsByRepository = `-- name: CountTagsByRepository :one
+SELECT COUNT(*) FROM tag WHERE repository_id = ?
+`
+
+func (q *Queries) CountTagsByRepository(ctx context.Context, repositoryID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countTagsByRepository, repositoryID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const deleteAccessTokensByRepository = `-- name: DeleteAccessTokensByRepository :exec
+DELETE FROM accesstoken WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteAccessTokensByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteAccessTokensByRepository, repositoryID)
+	return err
+}
+
+const deleteApprTagsByRepository = `-- name: DeleteApprTagsByRepository :exec
+DELETE FROM apprtag WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteApprTagsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteApprTagsByRepository, repositoryID)
+	return err
+}
+
+const deleteBlobUploadsByRepository = `-- name: DeleteBlobUploadsByRepository :exec
+DELETE FROM blobupload WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteBlobUploadsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteBlobUploadsByRepository, repositoryID)
+	return err
+}
+
+const deleteDeletedRepositoryMarkers = `-- name: DeleteDeletedRepositoryMarkers :exec
+DELETE FROM deletedrepository WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteDeletedRepositoryMarkers(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteDeletedRepositoryMarkers, repositoryID)
+	return err
+}
+
 const deleteExpiredTag = `-- name: DeleteExpiredTag :exec
 DELETE FROM tag WHERE id = ?
 `
@@ -70,6 +128,204 @@ func (q *Queries) DeleteImageStorageSignatures(ctx context.Context, storageID in
 	return err
 }
 
+const deleteManifestBlobsByRepository = `-- name: DeleteManifestBlobsByRepository :exec
+DELETE FROM manifestblob WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestBlobsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestBlobsByRepository, repositoryID)
+	return err
+}
+
+const deleteManifestChildrenByRepository = `-- name: DeleteManifestChildrenByRepository :exec
+DELETE FROM manifestchild WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestChildrenByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestChildrenByRepository, repositoryID)
+	return err
+}
+
+const deleteManifestLabelsByRepository = `-- name: DeleteManifestLabelsByRepository :exec
+DELETE FROM manifestlabel WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestLabelsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestLabelsByRepository, repositoryID)
+	return err
+}
+
+const deleteManifestPullStatisticsByRepository = `-- name: DeleteManifestPullStatisticsByRepository :exec
+DELETE FROM manifestpullstatistics WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestPullStatisticsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestPullStatisticsByRepository, repositoryID)
+	return err
+}
+
+const deleteManifestSecurityStatusByRepository = `-- name: DeleteManifestSecurityStatusByRepository :exec
+DELETE FROM manifestsecuritystatus WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestSecurityStatusByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestSecurityStatusByRepository, repositoryID)
+	return err
+}
+
+const deleteManifestsByRepository = `-- name: DeleteManifestsByRepository :exec
+DELETE FROM manifest WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteManifestsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteManifestsByRepository, repositoryID)
+	return err
+}
+
+const deleteOrgMirrorRepositoriesByRepository = `-- name: DeleteOrgMirrorRepositoriesByRepository :exec
+DELETE FROM orgmirrorrepository WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteOrgMirrorRepositoriesByRepository(ctx context.Context, repositoryID sql.NullInt64) error {
+	_, err := q.db.ExecContext(ctx, deleteOrgMirrorRepositoriesByRepository, repositoryID)
+	return err
+}
+
+const deleteQueueItem = `-- name: DeleteQueueItem :exec
+DELETE FROM queueitem WHERE id = ?
+`
+
+func (q *Queries) DeleteQueueItem(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, deleteQueueItem, id)
+	return err
+}
+
+const deleteQuotaRepositorySizesByRepository = `-- name: DeleteQuotaRepositorySizesByRepository :exec
+DELETE FROM quotarepositorysize WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteQuotaRepositorySizesByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteQuotaRepositorySizesByRepository, repositoryID)
+	return err
+}
+
+const deleteRepoMirrorConfigByRepository = `-- name: DeleteRepoMirrorConfigByRepository :exec
+DELETE FROM repomirrorconfig WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepoMirrorConfigByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepoMirrorConfigByRepository, repositoryID)
+	return err
+}
+
+const deleteRepoMirrorRulesByRepository = `-- name: DeleteRepoMirrorRulesByRepository :exec
+DELETE FROM repomirrorrule WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepoMirrorRulesByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepoMirrorRulesByRepository, repositoryID)
+	return err
+}
+
+const deleteRepository = `-- name: DeleteRepository :exec
+DELETE FROM repository WHERE id = ? AND state = 3
+`
+
+func (q *Queries) DeleteRepository(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepository, id)
+	return err
+}
+
+const deleteRepositoryActionCountsByRepository = `-- name: DeleteRepositoryActionCountsByRepository :exec
+DELETE FROM repositoryactioncount WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryActionCountsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryActionCountsByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryAuthorizedEmailsByRepository = `-- name: DeleteRepositoryAuthorizedEmailsByRepository :exec
+DELETE FROM repositoryauthorizedemail WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryAuthorizedEmailsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryAuthorizedEmailsByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryAutoPrunePoliciesByRepository = `-- name: DeleteRepositoryAutoPrunePoliciesByRepository :exec
+DELETE FROM repositoryautoprunepolicy WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryAutoPrunePoliciesByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryAutoPrunePoliciesByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryBuildTriggersByRepository = `-- name: DeleteRepositoryBuildTriggersByRepository :exec
+DELETE FROM repositorybuildtrigger WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryBuildTriggersByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryBuildTriggersByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryBuildsByRepository = `-- name: DeleteRepositoryBuildsByRepository :exec
+DELETE FROM repositorybuild WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryBuildsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryBuildsByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryImmutabilityPoliciesByRepository = `-- name: DeleteRepositoryImmutabilityPoliciesByRepository :exec
+DELETE FROM repositoryimmutabilitypolicy WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryImmutabilityPoliciesByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryImmutabilityPoliciesByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryNotificationsByRepository = `-- name: DeleteRepositoryNotificationsByRepository :exec
+DELETE FROM repositorynotification WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryNotificationsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryNotificationsByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositoryPermissionsByRepository = `-- name: DeleteRepositoryPermissionsByRepository :exec
+DELETE FROM repositorypermission WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositoryPermissionsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositoryPermissionsByRepository, repositoryID)
+	return err
+}
+
+const deleteRepositorySearchScoresByRepository = `-- name: DeleteRepositorySearchScoresByRepository :exec
+DELETE FROM repositorysearchscore WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteRepositorySearchScoresByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteRepositorySearchScoresByRepository, repositoryID)
+	return err
+}
+
+const deleteStarsByRepositoryForPurge = `-- name: DeleteStarsByRepositoryForPurge :exec
+DELETE FROM star WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteStarsByRepositoryForPurge(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteStarsByRepositoryForPurge, repositoryID)
+	return err
+}
+
 const deleteTagNotifications = `-- name: DeleteTagNotifications :exec
 DELETE FROM tagnotificationsuccess WHERE tag_id = ?
 `
@@ -79,12 +335,49 @@ func (q *Queries) DeleteTagNotifications(ctx context.Context, tagID int64) error
 	return err
 }
 
+const deleteTagNotificationsByRepository = `-- name: DeleteTagNotificationsByRepository :exec
+DELETE FROM tagnotificationsuccess
+WHERE tag_id IN (SELECT id FROM tag WHERE repository_id = ?)
+`
+
+func (q *Queries) DeleteTagNotificationsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteTagNotificationsByRepository, repositoryID)
+	return err
+}
+
+const deleteTagPullStatisticsByRepository = `-- name: DeleteTagPullStatisticsByRepository :exec
+DELETE FROM tagpullstatistics WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteTagPullStatisticsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteTagPullStatisticsByRepository, repositoryID)
+	return err
+}
+
+const deleteTagsByRepository = `-- name: DeleteTagsByRepository :exec
+DELETE FROM tag WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteTagsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteTagsByRepository, repositoryID)
+	return err
+}
+
 const deleteUploadedBlobsByBlobID = `-- name: DeleteUploadedBlobsByBlobID :exec
 DELETE FROM uploadedblob WHERE blob_id = ?
 `
 
 func (q *Queries) DeleteUploadedBlobsByBlobID(ctx context.Context, blobID int64) error {
 	_, err := q.db.ExecContext(ctx, deleteUploadedBlobsByBlobID, blobID)
+	return err
+}
+
+const deleteUploadedBlobsByRepository = `-- name: DeleteUploadedBlobsByRepository :exec
+DELETE FROM uploadedblob WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteUploadedBlobsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteUploadedBlobsByRepository, repositoryID)
 	return err
 }
 
@@ -124,6 +417,50 @@ func (q *Queries) FindExpiredTags(ctx context.Context) ([]FindExpiredTagsRow, er
 			&i.RepositoryID,
 			&i.ManifestID,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findMarkedRepositories = `-- name: FindMarkedRepositories :many
+
+SELECT r.id, d.id AS marker_id, d.queue_id
+FROM repository r
+LEFT JOIN deletedrepository d ON d.repository_id = r.id
+WHERE r.state = 3
+ORDER BY r.id
+`
+
+type FindMarkedRepositoriesRow struct {
+	ID       int64          `json:"id"`
+	MarkerID sql.NullInt64  `json:"marker_id"`
+	QueueID  sql.NullString `json:"queue_id"`
+}
+
+// Repository purge (PROJQUAY-13202). The repository API marks a repository as
+// deleted (state = 3, renamed to a UUID, deletedrepository marker plus a
+// queueitem) exactly like Quay's mark_repository_for_deletion. Quay drains
+// that queue with repositorygcworker; the mirror registry purges marked
+// repositories inside its GC cycle instead. Deletes run child tables first so
+// SQLite foreign keys (PRAGMA foreign_keys=1) are satisfied.
+func (q *Queries) FindMarkedRepositories(ctx context.Context) ([]FindMarkedRepositoriesRow, error) {
+	rows, err := q.db.QueryContext(ctx, findMarkedRepositories)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindMarkedRepositoriesRow
+	for rows.Next() {
+		var i FindMarkedRepositoriesRow
+		if err := rows.Scan(&i.ID, &i.MarkerID, &i.QueueID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/dal/queries/gc.sql
+++ b/internal/dal/queries/gc.sql
@@ -79,3 +79,114 @@ SELECT COUNT(*) FROM uploadedblob WHERE blob_id = ? AND expires_at > datetime('n
 
 -- name: CountBlobsByChecksum :one
 SELECT COUNT(*) FROM imagestorage WHERE content_checksum = ?;
+
+-- Repository purge (PROJQUAY-13202). The repository API marks a repository as
+-- deleted (state = 3, renamed to a UUID, deletedrepository marker plus a
+-- queueitem) exactly like Quay's mark_repository_for_deletion. Quay drains
+-- that queue with repositorygcworker; the mirror registry purges marked
+-- repositories inside its GC cycle instead. Deletes run child tables first so
+-- SQLite foreign keys (PRAGMA foreign_keys=1) are satisfied.
+
+-- name: FindMarkedRepositories :many
+SELECT r.id, d.id AS marker_id, d.queue_id
+FROM repository r
+LEFT JOIN deletedrepository d ON d.repository_id = r.id
+WHERE r.state = 3
+ORDER BY r.id;
+
+-- name: CountManifestsByRepository :one
+SELECT COUNT(*) FROM manifest WHERE repository_id = ?;
+
+-- name: CountTagsByRepository :one
+SELECT COUNT(*) FROM tag WHERE repository_id = ?;
+
+-- name: DeleteTagNotificationsByRepository :exec
+DELETE FROM tagnotificationsuccess
+WHERE tag_id IN (SELECT id FROM tag WHERE repository_id = ?);
+
+-- name: DeleteTagsByRepository :exec
+DELETE FROM tag WHERE repository_id = ?;
+
+-- name: DeleteManifestLabelsByRepository :exec
+DELETE FROM manifestlabel WHERE repository_id = ?;
+
+-- name: DeleteManifestChildrenByRepository :exec
+DELETE FROM manifestchild WHERE repository_id = ?;
+
+-- name: DeleteManifestBlobsByRepository :exec
+DELETE FROM manifestblob WHERE repository_id = ?;
+
+-- name: DeleteManifestSecurityStatusByRepository :exec
+DELETE FROM manifestsecuritystatus WHERE repository_id = ?;
+
+-- name: DeleteManifestPullStatisticsByRepository :exec
+DELETE FROM manifestpullstatistics WHERE repository_id = ?;
+
+-- name: DeleteTagPullStatisticsByRepository :exec
+DELETE FROM tagpullstatistics WHERE repository_id = ?;
+
+-- name: DeleteManifestsByRepository :exec
+DELETE FROM manifest WHERE repository_id = ?;
+
+-- name: DeleteUploadedBlobsByRepository :exec
+DELETE FROM uploadedblob WHERE repository_id = ?;
+
+-- name: DeleteBlobUploadsByRepository :exec
+DELETE FROM blobupload WHERE repository_id = ?;
+
+-- name: DeleteRepositoryBuildsByRepository :exec
+DELETE FROM repositorybuild WHERE repository_id = ?;
+
+-- name: DeleteRepositoryBuildTriggersByRepository :exec
+DELETE FROM repositorybuildtrigger WHERE repository_id = ?;
+
+-- name: DeleteAccessTokensByRepository :exec
+DELETE FROM accesstoken WHERE repository_id = ?;
+
+-- name: DeleteRepoMirrorConfigByRepository :exec
+DELETE FROM repomirrorconfig WHERE repository_id = ?;
+
+-- name: DeleteRepoMirrorRulesByRepository :exec
+DELETE FROM repomirrorrule WHERE repository_id = ?;
+
+-- name: DeleteOrgMirrorRepositoriesByRepository :exec
+DELETE FROM orgmirrorrepository WHERE repository_id = ?;
+
+-- name: DeleteApprTagsByRepository :exec
+DELETE FROM apprtag WHERE repository_id = ?;
+
+-- name: DeleteRepositoryPermissionsByRepository :exec
+DELETE FROM repositorypermission WHERE repository_id = ?;
+
+-- name: DeleteRepositoryNotificationsByRepository :exec
+DELETE FROM repositorynotification WHERE repository_id = ?;
+
+-- name: DeleteRepositoryActionCountsByRepository :exec
+DELETE FROM repositoryactioncount WHERE repository_id = ?;
+
+-- name: DeleteRepositoryAuthorizedEmailsByRepository :exec
+DELETE FROM repositoryauthorizedemail WHERE repository_id = ?;
+
+-- name: DeleteRepositoryAutoPrunePoliciesByRepository :exec
+DELETE FROM repositoryautoprunepolicy WHERE repository_id = ?;
+
+-- name: DeleteRepositoryImmutabilityPoliciesByRepository :exec
+DELETE FROM repositoryimmutabilitypolicy WHERE repository_id = ?;
+
+-- name: DeleteRepositorySearchScoresByRepository :exec
+DELETE FROM repositorysearchscore WHERE repository_id = ?;
+
+-- name: DeleteQuotaRepositorySizesByRepository :exec
+DELETE FROM quotarepositorysize WHERE repository_id = ?;
+
+-- name: DeleteStarsByRepositoryForPurge :exec
+DELETE FROM star WHERE repository_id = ?;
+
+-- name: DeleteDeletedRepositoryMarkers :exec
+DELETE FROM deletedrepository WHERE repository_id = ?;
+
+-- name: DeleteQueueItem :exec
+DELETE FROM queueitem WHERE id = ?;
+
+-- name: DeleteRepository :exec
+DELETE FROM repository WHERE id = ? AND state = 3;

--- a/internal/e2e/mirrorregistry/internal/e2etest/harness.go
+++ b/internal/e2e/mirrorregistry/internal/e2etest/harness.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -169,6 +170,61 @@ func (h *Harness) ExpireUploadProtection(ctx context.Context) error {
 		return fmt.Errorf("expire E2E uploaded blobs: %w", err)
 	}
 	return nil
+}
+
+// RepositoryRows reports how many repository, tag, manifest and manifestblob
+// rows still exist for a repository id, so tests can verify a purge.
+func (h *Harness) RepositoryRows(ctx context.Context, repositoryID int64) (repositories, tags, manifests, blobLinks int, err error) {
+	if h == nil || h.gcDB == nil {
+		return 0, 0, 0, 0, fmt.Errorf("count repository rows with uninitialized E2E harness")
+	}
+	err = h.gcDB.QueryRowContext(ctx, `
+		SELECT
+		    (SELECT count(*) FROM repository WHERE id = ?1),
+		    (SELECT count(*) FROM tag WHERE repository_id = ?1),
+		    (SELECT count(*) FROM manifest WHERE repository_id = ?1),
+		    (SELECT count(*) FROM manifestblob WHERE repository_id = ?1)`,
+		repositoryID).Scan(&repositories, &tags, &manifests, &blobLinks)
+	if err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("count E2E repository rows: %w", err)
+	}
+	return repositories, tags, manifests, blobLinks, nil
+}
+
+// RepositoryID looks up the id of "namespace/name".
+func (h *Harness) RepositoryID(ctx context.Context, repository string) (int64, error) {
+	if h == nil || h.gcDB == nil {
+		return 0, fmt.Errorf("look up repository with uninitialized E2E harness")
+	}
+	namespace, name, ok := strings.Cut(repository, "/")
+	if !ok {
+		return 0, fmt.Errorf("repository %q must be namespace/name", repository)
+	}
+	var id int64
+	err := h.gcDB.QueryRowContext(ctx, `
+		SELECT r.id FROM repository r
+		JOIN "user" u ON u.id = r.namespace_user_id
+		WHERE u.username = ? AND r.name = ?`, namespace, name).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("look up E2E repository %q: %w", repository, err)
+	}
+	return id, nil
+}
+
+// DeletionMarkers counts deletedrepository markers and repository-GC queue
+// items, which the purge must remove along with the repository.
+func (h *Harness) DeletionMarkers(ctx context.Context) (markers, queueItems int, err error) {
+	if h == nil || h.gcDB == nil {
+		return 0, 0, fmt.Errorf("count deletion markers with uninitialized E2E harness")
+	}
+	err = h.gcDB.QueryRowContext(ctx, `
+		SELECT
+		    (SELECT count(*) FROM deletedrepository),
+		    (SELECT count(*) FROM queueitem WHERE queue_name LIKE 'repositorygc/%')`).Scan(&markers, &queueItems)
+	if err != nil {
+		return 0, 0, fmt.Errorf("count E2E deletion markers: %w", err)
+	}
+	return markers, queueItems, nil
 }
 
 // BaseURL returns the HTTP URL of the in-process registry.

--- a/internal/e2e/mirrorregistry/internal/e2etest/registry.go
+++ b/internal/e2e/mirrorregistry/internal/e2etest/registry.go
@@ -634,6 +634,29 @@ func (c *RegistryClient) getReferrers(ctx context.Context, repository string, su
 	return response, nil
 }
 
+// DeleteRepository calls the repository API (DELETE /api/v1/repository/<name>)
+// with the client's Basic credentials, as the CLI and UI do, and returns nil
+// on 204.
+func (c *RegistryClient) DeleteRepository(ctx context.Context, repository string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/v1/repository/"+repository, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(c.username, c.password)
+	resp, err := c.client.Do(req) //nolint:bodyclose // readBody closes every response body
+	if err != nil {
+		return err
+	}
+	body, err := readBody(resp)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return responseError(resp, body)
+	}
+	return nil
+}
+
 // DeleteManifest deletes a manifest by digest.
 func (c *RegistryClient) DeleteManifest(ctx context.Context, repository string, dgst digest.Digest) error {
 	token, err := c.token(ctx, repository, "pull", "push")

--- a/internal/e2e/mirrorregistry/registry_test.go
+++ b/internal/e2e/mirrorregistry/registry_test.go
@@ -519,3 +519,77 @@ func assertBlobMissing(t *testing.T, h *e2etest.Harness, repository string, dgst
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
+
+// TestRegistryDeleteRepositoryPurgesAndReclaimsStorage covers
+// PROJQUAY-13202: DELETE /api/v1/repository/<name> only marks a repository
+// deleted; the GC cycle must then purge its rows and reclaim blobs that no
+// other repository references, while a shared blob survives.
+func TestRegistryDeleteRepositoryPurgesAndReclaimsStorage(t *testing.T) {
+	h := e2etest.New(t)
+	ctx := t.Context()
+	const doomed = "admin/doomed"
+	const survivor = "admin/survivor"
+
+	sharedLayer := []byte("layer-shared-between-repositories")
+	image := pushImage(t, h, doomed, "latest", []byte(`{"arch":"amd64"}`), sharedLayer)
+	privateLayer := []byte("layer-only-in-doomed")
+	private := pushImage(t, h, doomed, "extra", []byte(`{"arch":"arm64"}`), privateLayer)
+	pushImage(t, h, survivor, "latest", []byte(`{"arch":"s390x"}`), sharedLayer)
+
+	doomedID, err := h.RepositoryID(ctx, doomed)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Registry().DeleteRepository(ctx, doomed))
+
+	// The repository is hidden immediately but nothing is purged until GC.
+	_, err = h.Registry().GetManifest(ctx, doomed, "latest")
+	require.Error(t, err)
+	repositories, tags, manifests, blobLinks, err := h.RepositoryRows(ctx, doomedID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, repositories)
+	// Two live tags; tag history may hold more rows than that.
+	assert.GreaterOrEqual(t, tags, 2)
+	assert.Equal(t, 2, manifests)
+	assert.Equal(t, 4, blobLinks)
+	markers, queueItems, err := h.DeletionMarkers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, markers)
+	assert.Equal(t, 1, queueItems)
+
+	stats, err := h.CollectGarbage(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.RepositoriesPurged)
+	assert.Equal(t, tags, stats.TagsExpired, "every tag row of the repository is removed")
+	assert.Equal(t, 2, stats.ManifestsDeleted)
+	// Blobs only the deleted repository used are reclaimed in the same cycle
+	// (its upload markers go with it); the shared layer stays.
+	assert.Equal(t, 3, stats.BlobsDeleted, "two configs and the private layer")
+	assert.Equal(t, int64(len(`{"arch":"amd64"}`)+len(`{"arch":"arm64"}`)+len(privateLayer)), stats.BytesReclaimed)
+
+	repositories, tags, manifests, blobLinks, err = h.RepositoryRows(ctx, doomedID)
+	require.NoError(t, err)
+	assert.Zero(t, repositories)
+	assert.Zero(t, tags)
+	assert.Zero(t, manifests)
+	assert.Zero(t, blobLinks)
+	markers, queueItems, err = h.DeletionMarkers(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, markers)
+	assert.Zero(t, queueItems)
+
+	// The survivor still serves the shared layer; the private layer is gone.
+	_, err = h.Registry().GetBlob(ctx, survivor, image.layer)
+	require.NoError(t, err)
+	_, err = h.Registry().GetBlob(ctx, survivor, private.layer)
+	require.Error(t, err)
+
+	// A second cycle is a no-op, and the name can be reused for a fresh push.
+	stats, err = h.CollectGarbage(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, stats.RepositoriesPurged)
+	assert.Zero(t, stats.BlobsDeleted)
+	fresh := pushImage(t, h, doomed, "latest", []byte(`{"arch":"ppc64le"}`), []byte("layer-after-recreate"))
+	manifest, err := h.Registry().GetManifest(ctx, doomed, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, fresh.manifest, manifest.Body)
+}

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -19,8 +19,12 @@ type Collector interface {
 
 // Stats summarizes a single GC cycle.
 type Stats struct {
-	TagsExpired      int
-	ManifestsDeleted int
+	// RepositoriesPurged counts API-deleted repositories whose rows were
+	// removed this cycle; their tags and manifests are included in
+	// TagsExpired and ManifestsDeleted.
+	RepositoriesPurged int
+	TagsExpired        int
+	ManifestsDeleted   int
 	// BlobsDeleted counts imagestorage metadata rows actually deleted.
 	BlobsDeleted        int
 	StaleUploadsRemoved int

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -1431,4 +1433,219 @@ func getManifestID(t *testing.T, env *testEnv, repoID int64, dgst digest.Digest)
 func ctx(t *testing.T) context.Context {
 	t.Helper()
 	return t.Context()
+}
+
+// markRepositoryDeleted soft-deletes a repository the way the repository API
+// does: rename to a UUID, state = 3, deletedrepository marker, queue item.
+func markRepositoryDeleted(t *testing.T, env *testEnv, repoID int64, originalName string) (markerID, queueID int64) {
+	t.Helper()
+	ctx := t.Context()
+	res, err := env.q.MarkRepositoryDeleted(ctx, daldb.MarkRepositoryDeletedParams{
+		DeletedName:  "deleted-" + originalName,
+		RepositoryID: repoID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := res.RowsAffected(); n != 1 {
+		t.Fatalf("mark repository %d deleted: %d rows affected", repoID, n)
+	}
+	markerID, err = env.q.InsertDeletedRepository(ctx, daldb.InsertDeletedRepositoryParams{
+		RepositoryID: repoID,
+		OriginalName: originalName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	queueID, err = env.q.InsertRepositoryGCQueueItem(ctx, daldb.InsertRepositoryGCQueueItemParams{
+		QueueName:        fmt.Sprintf("repositorygc/library/%d/", repoID),
+		Body:             fmt.Sprintf(`{"marker_id":%d,"original_name":%q}`, markerID, originalName),
+		Available:        true,
+		RetriesRemaining: 5,
+		StateID:          fmt.Sprintf("state-%d", repoID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.q.UpdateDeletedRepositoryQueueID(ctx, daldb.UpdateDeletedRepositoryQueueIDParams{
+		QueueID: sql.NullString{String: strconv.FormatInt(queueID, 10), Valid: true},
+		ID:      markerID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return markerID, queueID
+}
+
+func countRows(t *testing.T, env *testEnv, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := env.db.QueryRowContext(t.Context(), query, args...).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// putBlob stores content in blob storage and metadata, returning the blob id.
+func putBlob(t *testing.T, env *testEnv, content []byte) (int64, digest.Digest) {
+	t.Helper()
+	dgst := digest.FromBytes(content)
+	if err := env.blobs.PutContent(t.Context(), dgst, content); err != nil {
+		t.Fatal(err)
+	}
+	id, err := env.store.PutBlob(t.Context(), oci.BlobRecord{Digest: dgst, Size: int64(len(content))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id, dgst
+}
+
+// TestCollect_PurgesMarkedRepository covers PROJQUAY-13202: a repository the
+// API soft-deleted must have its tags, manifests, links, marker and queue
+// item removed by the next GC cycle, and its blobs reclaimed once their
+// upload protection lapses.
+func TestCollect_PurgesMarkedRepository(t *testing.T) {
+	env := setup(t)
+	ctx := t.Context()
+
+	repoID := ensureRepo(t, env, "library", "doomed")
+	dgst := mustDigest("doomed-manifest")
+	manifestID := insertManifest(t, env, repoID, dgst)
+	insertTag(t, env, repoID, "v1", dgst)
+	insertTag(t, env, repoID, "v2", dgst)
+	blobID, blobDigest := putBlob(t, env, []byte("doomed-layer"))
+	linkBlobToManifest(t, env, repoID, manifestID, blobID)
+	// A real push also records a one-hour upload marker for the repository.
+	if err := env.q.InsertUploadedBlob(ctx, daldb.InsertUploadedBlobParams{RepositoryID: repoID, BlobID: blobID}); err != nil {
+		t.Fatal(err)
+	}
+	markerID, queueID := markRepositoryDeleted(t, env, repoID, "doomed")
+
+	// Before the fix a cycle left every row behind. The purge removes the
+	// repository's upload marker too, so the now-unreferenced blob is
+	// reclaimed by the orphaned-blob phase of the same cycle.
+	stats, err := env.collector.Collect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.RepositoriesPurged != 1 {
+		t.Fatalf("expected 1 purged repository, got %d", stats.RepositoriesPurged)
+	}
+	if stats.TagsExpired != 2 {
+		t.Fatalf("expected 2 tags removed with the repository, got %d", stats.TagsExpired)
+	}
+	if stats.ManifestsDeleted != 1 {
+		t.Fatalf("expected 1 manifest removed with the repository, got %d", stats.ManifestsDeleted)
+	}
+	if stats.BlobsDeleted != 1 {
+		t.Fatalf("expected the orphaned blob to be reclaimed, got %d deleted", stats.BlobsDeleted)
+	}
+	if _, err := env.blobs.Stat(ctx, blobDigest); err == nil {
+		t.Fatal("expected blob storage file to be deleted")
+	}
+
+	for _, check := range []struct {
+		what  string
+		query string
+		args  []any
+	}{
+		{"repository", `SELECT count(*) FROM repository WHERE id = ?`, []any{repoID}},
+		{"tag", `SELECT count(*) FROM tag WHERE repository_id = ?`, []any{repoID}},
+		{"manifest", `SELECT count(*) FROM manifest WHERE repository_id = ?`, []any{repoID}},
+		{"manifestblob", `SELECT count(*) FROM manifestblob WHERE repository_id = ?`, []any{repoID}},
+		{"uploadedblob", `SELECT count(*) FROM uploadedblob WHERE repository_id = ?`, []any{repoID}},
+		{"deletedrepository", `SELECT count(*) FROM deletedrepository WHERE id = ?`, []any{markerID}},
+		{"queueitem", `SELECT count(*) FROM queueitem WHERE id = ?`, []any{queueID}},
+	} {
+		if n := countRows(t, env, check.query, check.args...); n != 0 {
+			t.Errorf("%s rows left after purge: %d", check.what, n)
+		}
+	}
+
+	// A second cycle finds nothing to do.
+	stats, err = env.collector.Collect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats != (gc.Stats{}) {
+		t.Fatalf("second cycle should be a no-op, got %+v", stats)
+	}
+}
+
+// TestCollect_PurgeKeepsBlobsSharedWithLiveRepository verifies that purging
+// a deleted repository never reclaims a blob still referenced elsewhere and
+// never touches the surviving repository's rows.
+func TestCollect_PurgeKeepsBlobsSharedWithLiveRepository(t *testing.T) {
+	env := setup(t)
+	ctx := t.Context()
+
+	blobID, blobDigest := putBlob(t, env, []byte("shared-layer"))
+
+	liveRepo := ensureRepo(t, env, "library", "keep")
+	liveDigest := mustDigest("keep-manifest")
+	liveManifest := insertManifest(t, env, liveRepo, liveDigest)
+	insertTag(t, env, liveRepo, "latest", liveDigest)
+	linkBlobToManifest(t, env, liveRepo, liveManifest, blobID)
+
+	doomedRepo := ensureRepo(t, env, "library", "doomed")
+	doomedDigest := mustDigest("doomed-manifest")
+	doomedManifest := insertManifest(t, env, doomedRepo, doomedDigest)
+	insertTag(t, env, doomedRepo, "latest", doomedDigest)
+	linkBlobToManifest(t, env, doomedRepo, doomedManifest, blobID)
+	markRepositoryDeleted(t, env, doomedRepo, "doomed")
+
+	if _, err := env.db.ExecContext(ctx, `UPDATE uploadedblob SET expires_at = datetime('now', '-1 second')`); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := env.collector.Collect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.RepositoriesPurged != 1 {
+		t.Fatalf("expected 1 purged repository, got %d", stats.RepositoriesPurged)
+	}
+	if stats.BlobsDeleted != 0 {
+		t.Fatalf("shared blob must survive while the live repository references it, got %d deleted", stats.BlobsDeleted)
+	}
+	if _, err := env.blobs.Stat(ctx, blobDigest); err != nil {
+		t.Fatalf("shared blob storage file missing: %v", err)
+	}
+	if n := countRows(t, env, `SELECT count(*) FROM repository WHERE id = ?`, doomedRepo); n != 0 {
+		t.Errorf("deleted repository row still present")
+	}
+	if n := countRows(t, env, `SELECT count(*) FROM tag WHERE repository_id = ? AND lifetime_end_ms IS NULL`, liveRepo); n != 1 {
+		t.Errorf("live repository lost its tag: %d live tags", n)
+	}
+	if n := countRows(t, env, `SELECT count(*) FROM manifestblob WHERE repository_id = ?`, liveRepo); n != 1 {
+		t.Errorf("live repository lost its blob link: %d rows", n)
+	}
+}
+
+// TestCollect_ActiveRepositoryIsNeverPurged guards the state = 3 condition:
+// a repository that merely has a stale deletedrepository marker but is still
+// active must not be touched.
+func TestCollect_ActiveRepositoryIsNeverPurged(t *testing.T) {
+	env := setup(t)
+	ctx := t.Context()
+
+	repoID := ensureRepo(t, env, "library", "active")
+	dgst := mustDigest("active-manifest")
+	insertManifest(t, env, repoID, dgst)
+	insertTag(t, env, repoID, "latest", dgst)
+	if _, err := env.q.InsertDeletedRepository(ctx, daldb.InsertDeletedRepositoryParams{
+		RepositoryID: repoID,
+		OriginalName: "active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := env.collector.Collect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.RepositoriesPurged != 0 {
+		t.Fatalf("active repository was purged: %+v", stats)
+	}
+	if n := countRows(t, env, `SELECT count(*) FROM tag WHERE repository_id = ?`, repoID); n != 1 {
+		t.Errorf("active repository lost tags: %d rows", n)
+	}
 }

--- a/internal/gc/sqlite_collector.go
+++ b/internal/gc/sqlite_collector.go
@@ -13,7 +13,9 @@ import (
 
 const staleUploadThreshold = 48 * time.Hour
 
-// Collector runs the four-phase GC algorithm. It depends on a Store for
+// Collector runs the GC algorithm: upload-marker cleanup, purge of
+// API-deleted repositories, tag expiry, orphaned manifests, orphaned blobs,
+// and stale uploads. It depends on a Store for
 // metadata operations and a BlobStore for storage file deletion. It has no
 // knowledge of SQL, transactions, or FK relationships — the Store handles
 // all of that.
@@ -39,19 +41,30 @@ func (c *collector) Collect(ctx context.Context) (Stats, error) {
 		return total, fmt.Errorf("gc: clean expired uploaded blobs: %w", err)
 	}
 
+	// Phase 0b: Purge repositories the API marked for deletion. Their tags,
+	// manifests and links go away here; their blobs fall through to Phase 3
+	// once nothing else references them (PROJQUAY-13202).
+	purged, err := c.purgeMarkedRepositories(ctx)
+	if err != nil {
+		return total, fmt.Errorf("gc: purge repositories: %w", err)
+	}
+	total.RepositoriesPurged = purged.repositories
+	total.TagsExpired += purged.tags
+	total.ManifestsDeleted += purged.manifests
+
 	// Phase 1: Expire tags past their grace period.
 	expired, err := c.expireTags(ctx)
 	if err != nil {
 		return total, fmt.Errorf("gc: expire tags: %w", err)
 	}
-	total.TagsExpired = expired
+	total.TagsExpired += expired
 
 	// Phase 2: Collect orphaned manifests (globally, iterative for cascades).
 	manifests, err := c.collectManifests(ctx)
 	if err != nil {
 		return total, fmt.Errorf("gc: collect manifests: %w", err)
 	}
-	total.ManifestsDeleted = manifests
+	total.ManifestsDeleted += manifests
 
 	// Phase 3: Collect orphaned blobs and delete storage files.
 	blobCount, blobBytes, err := c.collectBlobs(ctx)
@@ -73,6 +86,38 @@ func (c *collector) Collect(ctx context.Context) (Stats, error) {
 	}
 
 	return total, nil
+}
+
+type purgeTotals struct {
+	repositories int
+	tags         int
+	manifests    int
+}
+
+// purgeMarkedRepositories deletes every repository the API soft-deleted.
+// Each repository is purged in its own transaction; a failure stops the
+// phase and the remaining repositories are retried on the next cycle.
+func (c *collector) purgeMarkedRepositories(ctx context.Context) (purgeTotals, error) {
+	var totals purgeTotals
+	repos, err := c.store.FindMarkedRepositories(ctx)
+	if err != nil {
+		return totals, err
+	}
+	for _, repo := range repos {
+		purge, err := c.store.PurgeRepository(ctx, repo)
+		if err != nil {
+			return totals, fmt.Errorf("purge repository %d: %w", repo.ID, err)
+		}
+		totals.repositories++
+		totals.tags += purge.TagsDeleted
+		totals.manifests += purge.ManifestsDeleted
+		c.log.Info("gc: purged deleted repository",
+			"repo_id", repo.ID,
+			"tags_deleted", purge.TagsDeleted,
+			"manifests_deleted", purge.ManifestsDeleted,
+		)
+	}
+	return totals, nil
 }
 
 func (c *collector) expireTags(ctx context.Context) (int, error) {

--- a/internal/gc/sqlite_store.go
+++ b/internal/gc/sqlite_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/quay/quay/internal/dal/daldb"
 )
@@ -23,6 +24,109 @@ func NewSQLiteStore(db *sql.DB) *SQLiteStore {
 // CleanExpiredUploadedBlobs removes uploadedblob rows past their expiry.
 func (s *SQLiteStore) CleanExpiredUploadedBlobs(ctx context.Context) error {
 	return daldb.New(s.db).CleanExpiredUploadedBlobs(ctx)
+}
+
+// FindMarkedRepositories returns repositories in the deleted state.
+func (s *SQLiteStore) FindMarkedRepositories(ctx context.Context) ([]MarkedRepository, error) {
+	rows, err := daldb.New(s.db).FindMarkedRepositories(ctx)
+	if err != nil {
+		return nil, err
+	}
+	repos := make([]MarkedRepository, 0, len(rows))
+	for _, r := range rows {
+		repo := MarkedRepository{ID: r.ID}
+		if r.MarkerID.Valid {
+			repo.MarkerID = r.MarkerID.Int64
+		}
+		if r.QueueID.Valid {
+			if id, err := strconv.ParseInt(r.QueueID.String, 10, 64); err == nil {
+				repo.QueueID = id
+			}
+		}
+		repos = append(repos, repo)
+	}
+	return repos, nil
+}
+
+// PurgeRepository removes all rows owned by a marked repository. The order
+// follows Python's purge_repository: tag and manifest dependants first, then
+// the manifests, then every table with a repository foreign key, then the
+// deletion marker, its queue item, and the repository itself. The repository
+// row is only removed while still in state 3 so an active repository can
+// never be dropped by mistake.
+func (s *SQLiteStore) PurgeRepository(ctx context.Context, repo MarkedRepository) (RepositoryPurge, error) {
+	var purge RepositoryPurge
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return purge, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	q := daldb.New(tx)
+
+	tags, err := q.CountTagsByRepository(ctx, repo.ID)
+	if err != nil {
+		return purge, fmt.Errorf("count tags: %w", err)
+	}
+	manifests, err := q.CountManifestsByRepository(ctx, repo.ID)
+	if err != nil {
+		return purge, fmt.Errorf("count manifests: %w", err)
+	}
+
+	steps := []struct {
+		name string
+		fn   func(context.Context, int64) error
+	}{
+		{"tag notifications", q.DeleteTagNotificationsByRepository},
+		{"tags", q.DeleteTagsByRepository},
+		{"manifest labels", q.DeleteManifestLabelsByRepository},
+		{"manifest children", q.DeleteManifestChildrenByRepository},
+		{"manifest blobs", q.DeleteManifestBlobsByRepository},
+		{"manifest security status", q.DeleteManifestSecurityStatusByRepository},
+		{"manifest pull statistics", q.DeleteManifestPullStatisticsByRepository},
+		{"tag pull statistics", q.DeleteTagPullStatisticsByRepository},
+		{"manifests", q.DeleteManifestsByRepository},
+		{"uploaded blobs", q.DeleteUploadedBlobsByRepository},
+		{"blob uploads", q.DeleteBlobUploadsByRepository},
+		{"builds", q.DeleteRepositoryBuildsByRepository},
+		{"build triggers", q.DeleteRepositoryBuildTriggersByRepository},
+		{"access tokens", q.DeleteAccessTokensByRepository},
+		{"mirror config", q.DeleteRepoMirrorConfigByRepository},
+		{"mirror rules", q.DeleteRepoMirrorRulesByRepository},
+		{"org mirror repositories", func(ctx context.Context, id int64) error {
+			return q.DeleteOrgMirrorRepositoriesByRepository(ctx, sql.NullInt64{Int64: id, Valid: true})
+		}},
+		{"appr tags", q.DeleteApprTagsByRepository},
+		{"permissions", q.DeleteRepositoryPermissionsByRepository},
+		{"notifications", q.DeleteRepositoryNotificationsByRepository},
+		{"action counts", q.DeleteRepositoryActionCountsByRepository},
+		{"authorized emails", q.DeleteRepositoryAuthorizedEmailsByRepository},
+		{"auto-prune policies", q.DeleteRepositoryAutoPrunePoliciesByRepository},
+		{"immutability policies", q.DeleteRepositoryImmutabilityPoliciesByRepository},
+		{"search scores", q.DeleteRepositorySearchScoresByRepository},
+		{"quota sizes", q.DeleteQuotaRepositorySizesByRepository},
+		{"stars", q.DeleteStarsByRepositoryForPurge},
+		{"deletion markers", q.DeleteDeletedRepositoryMarkers},
+	}
+	for _, step := range steps {
+		if err := step.fn(ctx, repo.ID); err != nil {
+			return purge, fmt.Errorf("delete %s for repository %d: %w", step.name, repo.ID, err)
+		}
+	}
+	if repo.QueueID != 0 {
+		if err := q.DeleteQueueItem(ctx, repo.QueueID); err != nil {
+			return purge, fmt.Errorf("delete queue item %d for repository %d: %w", repo.QueueID, repo.ID, err)
+		}
+	}
+	if err := q.DeleteRepository(ctx, repo.ID); err != nil {
+		return purge, fmt.Errorf("delete repository %d: %w", repo.ID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return purge, err
+	}
+	purge.TagsDeleted = int(tags)
+	purge.ManifestsDeleted = int(manifests)
+	return purge, nil
 }
 
 // FindExpiredTags returns tags whose soft-delete grace period has elapsed.

--- a/internal/gc/store.go
+++ b/internal/gc/store.go
@@ -10,6 +10,16 @@ type Store interface {
 	// CleanExpiredUploadedBlobs removes uploadedblob rows past their expiry.
 	CleanExpiredUploadedBlobs(ctx context.Context) error
 
+	// FindMarkedRepositories returns repositories the API marked for deletion
+	// (state = 3) together with their deletedrepository marker, if any.
+	FindMarkedRepositories(ctx context.Context) ([]MarkedRepository, error)
+
+	// PurgeRepository deletes every row owned by a marked repository — tags,
+	// manifests and their links, upload markers, permissions, the deletion
+	// marker and its queue item, and finally the repository row — in a single
+	// transaction. Blobs are left for the orphaned-blob phase.
+	PurgeRepository(ctx context.Context, repo MarkedRepository) (RepositoryPurge, error)
+
 	// FindExpiredTags returns tags whose soft-delete grace period has elapsed.
 	FindExpiredTags(ctx context.Context) ([]ExpiredTag, error)
 
@@ -33,6 +43,21 @@ type Store interface {
 	// dependent rows in a transaction. The result reports the actual metadata
 	// deletion and whether no remaining row shares its physical content.
 	DeleteBlobRecord(ctx context.Context, candidate OrphanedBlob) (BlobDeletion, error)
+}
+
+// MarkedRepository is a repository the API soft-deleted and GC must purge.
+type MarkedRepository struct {
+	ID       int64
+	MarkerID int64
+	// QueueID is the repository-GC queueitem id recorded on the marker; zero
+	// when the marker has no queue item.
+	QueueID int64
+}
+
+// RepositoryPurge counts what PurgeRepository removed.
+type RepositoryPurge struct {
+	TagsDeleted      int
+	ManifestsDeleted int
 }
 
 // ExpiredTag is a tag whose grace period has elapsed.

--- a/internal/gc/worker.go
+++ b/internal/gc/worker.go
@@ -45,8 +45,9 @@ func (w *Worker) Run(ctx context.Context) error {
 				w.log.Error("gc cycle failed", "err", err)
 				continue
 			}
-			if stats.TagsExpired+stats.ManifestsDeleted+stats.BlobsDeleted+stats.StaleUploadsRemoved > 0 {
+			if stats.RepositoriesPurged+stats.TagsExpired+stats.ManifestsDeleted+stats.BlobsDeleted+stats.StaleUploadsRemoved > 0 {
 				w.log.Info("gc cycle complete",
+					"repositories_purged", stats.RepositoriesPurged,
 					"tags_expired", stats.TagsExpired,
 					"manifests_deleted", stats.ManifestsDeleted,
 					"blobs_deleted", stats.BlobsDeleted,


### PR DESCRIPTION
## Summary

- Adds a purge phase to the GC collector (after expired upload-marker cleanup, before tag expiry) that finds repositories in state 3 and deletes, in one transaction and in foreign-key order, every row referencing the repository, then the `deletedrepository` marker, its `queueitem`, and the repository row (only while still in state 3)
- Blobs are left to the existing orphaned-blob phase; with the links and the repository's upload markers gone they are reclaimed in the same cycle unless another repository references them
- `gc.Stats` gains `RepositoriesPurged`; the cycle log line reports it
- Adds sqlc queries for each delete, unit tests (purge, shared-blob survival, state guard), an e2e `DeleteRepository` client helper, and an e2e test that deletes through the API and checks rows, markers, reclamation, the surviving shared blob, and reuse of the name

## Context

`DELETE /api/v1/repository/<ns>/<name>` renames the repository to a UUID, sets `state = 3`, inserts a `deletedrepository` marker and a `queueitem`, and returns 204 — the first half of Quay's `mark_repository_for_deletion`. Quay drains that queue with `workers/repositorygcworker.py` → `model.gc.purge_repository`; the mirror registry had no consumer. Tags, manifests, `manifestblob` links, upload markers and blob files stayed forever, and a blob shared with a deleted repository could never be reclaimed because the hidden repository still referenced it. On the performance VM, deleting a repository holding a 1 GiB layer freed nothing after any number of cycles.

## Test plan

- [x] `go test ./internal/gc/ -count=1` (new `TestCollect_PurgesMarkedRepository`, `TestCollect_PurgeKeepsBlobsSharedWithLiveRepository`, `TestCollect_ActiveRepositoryIsNeverPurged`)
- [x] `go test ./internal/e2e/mirrorregistry/ -count=1` (new `TestRegistryDeleteRepositoryPurgesAndReclaimsStorage`)
- [x] `go test ./internal/... -count=1`, `golangci-lint run ./internal/gc/... ./internal/dal/... ./internal/e2e/...`
- [x] Manual, on the OMR VM: two repositories soft-deleted earlier with the master build (one holding a 1 GiB layer) were purged on the first cycle after swapping in the fixed binary — `repositories_purged=2 … blobs_deleted=2 bytes_reclaimed=1073834182`, storage dir shrank by 1024 MiB, marker and queue tables empty. A fresh push → API delete was purged on the next 30 s cycle; a sibling repository sharing the same layers still pulls

## Review follow-ups (2026-09-21)

- A `deletedrepository.queue_id` that does not parse as an integer is now an error from `FindMarkedRepositories`; the purge phase reports it instead of purging around the marker and leaving the queue row behind.
- `DeleteRepository` is `:execrows`. If it affects zero rows (another cycle purged the repository in the discovery gap, or it was reactivated) `PurgeRepository` returns `gc.ErrRepositoryNotMarked` without committing, so the dependent deletes roll back; the collector logs and skips it rather than failing the phase.
- Tests: `TestFindMarkedRepositories_MalformedQueueIDIsAnError`, `TestPurgeRepository_NoLongerMarkedRollsBackAndIsSkipped`. `go test -race ./internal/gc/` and `golangci-lint` clean on Linux; `internal/dal/daldb/gc.sql.go` regenerated with sqlc 1.30.0.
