### PR TITLE
PROJQUAY-13203: fix(omr): log client-caused 4xx responses below ERROR

### DIFF
--- a/internal/logging/bridge.go
+++ b/internal/logging/bridge.go
@@ -3,16 +3,26 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
+
+// responseErrorMessage is the message docker/distribution logs, at ERROR, for
+// every response that carried an error code, including routine 4xx answers
+// such as the blob-existence HEAD before an upload or a cosign ".sig" tag probe.
+const responseErrorMessage = "response completed with error"
+
+// responseStatusField is the logrus field docker/distribution attaches with
+// the HTTP status of the completed response.
+const responseStatusField = "http.response.status"
 
 type slogFormatter struct {
 	handler slog.Handler
 }
 
 func (f *slogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	level := logrusToSlog(entry.Level)
+	level := responseErrorLevel(entry, logrusToSlog(entry.Level))
 	if !f.handler.Enabled(context.Background(), level) {
 		return nil, nil
 	}
@@ -26,4 +36,47 @@ func (f *slogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		return nil, err
 	}
 	return nil, nil
+}
+
+// responseErrorLevel demotes docker/distribution's "response completed with
+// error" entries when the response status shows the client, not the registry,
+// caused the error. A 404 is the normal answer to a blob or manifest existence
+// probe and is logged at INFO, the same level as the access log line for a
+// successful request, so the request and its status stay visible without
+// looking like a failure. Other 4xx responses are logged at WARN. 5xx
+// responses, and entries without a recognizable status, keep their level.
+// This entry is the only per-request line that carries the status for error
+// responses, which is why 404 is not pushed down to DEBUG.
+func responseErrorLevel(entry *logrus.Entry, level slog.Level) slog.Level {
+	if entry.Message != responseErrorMessage || level < slog.LevelError {
+		return level
+	}
+	status, ok := responseStatus(entry.Data[responseStatusField])
+	if !ok || status < 400 || status >= 500 {
+		return level
+	}
+	if status == 404 {
+		return slog.LevelInfo
+	}
+	return slog.LevelWarn
+}
+
+func responseStatus(v any) (int, bool) {
+	switch s := v.(type) {
+	case int:
+		return s, true
+	case int32:
+		return int(s), true
+	case int64:
+		return int(s), true
+	case uint:
+		return int(s), true
+	case float64:
+		return int(s), true
+	case string:
+		n, err := strconv.Atoi(s)
+		return n, err == nil
+	default:
+		return 0, false
+	}
 }

--- a/internal/logging/bridge_test.go
+++ b/internal/logging/bridge_test.go
@@ -71,3 +71,91 @@ func TestSlogFormatter_LevelFiltering(t *testing.T) {
 		t.Errorf("expected no output for info at warn level, got: %s", buf.String())
 	}
 }
