### PR TITLE
PROJQUAY-13204: fix(omr): remember verified passwords so token issuance skips bcrypt

### DIFF
--- a/internal/auth/credential_cache.go
+++ b/internal/auth/credential_cache.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"sync"
+	"time"
+)
+
+// DefaultPasswordCacheTTL is how long a successful password verification is
+// remembered so repeat logins with the same credentials skip bcrypt.
+const DefaultPasswordCacheTTL = 5 * time.Minute
+
+// maxCredentialCacheEntries bounds the cache; the mirror registry has a
+// handful of users, so this is far above any realistic working set.
+const maxCredentialCacheEntries = 1024
+
+// credentialCache remembers recent successful password verifications.
+//
+// A bcrypt comparison at the cost factor Quay uses takes roughly a third of a
+// CPU second on a small host, and registry clients request a new token for
+// every image (skopeo asks twice per push), so on a single-process mirror
+// registry token issuance was the dominant CPU cost of a push. Quay's Python
+// service has the same per-login cost but is rarely hit by it because
+// production clients use robot accounts, whose secret is compared without
+// bcrypt.
+//
+// The cache never stores the secret itself: it keeps an HMAC-SHA256 of the
+// presented secret under a random per-process key, together with the password
+// hash that was current when the verification succeeded. A hit requires the
+// same username, an unexpired entry, the same stored hash (so a password
+// change invalidates immediately) and a matching HMAC. Only successful
+// verifications are cached, so a wrong password always pays the full bcrypt
+// cost and gains no timing information.
+type credentialCache struct {
+	ttl time.Duration
+	now func() time.Time
+	key []byte
+
+	mu      sync.Mutex
+	entries map[string]credentialCacheEntry
+}
+
+type credentialCacheEntry struct {
+	passwordHash string
+	secretMAC    []byte
+	expiresAt    time.Time
+}
+
+func newCredentialCache(ttl time.Duration) *credentialCache {
+	if ttl <= 0 {
+		return nil
+	}
+	key := make([]byte, sha256.Size)
+	if _, err := rand.Read(key); err != nil {
+		// Without a random key the cache cannot be made safe; run without it.
+		return nil
+	}
+	return &credentialCache{
+		ttl:     ttl,
+		now:     time.Now,
+		key:     key,
+		entries: make(map[string]credentialCacheEntry),
+	}
+}
+
+func (c *credentialCache) mac(secret string) []byte {
+	h := hmac.New(sha256.New, c.key)
+	h.Write([]byte(secret))
+	return h.Sum(nil)
+}
+
+// matches reports whether a recent successful verification exists for the
+// same username, stored password hash and secret.
+func (c *credentialCache) matches(username, passwordHash, secret string) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[username]
+	if !ok {
+		return false
+	}
+	if !c.now().Before(entry.expiresAt) {
+		delete(c.entries, username)
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(entry.passwordHash), []byte(passwordHash)) != 1 {
+		delete(c.entries, username)
+		return false
+	}
+	return hmac.Equal(entry.secretMAC, c.mac(secret))
+}
+
+// remember records a successful verification.
+func (c *credentialCache) remember(username, passwordHash, secret string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	if len(c.entries) >= maxCredentialCacheEntries {
+		c.evictLocked(now)
+	}
+	c.entries[username] = credentialCacheEntry{
+		passwordHash: passwordHash,
+		secretMAC:    c.mac(secret),
+		expiresAt:    now.Add(c.ttl),
+	}
+}
+
+// evictLocked drops expired entries and, if the cache is still full, the
+// entry closest to expiry.
+func (c *credentialCache) evictLocked(now time.Time) {
+	var oldestKey string
+	var oldest time.Time
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+			continue
+		}
+		if oldestKey == "" || entry.expiresAt.Before(oldest) {
+			oldestKey, oldest = key, entry.expiresAt
+		}
+	}
+	if len(c.entries) >= maxCredentialCacheEntries && oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}

--- a/internal/auth/database_verifier.go
+++ b/internal/auth/database_verifier.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"database/sql"
+	"time"
 )
 
 // DatabaseVerifierConfig configures DB-backed credential verification.