+
+// TestSlogFormatter_ResponseErrorLevel covers PROJQUAY-13203: the
+// docker/distribution "response completed with error" entry is emitted at
+// ERROR for every error-coded response, including the 404 a client gets when
+// it probes for a blob or manifest before pushing. Client-caused 4xx entries
+// are demoted (404 to INFO, other 4xx to WARN); server errors and unrelated
+// messages keep their level.
+func TestSlogFormatter_ResponseErrorLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		level   logrus.Level
+		status  any
+		want    string
+	}{
+		{name: "404 blob probe is info", message: responseErrorMessage, level: logrus.ErrorLevel, status: 404, want: "INFO"},
+		{name: "404 as int64", message: responseErrorMessage, level: logrus.ErrorLevel, status: int64(404), want: "INFO"},
+		{name: "404 as string", message: responseErrorMessage, level: logrus.ErrorLevel, status: "404", want: "INFO"},
+		{name: "401 is warn", message: responseErrorMessage, level: logrus.ErrorLevel, status: 401, want: "WARN"},
+		{name: "400 is warn", message: responseErrorMessage, level: logrus.ErrorLevel, status: 400, want: "WARN"},
+		{name: "500 stays error", message: responseErrorMessage, level: logrus.ErrorLevel, status: 500, want: "ERROR"},
+		{name: "missing status stays error", message: responseErrorMessage, level: logrus.ErrorLevel, status: nil, want: "ERROR"},
+		{name: "unparseable status stays error", message: responseErrorMessage, level: logrus.ErrorLevel, status: "n/a", want: "ERROR"},
+		{name: "other message with 404 stays error", message: "metadata write failed", level: logrus.ErrorLevel, status: 404, want: "ERROR"},
+		{name: "already warn is untouched", message: responseErrorMessage, level: logrus.WarnLevel, status: 404, want: "WARN"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			formatter := &slogFormatter{handler: handler}
+
+			data := logrus.Fields{"err.code": "blob unknown", "http.request.method": "HEAD"}
+			if tc.status != nil {
+				data[responseStatusField] = tc.status
+			}
+			entry := &logrus.Entry{
+				Logger:  logrus.StandardLogger(),
+				Time:    time.Now(),
+				Level:   tc.level,
+				Message: tc.message,
+				Data:    data,
+			}
+			if _, err := formatter.Format(entry); err != nil {
+				t.Fatalf("Format() error: %v", err)
+			}
+
+			var record map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+				t.Fatalf("unmarshal slog output: %v (raw: %s)", err, buf.String())
+			}
+			if got := record["level"]; got != tc.want {
+				t.Errorf("level = %v, want %q", got, tc.want)
+			}
+			if got := record["msg"]; got != tc.message {
+				t.Errorf("msg = %v, want %q", got, tc.message)
+			}
+			if tc.status != nil {
+				if _, ok := record[responseStatusField]; !ok {
+					t.Errorf("record dropped %s field", responseStatusField)
+				}
+			}
+		})
+	}
+}
+
+// TestSlogFormatter_DemotedEntryRespectsHandlerLevel verifies a demoted 404
+// entry is still filtered by the handler level like any other INFO record, so
+// a WARN-level configuration no longer shows client probes at all.
+func TestSlogFormatter_DemotedEntryRespectsHandlerLevel(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	formatter := &slogFormatter{handler: handler}
+
+	entry := &logrus.Entry{
+		Logger:  logrus.StandardLogger(),
+		Time:    time.Now(),
+		Level:   logrus.ErrorLevel,
+		Message: responseErrorMessage,
+		Data:    logrus.Fields{responseStatusField: 404},
+	}
+	if _, err := formatter.Format(entry); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("demoted 404 entry was emitted at WARN handler level: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

- In the logrus→slog bridge, demote docker/distribution's `"response completed with error"` entry by response status: 404 → INFO, other 4xx → WARN, 5xx or no usable status → unchanged (ERROR)
- Unit tests cover the status types the library passes (int, int64, string), each level branch, unrelated messages, and handler-level filtering

## Context

docker/distribution logs that line at ERROR for every error-coded response, including the 404 every client gets when it probes for a blob before uploading it (`HEAD /v2/<repo>/blobs/<digest>`) and when cosign or oc-mirror looks up a non-existent `.sig` tag. One oc-mirror run of eleven images produced 183 ERROR lines with zero real failures, which hides genuine errors and trips alerting on the ERROR level. Quay's Python endpoints return the same 404s as `V2RegistryException` responses without logging them at error level.

The entry is emitted inside the library, so the bridge is the interception point. Error responses get no separate access-log line, so 404 stays at INFO rather than DEBUG to keep the request and its status visible at the default level.

## Test plan

- [x] `go test ./internal/logging/ -count=1` (new `TestSlogFormatter_ResponseErrorLevel`, `TestSlogFormatter_DemotedEntryRespectsHandlerLevel`)
- [x] `go test ./internal/... -count=1`, `golangci-lint run ./internal/logging/...`
- [x] Manual, on the OMR VM: a `HEAD` for an unknown blob, a `.sig` manifest probe and a full `skopeo copy` push produce zero ERROR lines; the 404 shows as INFO with `err.code` and status, an invalid manifest PUT (400) shows as WARN