@@ -12,6 +13,9 @@ type DatabaseVerifierConfig struct {
 	RobotsWhitelist                []string
 	FeatureUserLastAccessed        bool
 	LastAccessedUpdateThresholdSec int
+	// PasswordCacheTTL is how long a successful user password verification
+	// is remembered so repeat logins skip bcrypt; zero disables the cache.
+	PasswordCacheTTL time.Duration
 }
 
 type databaseVerifier struct {
@@ -22,7 +26,7 @@ type databaseVerifier struct {
 // NewDatabaseVerifier creates a DB-backed verifier for user and robot credentials.
 func NewDatabaseVerifier(db *sql.DB, cfg DatabaseVerifierConfig) Verifier {
 	return &databaseVerifier{
-		user:  NewUserPasswordVerifier(db),
+		user:  NewUserPasswordVerifierWithCacheTTL(db, cfg.PasswordCacheTTL),
 		robot: newRobotVerifier(db, cfg),
 	}
 }

--- a/internal/auth/user_password.go
+++ b/internal/auth/user_password.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -12,14 +13,31 @@ import (
 
 type userPasswordVerifier struct {
 	queries *daldb.Queries
+	// compare is bcrypt.CompareHashAndPassword; tests substitute it to count
+	// how often the expensive comparison runs.
+	compare func(hashedPassword, password []byte) error
+	cache   *credentialCache
 }
 
-// NewUserPasswordVerifier creates a verifier for regular Quay user passwords.
+// NewUserPasswordVerifier creates a verifier for regular Quay user passwords
+// that remembers successful verifications for DefaultPasswordCacheTTL.
 func NewUserPasswordVerifier(db *sql.DB) Verifier {
+	return NewUserPasswordVerifierWithCacheTTL(db, DefaultPasswordCacheTTL)
+}
+
+// NewUserPasswordVerifierWithCacheTTL creates a verifier for regular Quay
+// user passwords. Successful verifications are remembered for ttl so repeat
+// logins with the same credentials skip the bcrypt comparison; a ttl of zero
+// or less disables the cache.
+func NewUserPasswordVerifierWithCacheTTL(db *sql.DB, ttl time.Duration) Verifier {
 	if db == nil {
 		return nil
 	}
-	return &userPasswordVerifier{queries: daldb.New(db)}
+	return &userPasswordVerifier{
+		queries: daldb.New(db),
+		compare: bcrypt.CompareHashAndPassword,
+		cache:   newCredentialCache(ttl),
+	}
 }
 
 // dummyHash is a valid bcrypt hash used when the user is not found, so that
@@ -37,12 +55,17 @@ func (v *userPasswordVerifier) Verify(ctx context.Context, credentials Credentia
 	dbUser, err := v.queries.GetUserByUsername(ctx, username)
 
 	hashToCompare := dummyHash
-	if err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid {
+	usable := err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid
+	if usable {
 		hashToCompare = []byte(dbUser.PasswordHash.String)
+		// The user row is always re-read, so a disabled account or a changed
+		// password takes effect immediately even while an entry is cached.
+		if v.cache.matches(username, dbUser.PasswordHash.String, credentials.Secret) {
+			return v.authenticated(username, &dbUser)
+		}
 	}
 
-	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(credentials.Secret)) != nil ||
-		err != nil || !dbUser.Enabled || !dbUser.PasswordHash.Valid {
+	if v.compare(hashToCompare, []byte(credentials.Secret)) != nil || !usable {
 		attrs := []any{"username", username}
 		if err != nil {
 			attrs = append(attrs, "err", err)
@@ -51,6 +74,11 @@ func (v *userPasswordVerifier) Verify(ctx context.Context, credentials Credentia
 		return Result{Username: username, Presented: true}
 	}
 
+	v.cache.remember(username, dbUser.PasswordHash.String, credentials.Secret)
+	return v.authenticated(username, &dbUser)
+}
+
+func (v *userPasswordVerifier) authenticated(username string, dbUser *daldb.GetUserByUsernameRow) Result {
 	return Result{
 		Principal: Principal{
 			ID:       dbUser.ID,

--- a/internal/auth/user_password_test.go
+++ b/internal/auth/user_password_test.go
@@ -1,0 +1,214 @@
+package auth
+
+import (
+	"database/sql"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// countingVerifier wraps a userPasswordVerifier so tests can count bcrypt
+// comparisons and control the cache clock.
+type countingVerifier struct {
+	*userPasswordVerifier
+	db       *sql.DB
+	compares atomic.Int32
+	clock    time.Time
+}
+
+func newCountingVerifier(t *testing.T, ttl time.Duration) *countingVerifier {
+	t.Helper()
+	db := setupAuthTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	base, ok := NewUserPasswordVerifierWithCacheTTL(db, ttl).(*userPasswordVerifier)
+	if !ok {
+		t.Fatal("unexpected verifier type")
+	}
+	cv := &countingVerifier{userPasswordVerifier: base, db: db, clock: time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)}
+	base.compare = func(hash, password []byte) error {
+		cv.compares.Add(1)
+		return bcrypt.CompareHashAndPassword(hash, password)
+	}
+	if base.cache != nil {
+		base.cache.now = func() time.Time { return cv.clock }
+	}
+	return cv
+}
+
+func (cv *countingVerifier) verify(t *testing.T, username, secret string) Result {
+	t.Helper()
+	return cv.Verify(t.Context(), Credentials{Username: username, Secret: secret})
+}
+
+func (cv *countingVerifier) expectCompares(t *testing.T, want int32) {
+	t.Helper()
+	if got := cv.compares.Load(); got != want {
+		t.Fatalf("bcrypt comparisons: got %d, want %d", got, want)
+	}
+}
+
+func TestUserPasswordVerifier_RepeatLoginSkipsBcrypt(t *testing.T) {
+	cv := newCountingVerifier(t, DefaultPasswordCacheTTL)
+
+	first := cv.verify(t, "admin", "correct-password")
+	if !first.Authenticated {
+		t.Fatal("first verification should succeed")
+	}
+	cv.expectCompares(t, 1)
+
+	for i := 0; i < 5; i++ {
+		again := cv.verify(t, "admin", "correct-password")
+		if !again.Authenticated {
+			t.Fatalf("repeat verification %d should succeed", i)
+		}
+		if again.Principal != first.Principal {
+			t.Fatalf("cached principal %+v differs from %+v", again.Principal, first.Principal)
+		}
+	}
+	cv.expectCompares(t, 1)
+}
+
+func TestUserPasswordVerifier_WrongPasswordAlwaysPaysBcrypt(t *testing.T) {
+	cv := newCountingVerifier(t, DefaultPasswordCacheTTL)
+
+	for i := 0; i < 3; i++ {
+		if cv.verify(t, "admin", "wrong-password").Authenticated {
+			t.Fatal("wrong password must not authenticate")
+		}
+	}
+	cv.expectCompares(t, 3)
+
+	// A correct login does not make the wrong one cheap either.
+	if !cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("correct password should authenticate")
+	}
+	if cv.verify(t, "admin", "wrong-password").Authenticated {
+		t.Fatal("wrong password must not authenticate after a cached success")
+	}
+	cv.expectCompares(t, 5)
+}
+
+func TestUserPasswordVerifier_PasswordChangeInvalidatesCache(t *testing.T) {
+	cv := newCountingVerifier(t, DefaultPasswordCacheTTL)
+
+	if !cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("initial verification should succeed")
+	}
+	cv.expectCompares(t, 1)
+
+	newHash, err := bcrypt.GenerateFromPassword([]byte("new-password"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cv.db.ExecContext(t.Context(), `UPDATE "user" SET password_hash = ? WHERE username = 'admin'`, string(newHash)); err != nil {
+		t.Fatal(err)
+	}
+
+	if cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("old password must be rejected after a password change")
+	}
+	cv.expectCompares(t, 2)
+	if !cv.verify(t, "admin", "new-password").Authenticated {
+		t.Fatal("new password should authenticate")
+	}
+	cv.expectCompares(t, 3)
+	if !cv.verify(t, "admin", "new-password").Authenticated {
+		t.Fatal("new password should authenticate from cache")
+	}
+	cv.expectCompares(t, 3)
+}
+
+func TestUserPasswordVerifier_DisabledUserRejectedDespiteCache(t *testing.T) {
+	cv := newCountingVerifier(t, DefaultPasswordCacheTTL)
+
+	if !cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("initial verification should succeed")
+	}
+	if _, err := cv.db.ExecContext(t.Context(), `UPDATE "user" SET enabled = 0 WHERE username = 'admin'`); err != nil {
+		t.Fatal(err)
+	}
+	if cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("disabled user must not authenticate from cache")
+	}
+}
+
+func TestUserPasswordVerifier_CacheEntryExpires(t *testing.T) {
+	cv := newCountingVerifier(t, time.Minute)
+
+	cv.verify(t, "admin", "correct-password")
+	cv.clock = cv.clock.Add(59 * time.Second)
+	cv.verify(t, "admin", "correct-password")
+	cv.expectCompares(t, 1)
+
+	cv.clock = cv.clock.Add(2 * time.Second)
+	if !cv.verify(t, "admin", "correct-password").Authenticated {
+		t.Fatal("verification after expiry should still succeed")
+	}
+	cv.expectCompares(t, 2)
+	cv.verify(t, "admin", "correct-password")
+	cv.expectCompares(t, 2)
+}
+
+func TestUserPasswordVerifier_CacheDisabled(t *testing.T) {
+	cv := newCountingVerifier(t, 0)
+	if cv.cache != nil {
+		t.Fatal("ttl 0 must disable the cache")
+	}
+	for i := 0; i < 3; i++ {
+		if !cv.verify(t, "admin", "correct-password").Authenticated {
+			t.Fatal("verification should succeed")
+		}
+	}
+	cv.expectCompares(t, 3)
+}
+
+func TestUserPasswordVerifier_UnknownUserStillRunsComparison(t *testing.T) {
+	cv := newCountingVerifier(t, DefaultPasswordCacheTTL)
+	for i := 0; i < 2; i++ {
+		if cv.verify(t, "nobody", "anything").Authenticated {
+			t.Fatal("unknown user must not authenticate")
+		}
+	}
+	// The dummy comparison keeps timing independent of whether the user exists.
+	cv.expectCompares(t, 2)
+}
+
+func TestCredentialCache_SecretIsNotStoredAndUserIsIsolated(t *testing.T) {
+	cache := newCredentialCache(time.Minute)
+	if cache == nil {
+		t.Fatal("cache should be enabled")
+	}
+	cache.remember("alice", "$hash-a", "alice-secret")
+	if !cache.matches("alice", "$hash-a", "alice-secret") {
+		t.Fatal("expected a hit for the remembered credentials")
+	}
+	if cache.matches("alice", "$hash-a", "bob-secret") {
+		t.Fatal("different secret must miss")
+	}
+	if cache.matches("alice", "$hash-b", "alice-secret") {
+		t.Fatal("different stored hash must miss")
+	}
+	if cache.matches("bob", "$hash-a", "alice-secret") {
+		t.Fatal("different username must miss")
+	}
+	for _, entry := range cache.entries {
+		if string(entry.secretMAC) == "alice-secret" {
+			t.Fatal("cache must not hold the plaintext secret")
+		}
+	}
+}
+
+func TestCredentialCache_Bounded(t *testing.T) {
+	cache := newCredentialCache(time.Minute)
+	base := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	tick := 0
+	cache.now = func() time.Time { tick++; return base.Add(time.Duration(tick) * time.Millisecond) }
+	for i := 0; i < maxCredentialCacheEntries+10; i++ {
+		cache.remember(string(rune('a'+i%26))+"-"+time.Duration(i).String(), "$h", "s")
+	}
+	if got := len(cache.entries); got > maxCredentialCacheEntries {
+		t.Fatalf("cache grew to %d entries, want at most %d", got, maxCredentialCacheEntries)
+	}
+}

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -7,11 +7,22 @@ type Auth struct {
 	RobotsDisallow      bool     `yaml:"ROBOTS_DISALLOW"`
 	RobotsWhitelist     []string `yaml:"ROBOTS_WHITELIST"`
 	CreatePrivateOnPush bool     `yaml:"CREATE_PRIVATE_REPO_ON_PUSH"`
+	// PasswordAuthCacheTTLS is how many seconds a successful password
+	// verification is remembered so repeat logins with the same credentials
+	// skip the bcrypt comparison. 0 disables the cache.
+	PasswordAuthCacheTTLS int `yaml:"PASSWORD_AUTH_CACHE_TTL_S"`
 }
 
 // validateAuth checks authentication enum values.
 func validateAuth(cfg *Config, _ ValidateOptions) []ValidationError {
 	var errs []ValidationError
+
+	if cfg.PasswordAuthCacheTTLS < 0 {
+		errs = append(errs, ValidationError{
+			Field: "PASSWORD_AUTH_CACHE_TTL_S", Severity: SeverityError,
+			Message: "must be 0 (disabled) or a positive number of seconds",
+		})
+	}
 
 	switch cfg.AuthenticationType {
 	case "Database", "LDAP", "JWT", "Keystone", "OIDC", "AppToken":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,19 @@ func TestParseRobotAuthDefaults(t *testing.T) {
 	assert.True(t, cfg.FeatureLibrarySupport)
 	assert.True(t, cfg.FeatureUserLastAccessed)
 	assert.Equal(t, 60, cfg.LastAccessedUpdateThresholdS)
+	assert.Equal(t, DefaultPasswordAuthCacheTTLS, cfg.PasswordAuthCacheTTLS)
+}
+
+func TestParsePasswordAuthCacheTTL(t *testing.T) {
+	cfg, err := Parse([]byte("SERVER_HOSTNAME: test\nPASSWORD_AUTH_CACHE_TTL_S: 0\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 0, cfg.PasswordAuthCacheTTLS, "explicit 0 disables the cache")
+
+	cfg, err = Parse([]byte("SERVER_HOSTNAME: test\nPASSWORD_AUTH_CACHE_TTL_S: 30\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 30, cfg.PasswordAuthCacheTTLS)
+
+	assert.Equal(t, DefaultPasswordAuthCacheTTLS, NewDefault("localhost", "/data/storage").PasswordAuthCacheTTLS)
 }
 
 func TestNewDefaultConfiguresStandaloneAdminFullAccess(t *testing.T) {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -10,6 +10,9 @@ const (
 	DefaultLastAccessedUpdateThresholdS = 60
 	DefaultInstanceServiceKeyService    = "quay"
 	DefaultRegistryJWTAuthMaxFreshS     = 3660
+	// DefaultPasswordAuthCacheTTLS remembers a verified password for five
+	// minutes; see internal/auth.DefaultPasswordCacheTTL.
+	DefaultPasswordAuthCacheTTLS = 300
 
 	// Feature defaults mirror the Python configuration defaults. A nil feature
 	// value is resolved against these defaults by internal/features.
@@ -33,7 +36,8 @@ func newDefaultConfig() Config {
 			LibraryNamespace:   DefaultLibraryNamespace,
 		},
 		Auth: Auth{
-			AuthenticationType: DefaultAuthenticationType,
+			AuthenticationType:    DefaultAuthenticationType,
+			PasswordAuthCacheTTLS: DefaultPasswordAuthCacheTTLS,
 		},
 		Storage: Storage{
 			DefaultTagExpiration: DefaultTagExpiration,

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -120,8 +120,9 @@ func NewDefault(hostname, storagePath string) *Config {
 			PreferredURLScheme: "https",
 		},
 		Auth: Auth{
-			AuthenticationType: "Database",
-			SuperUsers:         []string{"admin"},
+			AuthenticationType:    "Database",
+			SuperUsers:            []string{"admin"},
+			PasswordAuthCacheTTLS: DefaultPasswordAuthCacheTTLS,
 		},
 		Features: Features{
 			FeatureAnonymousAccess:      DefaultFeatureAnonymousAccess,

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -279,6 +279,7 @@ var goOnlyFields = map[string]bool{
 	"INSTANCE_SERVICE_KEY_LOCATION":     true,
 	"INSTANCE_SERVICE_KEY_SERVICE":      true,
 	"REGISTRY_JWT_AUTH_MAX_FRESH_S":     true,
+	"PASSWORD_AUTH_CACHE_TTL_S":         true, // mirror-registry token issuance cache
 }
 
 // TestSchemaFieldCoverage compares the Python schema keys against the Go struct

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -93,6 +93,20 @@ func TestValidateInvalidAuthenticationType(t *testing.T) {
 	assert.True(t, hasFieldError(errs, "AUTHENTICATION_TYPE"), "expected error for invalid AUTHENTICATION_TYPE")
 }
 
+func TestValidatePasswordAuthCacheTTL(t *testing.T) {
+	cfg, err := Parse([]byte(minimalValidYAML + "PASSWORD_AUTH_CACHE_TTL_S: -1\n"))
+	require.NoError(t, err)
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.True(t, hasFieldError(errs, "PASSWORD_AUTH_CACHE_TTL_S"), "expected error for negative PASSWORD_AUTH_CACHE_TTL_S")
+
+	for _, value := range []string{"0", "300"} {
+		cfg, err := Parse([]byte(minimalValidYAML + "PASSWORD_AUTH_CACHE_TTL_S: " + value + "\n"))
+		require.NoError(t, err)
+		errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+		assert.False(t, hasFieldError(errs, "PASSWORD_AUTH_CACHE_TTL_S"), "value %s should be accepted", value)
+	}
+}
+
 func TestValidateInvalidTagExpiration(t *testing.T) {
 	yaml := strings.Replace(minimalValidYAML, "DEFAULT_TAG_EXPIRATION: 2w", "DEFAULT_TAG_EXPIRATION: forever", 1)
 	cfg, err := Parse([]byte(yaml))

--- a/internal/mirrorregistry/composition.go
+++ b/internal/mirrorregistry/composition.go
@@ -74,12 +74,14 @@ func compose(ctx context.Context, cfg *Config, resolved *config.Resolved, metric
 	configureStandaloneSuperuser(resolved, adminUsername)
 
 	featureUserLastAccessed := cfg.Features.FeatureUserLastAccessed
+	passwordAuthCacheTTL := time.Duration(resolved.Config.PasswordAuthCacheTTLS) * time.Second
 	databaseVerifierConfig := auth.DatabaseVerifierConfig{
 		DatabaseSecretKey:              resolved.Config.DatabaseSecretKey,
 		RobotsDisallow:                 resolved.Config.RobotsDisallow,
 		RobotsWhitelist:                resolved.Config.RobotsWhitelist,
 		FeatureUserLastAccessed:        featureUserLastAccessed,
 		LastAccessedUpdateThresholdSec: resolved.Config.LastAccessedUpdateThresholdS,
+		PasswordCacheTTL:               passwordAuthCacheTTL,
 	}
 	jwtService, tokenRealm, err := loadRegistryTokenService(resolved)
 	if err != nil {
@@ -102,6 +104,7 @@ func compose(ctx context.Context, cfg *Config, resolved *config.Resolved, metric
 		RobotsWhitelist:                    resolved.Config.RobotsWhitelist,
 		FeatureUserLastAccessed:            featureUserLastAccessed,
 		LastAccessedUpdateThresholdSeconds: resolved.Config.LastAccessedUpdateThresholdS,
+		PasswordAuthCacheTTL:               passwordAuthCacheTTL,
 		SuperUsers:                         resolved.Config.SuperUsers,
 		SuperUsersFullAccess:               cfg.Features.HasFullSuperuserAccess(),
 		JWTService:                         jwtService,

--- a/internal/mirrorregistry/distribution/auth.go
+++ b/internal/mirrorregistry/distribution/auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	distauth "github.com/distribution/distribution/v3/registry/auth"
 	"github.com/quay/quay/internal/auth"
@@ -90,6 +91,7 @@ func newAccessController(options map[string]interface{}) (*accessController, err
 	robotsWhitelist, _ := options[authOptionRobotsWhitelist].([]string)
 	featureUserLastAccessed, _ := options[authOptionLastAccess].(bool)
 	lastAccessedUpdateThresholdSeconds, _ := options[authOptionLastAccessS].(int)
+	passwordCacheTTL, _ := options[authOptionPasswordCacheTTL].(time.Duration)
 	superUsers, _ := options[authOptionSuperUsers].([]string)
 	superUsersFullAccess, _ := options[authOptionSuperUsersFullAccess].(bool)
 
@@ -99,6 +101,7 @@ func newAccessController(options map[string]interface{}) (*accessController, err
 		RobotsWhitelist:                robotsWhitelist,
 		FeatureUserLastAccessed:        featureUserLastAccessed,
 		LastAccessedUpdateThresholdSec: lastAccessedUpdateThresholdSeconds,
+		PasswordCacheTTL:               passwordCacheTTL,
 	})
 
 	return &accessController{

--- a/internal/mirrorregistry/distribution/constants.go
+++ b/internal/mirrorregistry/distribution/constants.go
@@ -23,6 +23,7 @@ const (
 	authOptionRobotsWhitelist      = "robotsWhitelist"
 	authOptionLastAccess           = "featureUserLastAccessed"
 	authOptionLastAccessS          = "lastAccessedUpdateThresholdSeconds"
+	authOptionPasswordCacheTTL     = "passwordCacheTTL"
 	authOptionSuperUsers           = "superUsers"
 	authOptionSuperUsersFullAccess = "superUsersFullAccess"
 )

--- a/internal/mirrorregistry/distribution/registry.go
+++ b/internal/mirrorregistry/distribution/registry.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
 	"github.com/distribution/distribution/v3/registry/handlers"
@@ -36,9 +37,12 @@ type Config struct {
 	RobotsWhitelist                    []string
 	FeatureUserLastAccessed            bool
 	LastAccessedUpdateThresholdSeconds int
-	SuperUsers                         []string
-	SuperUsersFullAccess               bool
-	JWTService                         registryTokenService
+	// PasswordAuthCacheTTL is how long a verified user password is
+	// remembered by the token endpoint; zero disables the cache.
+	PasswordAuthCacheTTL time.Duration
+	SuperUsers           []string
+	SuperUsersFullAccess bool
+	JWTService           registryTokenService
 	// MetricsRegisterer is the Prometheus registerer for middleware metrics.
 	// When nil, no metrics are recorded. Callers that want per-instance
 	// metrics must provide an explicit registerer (e.g. prometheus.NewRegistry()).
@@ -152,6 +156,7 @@ func newRegistry(ctx context.Context, cfg *Config, newApp appConstructor, afterA
 			authOptionRobotsWhitelist:      cfg.RobotsWhitelist,
 			authOptionLastAccess:           cfg.FeatureUserLastAccessed,
 			authOptionLastAccessS:          cfg.LastAccessedUpdateThresholdSeconds,
+			authOptionPasswordCacheTTL:     cfg.PasswordAuthCacheTTL,
 			authOptionSuperUsers:           cfg.SuperUsers,
 			authOptionSuperUsersFullAccess: cfg.SuperUsersFullAccess,
 		}


### PR DESCRIPTION
## Summary

- The user-password verifier remembers a successful verification for a short TTL (default 5 min) and serves repeat logins with the same credentials without running bcrypt
- The cache never holds the secret: it stores an HMAC-SHA256 of the presented secret under a random per-process key plus the password hash that was current at verification time. A hit needs the same username, an unexpired entry, the same stored hash (a password change invalidates immediately) and a matching HMAC. The user row is still read on every request, so a disabled account is rejected at once. Only successes are cached, so a wrong password always pays the full bcrypt cost and learns nothing from timing. Bounded to 1,024 entries
- New config `PASSWORD_AUTH_CACHE_TTL_S` (default 300, `0` disables), validated non-negative, plumbed to both the registry token endpoint and the API v1 authenticator
- Unit tests: repeat login skips bcrypt, wrong password always compares, password change and disabled user invalidate, TTL expiry, cache disabled, unknown user still runs the dummy comparison, no plaintext in cache, size bound; config parse/default/validation tests

## Context

Every `GET /v2/auth` with Basic credentials ran `bcrypt.CompareHashAndPassword` against the `$2b$12$` hash: 325 ms of CPU per token on the 2-vCPU OMR VM. Mirror clients re-authenticate constantly (skopeo requests two tokens per image, oc-mirror one per repository), so during a 1,000-tag push the registry process ran at 1.4 cores of which about 650 ms per push was bcrypt and under 15 ms was registry work; push throughput capped at ~2 images/s regardless of image size, and a burst of 20–30 fresh pull clients queued up to 10 s on their first token. Quay's Python service verifies the same way but is rarely hit because production clients use robot accounts (decrypt-and-compare, no bcrypt) and gunicorn spreads logins across workers; OMR is one process on a small host whose only client is a mirror tool using the bootstrap user's password.

## Test plan

- [x] `go test ./internal/auth/ ./internal/config/ ./internal/mirrorregistry/... -count=1`
- [x] `go test ./internal/... -count=1`, `golangci-lint run ./internal/auth/... ./internal/config/... ./internal/mirrorregistry/...`
- [x] Manual, on the OMR VM, same binary swapped into the running registry:
  - 10 sequential `GET /v2/auth` with the bootstrap user: registry CPU 3,251 ms → **386 ms** (first call 340 ms, the rest ~16 ms wall each)
  - 3 attempts with a wrong password: 972 ms registry CPU (324 ms each, unchanged)
  - 40 `skopeo copy` pushes at `xargs -P 2`: registry CPU per push 664 ms → **25 ms**, registry CPU share 139% → **16%**, throughput 2.1 → **6.5 push/s**, 1m load 0.9 instead of ~2.7; all 40 tags live, no 5xx
